### PR TITLE
refactor(test): テスト名を英語から日本語に修正

### DIFF
--- a/test/unit/application/usecases/create_group_usecase_test.dart
+++ b/test/unit/application/usecases/create_group_usecase_test.dart
@@ -18,7 +18,7 @@ void main() {
   });
 
   group('CreateGroupUsecase', () {
-    test('should save group to repository', () async {
+    test('グループをリポジトリに保存すること', () async {
       // arrange
       final group = Group(
         id: 'group123',
@@ -35,7 +35,7 @@ void main() {
       verify(mockGroupRepository.saveGroup(group));
     });
 
-    test('should complete without error for valid group', () async {
+    test('有効なグループに対してエラーなく完了すること', () async {
       // arrange
       final group = Group(
         id: 'group123',

--- a/test/unit/application/usecases/create_member_usecase_test.dart
+++ b/test/unit/application/usecases/create_member_usecase_test.dart
@@ -18,7 +18,7 @@ void main() {
   });
 
   group('CreateMemberUsecase', () {
-    test('should create a new member', () async {
+    test('新しいメンバーを作成すること', () async {
       // Arrange
       final newMember = Member(
         id: 'new-member-id',
@@ -41,7 +41,7 @@ void main() {
       verify(mockMemberRepository.saveMember(newMember)).called(1);
     });
 
-    test('should create member with minimal data', () async {
+    test('最小限のデータでメンバーを作成すること', () async {
       // Arrange
       final newMember = Member(
         id: 'new-member-id',

--- a/test/unit/application/usecases/delete_group_usecase_test.dart
+++ b/test/unit/application/usecases/delete_group_usecase_test.dart
@@ -17,7 +17,7 @@ void main() {
   });
 
   group('DeleteGroupUsecase', () {
-    test('should delete group from repository', () async {
+    test('リポジトリからグループを削除すること', () async {
       // arrange
       const groupId = 'group123';
 
@@ -32,7 +32,7 @@ void main() {
       verify(mockGroupRepository.deleteGroup(groupId));
     });
 
-    test('should complete without error for valid group id', () async {
+    test('有効なグループIDに対してエラーなく完了すること', () async {
       // arrange
       const groupId = 'group123';
 

--- a/test/unit/application/usecases/delete_member_usecase_test.dart
+++ b/test/unit/application/usecases/delete_member_usecase_test.dart
@@ -17,7 +17,7 @@ void main() {
   });
 
   group('DeleteMemberUsecase', () {
-    test('should delete member by ID', () async {
+    test('IDによってメンバーを削除すること', () async {
       // Arrange
       const memberId = 'member-to-delete-id';
 
@@ -30,7 +30,7 @@ void main() {
       verify(mockMemberRepository.deleteMember(memberId)).called(1);
     });
 
-    test('should handle empty member ID', () async {
+    test('空のメンバーIDを処理すること', () async {
       // Arrange
       const memberId = '';
 

--- a/test/unit/application/usecases/get_managed_groups_with_members_usecase_test.dart
+++ b/test/unit/application/usecases/get_managed_groups_with_members_usecase_test.dart
@@ -30,7 +30,7 @@ void main() {
   });
 
   group('GetManagedGroupsWithMembersUsecase', () {
-    test('should return list of managed groups with their members', () async {
+    test('管理するグループとそのメンバーの一覧を返すこと', () async {
       // arrange
       const administratorId = 'admin123';
       final administratorMember = Member(
@@ -102,7 +102,7 @@ void main() {
       verify(mockMemberRepository.getMemberById('member2'));
     });
 
-    test('should return empty list when no groups found', () async {
+    test('グループが見つからない場合に空のリストを返すこと', () async {
       // arrange
       const administratorId = 'admin123';
       final administratorMember = Member(

--- a/test/unit/application/usecases/get_managed_members_usecase_test.dart
+++ b/test/unit/application/usecases/get_managed_members_usecase_test.dart
@@ -18,66 +18,63 @@ void main() {
   });
 
   group('GetManagedMembersUsecase', () {
-    test(
-      'should return list of managed members when administrator member is provided',
-      () async {
-        // Arrange
-        final administratorMember = Member(
-          id: 'admin-member-id',
-          accountId: 'admin-account-id',
-          administratorId: 'admin-administrator-id',
-          displayName: 'Admin',
-          kanjiLastName: '管理',
-          kanjiFirstName: '太郎',
-          hiraganaLastName: 'カンリ',
-          hiraganaFirstName: 'タロウ',
+    test('管理者メンバーが提供された時に管理されるメンバーのリストを返すこと', () async {
+      // Arrange
+      final administratorMember = Member(
+        id: 'admin-member-id',
+        accountId: 'admin-account-id',
+        administratorId: 'admin-administrator-id',
+        displayName: 'Admin',
+        kanjiLastName: '管理',
+        kanjiFirstName: '太郎',
+        hiraganaLastName: 'カンリ',
+        hiraganaFirstName: 'タロウ',
+        gender: 'male',
+        birthday: DateTime(1990, 1, 1),
+      );
+
+      final expectedMembers = [
+        Member(
+          id: 'member-1',
+          accountId: null,
+          administratorId: 'admin-member-id',
+          displayName: 'メンバー1',
+          kanjiLastName: '田中',
+          kanjiFirstName: '花子',
+          hiraganaLastName: 'タナカ',
+          hiraganaFirstName: 'ハナコ',
+          gender: 'female',
+          birthday: DateTime(1995, 5, 10),
+        ),
+        Member(
+          id: 'member-2',
+          accountId: null,
+          administratorId: 'admin-member-id',
+          displayName: 'メンバー2',
+          kanjiLastName: '佐藤',
+          kanjiFirstName: '次郎',
+          hiraganaLastName: 'サトウ',
+          hiraganaFirstName: 'ジロウ',
           gender: 'male',
-          birthday: DateTime(1990, 1, 1),
-        );
+          birthday: DateTime(2000, 12, 25),
+        ),
+      ];
 
-        final expectedMembers = [
-          Member(
-            id: 'member-1',
-            accountId: null,
-            administratorId: 'admin-member-id',
-            displayName: 'メンバー1',
-            kanjiLastName: '田中',
-            kanjiFirstName: '花子',
-            hiraganaLastName: 'タナカ',
-            hiraganaFirstName: 'ハナコ',
-            gender: 'female',
-            birthday: DateTime(1995, 5, 10),
-          ),
-          Member(
-            id: 'member-2',
-            accountId: null,
-            administratorId: 'admin-member-id',
-            displayName: 'メンバー2',
-            kanjiLastName: '佐藤',
-            kanjiFirstName: '次郎',
-            hiraganaLastName: 'サトウ',
-            hiraganaFirstName: 'ジロウ',
-            gender: 'male',
-            birthday: DateTime(2000, 12, 25),
-          ),
-        ];
+      when(
+        mockMemberRepository.getMembersByAdministratorId('admin-member-id'),
+      ).thenAnswer((_) async => expectedMembers);
 
-        when(
-          mockMemberRepository.getMembersByAdministratorId('admin-member-id'),
-        ).thenAnswer((_) async => expectedMembers);
+      // Act
+      final result = await usecase.execute(administratorMember);
 
-        // Act
-        final result = await usecase.execute(administratorMember);
+      // Assert
+      expect(result, equals(expectedMembers));
+      verify(
+        mockMemberRepository.getMembersByAdministratorId('admin-member-id'),
+      ).called(1);
+    });
 
-        // Assert
-        expect(result, equals(expectedMembers));
-        verify(
-          mockMemberRepository.getMembersByAdministratorId('admin-member-id'),
-        ).called(1);
-      },
-    );
-
-    test('should return empty list when no managed members exist', () async {
+    test('管理されるメンバーが存在しない場合に空のリストを返すこと', () async {
       // Arrange
       final administratorMember = Member(
         id: 'admin-member-id',

--- a/test/unit/application/usecases/update_group_usecase_test.dart
+++ b/test/unit/application/usecases/update_group_usecase_test.dart
@@ -18,7 +18,7 @@ void main() {
   });
 
   group('UpdateGroupUsecase', () {
-    test('should update group in repository', () async {
+    test('リポジトリでグループを更新すること', () async {
       // arrange
       final group = Group(
         id: 'group123',
@@ -35,7 +35,7 @@ void main() {
       verify(mockGroupRepository.updateGroup(group));
     });
 
-    test('should complete without error for valid group', () async {
+    test('有効なグループに対してエラーなく完了すること', () async {
       // arrange
       final group = Group(
         id: 'group123',

--- a/test/unit/application/usecases/update_member_usecase_test.dart
+++ b/test/unit/application/usecases/update_member_usecase_test.dart
@@ -18,7 +18,7 @@ void main() {
   });
 
   group('UpdateMemberUsecase', () {
-    test('should update member information', () async {
+    test('メンバー情報を更新すること', () async {
       // Arrange
       final updatedMember = Member(
         id: 'member-id',
@@ -42,7 +42,7 @@ void main() {
       verify(mockMemberRepository.updateMember(updatedMember)).called(1);
     });
 
-    test('should update member with minimal data', () async {
+    test('最小限のデータでメンバーを更新すること', () async {
       // Arrange
       final updatedMember = Member(id: 'member-id', displayName: '更新表示名');
 


### PR DESCRIPTION
## Summary
- 英語で記載されていたテスト名を日本語に統一
- プロジェクトのコーディング規約に準拠
- 8つのテストファイルで合計15個のテスト名を修正

## Test plan
- [x] `flutter test test/unit/` でテストが全て通ることを確認
- [x] `./check.sh` でフォーマット・解析・テストが全て成功することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)