### PR TITLE
refactor(usecase): CreateMemberUsecaseにnewMember作成責務を移動

### DIFF
--- a/doc/todo_list.md
+++ b/doc/todo_list.md
@@ -124,6 +124,7 @@
 - [x] メンバー削除
   - [x] メンバー一覧から対象メンバーの削除ボタンをクリック
   - [x] 確認ダイアログ(モーダル)を表示して、OKなら削除実行
+- [x] newMemberの作成はcreateMemberUsecase側の責務とし、executeにeditedMemberとadministratorIdを渡す形に変更する
 
 ## グループ設定画面
 - [x] グループ設定メニューから開く

--- a/lib/application/usecases/create_member_usecase.dart
+++ b/lib/application/usecases/create_member_usecase.dart
@@ -1,3 +1,4 @@
+import 'package:uuid/uuid.dart';
 import '../../domain/entities/member.dart';
 import '../../domain/repositories/member_repository.dart';
 
@@ -6,7 +7,29 @@ class CreateMemberUsecase {
 
   CreateMemberUsecase(this._memberRepository);
 
-  Future<void> execute(Member member) async {
-    await _memberRepository.saveMember(member);
+  Future<void> execute(Member editedMember, String administratorId) async {
+    final newMember = Member(
+      id: const Uuid().v4(),
+      accountId: editedMember.accountId,
+      administratorId: administratorId,
+      displayName: editedMember.displayName,
+      kanjiLastName: editedMember.kanjiLastName,
+      kanjiFirstName: editedMember.kanjiFirstName,
+      hiraganaLastName: editedMember.hiraganaLastName,
+      hiraganaFirstName: editedMember.hiraganaFirstName,
+      firstName: editedMember.firstName,
+      lastName: editedMember.lastName,
+      gender: editedMember.gender,
+      birthday: editedMember.birthday,
+      email: editedMember.email,
+      phoneNumber: editedMember.phoneNumber,
+      type: editedMember.type,
+      passportNumber: editedMember.passportNumber,
+      passportExpiration: editedMember.passportExpiration,
+      anaMileageNumber: editedMember.anaMileageNumber,
+      jalMileageNumber: editedMember.jalMileageNumber,
+    );
+
+    await _memberRepository.saveMember(newMember);
   }
 }

--- a/lib/presentation/widgets/member_settings.dart
+++ b/lib/presentation/widgets/member_settings.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:uuid/uuid.dart';
 import '../../application/usecases/get_managed_members_usecase.dart';
 import '../../application/usecases/create_member_usecase.dart';
 import '../../application/usecases/update_member_usecase.dart';
@@ -93,28 +92,10 @@ class _MemberSettingsState extends State<MemberSettings> {
         onSave: (editedMember) async {
           try {
             if (member == null) {
-              final newMember = Member(
-                id: const Uuid().v4(),
-                accountId: editedMember.accountId,
-                administratorId: widget.member.id,
-                displayName: editedMember.displayName,
-                kanjiLastName: editedMember.kanjiLastName,
-                kanjiFirstName: editedMember.kanjiFirstName,
-                hiraganaLastName: editedMember.hiraganaLastName,
-                hiraganaFirstName: editedMember.hiraganaFirstName,
-                firstName: editedMember.firstName,
-                lastName: editedMember.lastName,
-                gender: editedMember.gender,
-                birthday: editedMember.birthday,
-                email: editedMember.email,
-                phoneNumber: editedMember.phoneNumber,
-                type: editedMember.type,
-                passportNumber: editedMember.passportNumber,
-                passportExpiration: editedMember.passportExpiration,
-                anaMileageNumber: editedMember.anaMileageNumber,
-                jalMileageNumber: editedMember.jalMileageNumber,
+              await _createMemberUsecase.execute(
+                editedMember,
+                widget.member.id,
               );
-              await _createMemberUsecase.execute(newMember);
             } else {
               await _updateMemberUsecase.execute(editedMember);
             }

--- a/test/unit/application/usecases/create_member_usecase_test.dart
+++ b/test/unit/application/usecases/create_member_usecase_test.dart
@@ -20,9 +20,8 @@ void main() {
   group('CreateMemberUsecase', () {
     test('新しいメンバーを作成すること', () async {
       // Arrange
-      final newMember = Member(
-        id: 'new-member-id',
-        administratorId: 'admin-member-id',
+      final editedMember = Member(
+        id: 'edited-member-id',
         displayName: '新メンバー',
         kanjiLastName: '新田',
         kanjiFirstName: '三郎',
@@ -31,31 +30,47 @@ void main() {
         gender: 'male',
         birthday: DateTime(2005, 3, 15),
       );
+      const administratorId = 'admin-member-id';
 
       when(mockMemberRepository.saveMember(any)).thenAnswer((_) async {});
 
       // Act
-      await usecase.execute(newMember);
+      await usecase.execute(editedMember, administratorId);
 
       // Assert
-      verify(mockMemberRepository.saveMember(newMember)).called(1);
+      final captured = verify(
+        mockMemberRepository.saveMember(captureAny),
+      ).captured;
+      final savedMember = captured[0] as Member;
+      expect(savedMember.administratorId, administratorId);
+      expect(savedMember.displayName, editedMember.displayName);
+      expect(savedMember.kanjiLastName, editedMember.kanjiLastName);
+      expect(savedMember.kanjiFirstName, editedMember.kanjiFirstName);
+      expect(savedMember.hiraganaLastName, editedMember.hiraganaLastName);
+      expect(savedMember.hiraganaFirstName, editedMember.hiraganaFirstName);
+      expect(savedMember.gender, editedMember.gender);
+      expect(savedMember.birthday, editedMember.birthday);
+      expect(savedMember.id, isNot(editedMember.id)); // 新しいIDが生成されること
     });
 
     test('最小限のデータでメンバーを作成すること', () async {
       // Arrange
-      final newMember = Member(
-        id: 'new-member-id',
-        administratorId: 'admin-member-id',
-        displayName: 'ミニマル',
-      );
+      final editedMember = Member(id: 'edited-member-id', displayName: 'ミニマル');
+      const administratorId = 'admin-member-id';
 
       when(mockMemberRepository.saveMember(any)).thenAnswer((_) async {});
 
       // Act
-      await usecase.execute(newMember);
+      await usecase.execute(editedMember, administratorId);
 
       // Assert
-      verify(mockMemberRepository.saveMember(newMember)).called(1);
+      final captured = verify(
+        mockMemberRepository.saveMember(captureAny),
+      ).captured;
+      final savedMember = captured[0] as Member;
+      expect(savedMember.administratorId, administratorId);
+      expect(savedMember.displayName, editedMember.displayName);
+      expect(savedMember.id, isNot(editedMember.id)); // 新しいIDが生成されること
     });
   });
 }


### PR DESCRIPTION
## Summary
- CreateMemberUsecase.executeの引数をeditedMemberとadministratorIdに変更
- newMemberの作成をユースケース内部に移動しUUIDの生成も含める
- member_settings.dartでの重複コード（newMember作成処理）を削除

## Test plan
- [x] 既存テストケースを新しいAPIに合わせて更新
- [x] TDDワークフローに従いRed-Green-Refactorサイクルで実装
- [x] 全テストが通ることを確認

## 対応項目
- [x] newMemberの作成はcreateMemberUsecase側の責務とし、executeにeditedMemberとadministratorIdを渡す形に変更する (doc/todo_list.md:127)

🤖 Generated with [Claude Code](https://claude.ai/code)