### PR TITLE
feat(ui): グループ設定画面の基本機能を実装

### DIFF
--- a/doc/todo_list.md
+++ b/doc/todo_list.md
@@ -118,25 +118,25 @@
   - [x] 確認ダイアログ(モーダル)を表示して、OKなら削除実行
 
 ## グループ設定画面
+- [x] グループ設定メニューから開く
 - [x] usecaseの作成
   - [x] GroupをadministratorIdで取得するusecaseを作成する（GetManagedMembersUsecaseを参考に）
   - [x] GroupMemberをgroupIdで取得するusecaseを作成する（GetGroupMembersByGroupIdUsecase）
   - [x] Groupを新規作成するusecaseを作成する（CreateMemberUsecaseを参考に）
   - [x] Groupを編集するusecaseを作成する（UpdateMemberUsecaseを参考に）
   - [x] Groupを削除するusecaseを作成する（DeleteMemberUsecaseを参考に）
-- [ ] グループ設定メニューから開く
-- [ ] グループ一覧表示
-  - [ ] ログインユーザーが管理しているグループの一覧を表示する
-  - [ ] ログインユーザーのmemberIdでadministratorIdを紐づけて取得する
-- [ ] グループ新規登録
+- [x] グループ一覧表示(MemberSettingsを参考に)
+  - [x] ログインユーザーが管理しているグループの一覧を表示する
+  - [x] ログインユーザーのmemberIdでadministratorIdを紐づけて取得する
+- [ ] グループ新規登録(MemberSettings,MemberEditModalを参考に)
   - [ ] Groupのid,administratorId以外の入力項目を作成する(モーダル画面)
   - [ ] 登録時にログインユーザーのmemberIdをadministratorIdにセットする
   - [ ] グループに所属させるメンバーを選択できる（ログインユーザーが管理しているメンバーから選択）
-- [ ] グループ情報編集
+- [ ] グループ情報編集(MemberSettings,MemberEditModalを参考に)
   - [ ] グループ一覧から対象グループの編集ボタンをクリックして開く
   - [ ] グループ新規登録と同一の情報がすべて編集可能（同一画面を使いまわす）
   - [ ] グループに所属させるメンバーの追加削除ができる（ログインユーザーが管理しているメンバーから選択）
-- [ ] グループ削除
+- [ ] グループ削除(MemberSettingsを参考に)
   - [ ] グループ一覧から対象グループの削除ボタンをクリック
   - [ ] 確認ダイアログ(モーダル)を表示して、OKなら削除実行
 

--- a/lib/presentation/top_page.dart
+++ b/lib/presentation/top_page.dart
@@ -96,7 +96,36 @@ class _TopPageState extends State<TopPage> {
             ? const MapDisplayPlaceholder()
             : const MapDisplay();
       case NavigationItem.groupSettings:
-        return const GroupSettings();
+        if (_currentMember == null) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        return widget.isTestEnvironment
+            ? Container(
+                key: const Key('group_settings'),
+                child: const Center(
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Icon(Icons.group_work, size: 100, color: Colors.grey),
+                      SizedBox(height: 16),
+                      Text(
+                        'グループ設定',
+                        style: TextStyle(
+                          fontSize: 24,
+                          fontWeight: FontWeight.bold,
+                          color: Colors.grey,
+                        ),
+                      ),
+                      SizedBox(height: 8),
+                      Text(
+                        'グループ設定画面',
+                        style: TextStyle(fontSize: 16, color: Colors.grey),
+                      ),
+                    ],
+                  ),
+                ),
+              )
+            : GroupSettings(member: _currentMember!);
       case NavigationItem.memberSettings:
         if (_currentMember == null) {
           return const Center(child: CircularProgressIndicator());

--- a/lib/presentation/widgets/group_settings.dart
+++ b/lib/presentation/widgets/group_settings.dart
@@ -1,31 +1,205 @@
 import 'package:flutter/material.dart';
+import '../../application/usecases/get_managed_groups_usecase.dart';
+import '../../application/usecases/delete_group_usecase.dart';
+import '../../domain/entities/member.dart';
+import '../../domain/entities/group.dart';
+import '../../domain/repositories/group_repository.dart';
+import '../../infrastructure/repositories/firestore_group_repository.dart';
 
-class GroupSettings extends StatelessWidget {
-  const GroupSettings({super.key});
+class GroupSettings extends StatefulWidget {
+  final Member member;
+  final GroupRepository? groupRepository;
+
+  const GroupSettings({super.key, required this.member, this.groupRepository});
+
+  @override
+  State<GroupSettings> createState() => _GroupSettingsState();
+}
+
+class _GroupSettingsState extends State<GroupSettings> {
+  late final GetManagedGroupsUsecase _getManagedGroupsUsecase;
+  late final DeleteGroupUsecase _deleteGroupUsecase;
+
+  List<Group> _managedGroups = [];
+  bool _isLoading = true;
+
+  @override
+  void initState() {
+    super.initState();
+
+    // 注入されたリポジトリまたはデフォルトのFirestoreリポジトリを使用
+    final groupRepository =
+        widget.groupRepository ?? FirestoreGroupRepository();
+
+    _getManagedGroupsUsecase = GetManagedGroupsUsecase(groupRepository);
+    _deleteGroupUsecase = DeleteGroupUsecase(groupRepository);
+
+    _loadData();
+  }
+
+  Future<void> _loadData() async {
+    setState(() {
+      _isLoading = true;
+    });
+
+    try {
+      final managedGroups = await _getManagedGroupsUsecase.execute(
+        widget.member,
+      );
+      _managedGroups = managedGroups;
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('データの読み込みに失敗しました: $e')));
+      }
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _deleteGroup(Group group) async {
+    final scaffoldMessenger = ScaffoldMessenger.of(context);
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('グループ削除'),
+        content: Text('${group.name}を削除しますか？'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('キャンセル'),
+          ),
+          ElevatedButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            style: ElevatedButton.styleFrom(backgroundColor: Colors.red),
+            child: const Text('削除'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed == true) {
+      try {
+        await _deleteGroupUsecase.execute(group.id);
+        if (mounted) {
+          await _loadData();
+          scaffoldMessenger.showSnackBar(
+            const SnackBar(content: Text('グループを削除しました')),
+          );
+        }
+      } catch (e) {
+        if (mounted) {
+          scaffoldMessenger.showSnackBar(
+            SnackBar(content: Text('削除に失敗しました: $e')),
+          );
+        }
+      }
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
     return Container(
       key: const Key('group_settings'),
-      child: const Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Icon(Icons.group_work, size: 100, color: Colors.grey),
-            SizedBox(height: 16),
-            Text(
-              'グループ設定',
-              style: TextStyle(
-                fontSize: 24,
-                fontWeight: FontWeight.bold,
-                color: Colors.grey,
-              ),
+      child: _isLoading
+          ? const Center(child: CircularProgressIndicator())
+          : Column(
+              children: [
+                Container(
+                  padding: const EdgeInsets.all(16),
+                  child: Row(
+                    children: [
+                      const Icon(Icons.group_work, size: 32),
+                      const SizedBox(width: 16),
+                      const Text(
+                        'グループ設定',
+                        style: TextStyle(
+                          fontSize: 24,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      const Spacer(),
+                      ElevatedButton.icon(
+                        onPressed: () => {},
+                        icon: const Icon(Icons.add),
+                        label: const Text('グループ追加'),
+                      ),
+                    ],
+                  ),
+                ),
+                const Divider(),
+                Expanded(
+                  child: _managedGroups.isEmpty
+                      ? const Center(
+                          child: Column(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: [
+                              Icon(
+                                Icons.group_work,
+                                size: 100,
+                                color: Colors.grey,
+                              ),
+                              SizedBox(height: 16),
+                              Text(
+                                '管理しているグループがありません',
+                                style: TextStyle(
+                                  fontSize: 18,
+                                  fontWeight: FontWeight.bold,
+                                  color: Colors.grey,
+                                ),
+                              ),
+                              SizedBox(height: 8),
+                              Text(
+                                'グループを追加してください',
+                                style: TextStyle(
+                                  fontSize: 16,
+                                  color: Colors.grey,
+                                ),
+                              ),
+                            ],
+                          ),
+                        )
+                      : RefreshIndicator(
+                          onRefresh: _loadData,
+                          child: ListView.builder(
+                            itemCount: _managedGroups.length,
+                            itemBuilder: (context, index) {
+                              final group = _managedGroups[index];
+
+                              return Card(
+                                margin: const EdgeInsets.symmetric(
+                                  horizontal: 16,
+                                  vertical: 4,
+                                ),
+                                child: ListTile(
+                                  leading: CircleAvatar(
+                                    child: Text(group.name.substring(0, 1)),
+                                  ),
+                                  title: Text(group.name),
+                                  subtitle: group.memo != null
+                                      ? Text(group.memo!)
+                                      : null,
+                                  trailing: IconButton(
+                                    icon: const Icon(
+                                      Icons.delete,
+                                      color: Colors.red,
+                                    ),
+                                    onPressed: () => _deleteGroup(group),
+                                  ),
+                                ),
+                              );
+                            },
+                          ),
+                        ),
+                ),
+              ],
             ),
-            SizedBox(height: 8),
-            Text('今後実装予定', style: TextStyle(fontSize: 16, color: Colors.grey)),
-          ],
-        ),
-      ),
     );
   }
 }

--- a/test/unit/presentation/widgets/group_settings_test.dart
+++ b/test/unit/presentation/widgets/group_settings_test.dart
@@ -1,0 +1,238 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+
+import 'package:memora/domain/entities/member.dart';
+import 'package:memora/domain/entities/group.dart';
+import 'package:memora/domain/repositories/group_repository.dart';
+import 'package:memora/presentation/widgets/group_settings.dart';
+
+import 'group_settings_test.mocks.dart';
+
+@GenerateMocks([GroupRepository])
+void main() {
+  late MockGroupRepository mockGroupRepository;
+  late Member testMember;
+
+  setUp(() {
+    mockGroupRepository = MockGroupRepository();
+    testMember = Member(
+      id: 'test-member-id',
+      accountId: 'test-account-id',
+      administratorId: null,
+      displayName: 'Test User',
+      kanjiLastName: '山田',
+      kanjiFirstName: '太郎',
+      hiraganaLastName: 'やまだ',
+      hiraganaFirstName: 'たろう',
+      firstName: 'Taro',
+      lastName: 'Yamada',
+      gender: '男性',
+      birthday: DateTime(1990, 1, 1),
+      email: 'test@example.com',
+      phoneNumber: '090-1234-5678',
+      type: 'member',
+      passportNumber: null,
+      passportExpiration: null,
+      anaMileageNumber: null,
+      jalMileageNumber: null,
+    );
+  });
+
+  group('GroupSettings', () {
+    testWidgets('初期化時にグループリストが読み込まれること', (WidgetTester tester) async {
+      // Arrange
+      final managedGroups = [
+        Group(
+          id: 'group-1',
+          administratorId: testMember.id,
+          name: 'Test Group 1',
+          memo: 'Test memo 1',
+        ),
+        Group(
+          id: 'group-2',
+          administratorId: testMember.id,
+          name: 'Test Group 2',
+          memo: 'Test memo 2',
+        ),
+      ];
+
+      when(
+        mockGroupRepository.getGroupsByAdministratorId(testMember.id),
+      ).thenAnswer((_) async => managedGroups);
+
+      // Act
+      await tester.pumpWidget(
+        MaterialApp(
+          home: GroupSettings(
+            member: testMember,
+            groupRepository: mockGroupRepository,
+          ),
+        ),
+      );
+
+      // 初期ローディング状態を確認
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+      // ローディング完了まで待機
+      await tester.pumpAndSettle();
+
+      // Assert
+      verify(
+        mockGroupRepository.getGroupsByAdministratorId(testMember.id),
+      ).called(1);
+      expect(find.text('グループ設定'), findsOneWidget);
+      expect(find.text('Test Group 1'), findsOneWidget);
+      expect(find.text('Test Group 2'), findsOneWidget);
+      expect(find.text('Test memo 1'), findsOneWidget);
+      expect(find.text('Test memo 2'), findsOneWidget);
+    });
+
+    testWidgets('管理しているグループがない場合、空状態が表示されること', (WidgetTester tester) async {
+      // Arrange
+      when(
+        mockGroupRepository.getGroupsByAdministratorId(testMember.id),
+      ).thenAnswer((_) async => []);
+
+      // Act
+      await tester.pumpWidget(
+        MaterialApp(
+          home: GroupSettings(
+            member: testMember,
+            groupRepository: mockGroupRepository,
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      // Assert
+      expect(find.text('管理しているグループがありません'), findsOneWidget);
+      expect(find.text('グループを追加してください'), findsOneWidget);
+      expect(find.byType(ListTile), findsNothing);
+    });
+
+    testWidgets('グループ追加ボタンが表示されること', (WidgetTester tester) async {
+      // Arrange
+      when(
+        mockGroupRepository.getGroupsByAdministratorId(testMember.id),
+      ).thenAnswer((_) async => []);
+
+      // Act
+      await tester.pumpWidget(
+        MaterialApp(
+          home: GroupSettings(
+            member: testMember,
+            groupRepository: mockGroupRepository,
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      // Assert
+      expect(find.text('グループ追加'), findsOneWidget);
+      expect(find.byIcon(Icons.add), findsOneWidget);
+    });
+
+    testWidgets('データ読み込みエラー時にスナックバーが表示されること', (WidgetTester tester) async {
+      // Arrange
+      when(
+        mockGroupRepository.getGroupsByAdministratorId(testMember.id),
+      ).thenThrow(Exception('Network error'));
+
+      // Act
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: GroupSettings(
+              member: testMember,
+              groupRepository: mockGroupRepository,
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      // Assert
+      expect(
+        find.text('データの読み込みに失敗しました: Exception: Network error'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('リフレッシュ機能が動作すること', (WidgetTester tester) async {
+      // Arrange
+      final managedGroups = [
+        Group(
+          id: 'group-1',
+          administratorId: testMember.id,
+          name: 'Test Group 1',
+          memo: 'Test memo 1',
+        ),
+      ];
+
+      when(
+        mockGroupRepository.getGroupsByAdministratorId(testMember.id),
+      ).thenAnswer((_) async => managedGroups);
+
+      // Act
+      await tester.pumpWidget(
+        MaterialApp(
+          home: GroupSettings(
+            member: testMember,
+            groupRepository: mockGroupRepository,
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      // リフレッシュ実行
+      await tester.fling(
+        find.byType(RefreshIndicator),
+        const Offset(0, 300),
+        1000,
+      );
+      await tester.pumpAndSettle();
+
+      // Assert
+      verify(
+        mockGroupRepository.getGroupsByAdministratorId(testMember.id),
+      ).called(2);
+    });
+
+    testWidgets('削除ボタンが表示されること', (WidgetTester tester) async {
+      // Arrange
+      final managedGroups = [
+        Group(
+          id: 'group-1',
+          administratorId: testMember.id,
+          name: 'Test Group 1',
+          memo: 'Test memo 1',
+        ),
+      ];
+
+      when(
+        mockGroupRepository.getGroupsByAdministratorId(testMember.id),
+      ).thenAnswer((_) async => managedGroups);
+
+      // Act
+      await tester.pumpWidget(
+        MaterialApp(
+          home: GroupSettings(
+            member: testMember,
+            groupRepository: mockGroupRepository,
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      // Assert
+      expect(find.byIcon(Icons.delete), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- グループ設定メニューから開くグループ設定画面を実装
- ログインユーザーが管理しているグループの一覧表示機能
- ログインユーザーのmemberIdでadministratorIdを紐づけてグループを取得
- グループ削除機能（確認ダイアログ付き）
- 空状態メッセージの表示とリフレッシュ機能

## Test plan
- [x] グループ設定画面のユニットテストが全て通ること
- [x] TopPageからグループ設定画面への遷移が正常に動作すること  
- [x] テスト環境でもエラーなく表示されること
- [x] check.shが成功すること
- [x] 全テストが通ること

## 対応するTodo項目
- [x] グループ設定メニューから開く
- [x] グループ一覧表示(MemberSettingsを参考に)
  - [x] ログインユーザーが管理しているグループの一覧を表示する
  - [x] ログインユーザーのmemberIdでadministratorIdを紐づけて取得する

🤖 Generated with [Claude Code](https://claude.ai/code)