### PR TITLE
feat(member): accountIdを持つメンバーの削除ボタンを非表示にする

### DIFF
--- a/doc/todo.md
+++ b/doc/todo.md
@@ -134,6 +134,8 @@
   - [x] メンバー一覧から対象メンバーの削除ボタンをクリック
   - [x] 確認ダイアログ(モーダル)を表示して、OKなら削除実行
 - [x] newMemberの作成はcreateMemberUsecase側の責務とし、executeにeditedMemberとadministratorIdを渡す形に変更する
+- [x] accountIdを持っているメンバーは削除不可とする（削除ボタンを表示しない）
+- [ ] メンバー削除時は、memberIdで紐づくテーブル（trip_participants,group_members,member_events）をすべて削除する（delete_member_usecaseで対応）
 
 ## グループ管理画面
 
@@ -173,6 +175,7 @@
   - [x] グループに紐づくグループメンバーもあわせて削除する
 - [x] グループ新規作成時にグループメンバーを作成した場合、group_membersのgroupIdにグループのidが入っていない不具合を修正（idを統一する必要がある）
 - [x] グループに紐づくグループメンバーの削除は_deleteGroupUsecase.executeの責務とする
+- [ ] グループ削除時は、groupIdで紐づくテーブル（group_members,group_events,trip_entries）をすべて削除する（delete_group_usecaseで対応）
 
 ## グループ年表画面
 

--- a/lib/presentation/widgets/member_management.dart
+++ b/lib/presentation/widgets/member_management.dart
@@ -216,7 +216,9 @@ class _MemberManagementState extends State<MemberManagement> {
                                 : null,
                             onTap: () => _showMemberEditModal(member: member),
                             trailing:
-                                !isCurrentUser // ログインユーザーでない場合のみ削除ボタンを表示
+                                !isCurrentUser &&
+                                    member.accountId ==
+                                        null // ログインユーザーでなく、かつaccountIdを持たない場合のみ削除ボタンを表示
                                 ? IconButton(
                                     icon: const Icon(
                                       Icons.delete,

--- a/test/unit/presentation/widgets/member_management_test.dart
+++ b/test/unit/presentation/widgets/member_management_test.dart
@@ -50,7 +50,7 @@ void main() {
       final managedMembers = [
         Member(
           id: 'managed-member-1',
-          accountId: 'managed-account-1',
+          accountId: null,
           administratorId: testMember.id,
           displayName: 'Managed User 1',
           kanjiLastName: '佐藤',
@@ -216,7 +216,7 @@ void main() {
       final managedMembers = [
         Member(
           id: 'managed-member-1',
-          accountId: 'managed-account-1',
+          accountId: null,
           administratorId: testMember.id,
           displayName: 'Managed User 1',
           kanjiLastName: '佐藤',
@@ -272,7 +272,7 @@ void main() {
       final managedMembers = [
         Member(
           id: 'managed-member-1',
-          accountId: 'managed-account-1',
+          accountId: null,
           administratorId: testMember.id,
           displayName: 'Managed User 1',
           kanjiLastName: '佐藤',
@@ -325,7 +325,7 @@ void main() {
       final managedMembers = [
         Member(
           id: 'managed-member-1',
-          accountId: 'managed-account-1',
+          accountId: null,
           administratorId: testMember.id,
           displayName: 'Managed User 1',
           kanjiLastName: '佐藤',
@@ -415,6 +415,78 @@ void main() {
       );
     });
 
+    testWidgets('accountIdを持つメンバーは削除ボタンが表示されないこと', (WidgetTester tester) async {
+      // Arrange
+      final managedMembers = [
+        // accountIdを持つメンバー（削除ボタンが表示されない）
+        Member(
+          id: 'managed-member-1',
+          accountId: 'account-id-1',
+          administratorId: testMember.id,
+          displayName: 'Account Linked Member',
+        ),
+        // accountIdを持たないメンバー（削除ボタンが表示される）
+        Member(
+          id: 'managed-member-2',
+          accountId: null,
+          administratorId: testMember.id,
+          displayName: 'Regular Member',
+        ),
+      ];
+
+      when(
+        mockMemberRepository.getMembersByAdministratorId(testMember.id),
+      ).thenAnswer((_) async => managedMembers);
+
+      // Act
+      await tester.pumpWidget(
+        MaterialApp(
+          home: MemberManagement(
+            member: testMember,
+            memberRepository: mockMemberRepository,
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      // Assert
+      final cards = find.byType(Card);
+      expect(cards, findsNWidgets(3)); // ログインユーザー + 管理メンバー2人
+
+      // 1行目（ログインユーザー）- accountIdありなので削除ボタンなし
+      final firstCard = cards.at(0);
+      expect(
+        find.descendant(of: firstCard, matching: find.byIcon(Icons.delete)),
+        findsNothing,
+      );
+
+      // 2行目（accountIdありのメンバー）- 削除ボタンなし
+      final secondCard = cards.at(1);
+      expect(
+        find.descendant(
+          of: secondCard,
+          matching: find.text('Account Linked Member'),
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.descendant(of: secondCard, matching: find.byIcon(Icons.delete)),
+        findsNothing,
+      );
+
+      // 3行目（accountIdなしのメンバー）- 削除ボタンあり
+      final thirdCard = cards.at(2);
+      expect(
+        find.descendant(of: thirdCard, matching: find.text('Regular Member')),
+        findsOneWidget,
+      );
+      expect(
+        find.descendant(of: thirdCard, matching: find.byIcon(Icons.delete)),
+        findsOneWidget,
+      );
+    });
+
     testWidgets('1行目のログインユーザーメンバーを編集後にDBから再取得されること', (
       WidgetTester tester,
     ) async {
@@ -422,7 +494,7 @@ void main() {
       final managedMembers = [
         Member(
           id: 'managed-member-1',
-          accountId: 'managed-account-1',
+          accountId: null,
           administratorId: testMember.id,
           displayName: 'Managed User 1',
           kanjiLastName: '佐藤',


### PR DESCRIPTION
## Summary
- accountIdを持っているメンバーは削除不可とする（削除ボタンを表示しない）

## 変更内容
- `member_management.dart`の削除ボタン表示条件を修正
  - 従来：ログインユーザーでない場合のみ削除ボタンを表示
  - 変更後：ログインユーザーでなく、かつaccountIdがnullの場合のみ削除ボタンを表示
- テストケースを追加してaccountIdありなしの削除ボタン表示を確認
- 既存のテストデータをaccountId=nullに修正して整合性を保つ

## Test plan
- [x] 新しく追加したテストが通ることを確認
- [x] 既存の全テストが通ることを確認
- [x] `./check.sh`で静的解析・フォーマット・テスト全てが通ることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)