### PR TITLE
feat: メール確認の追加

### DIFF
--- a/doc/todo.md
+++ b/doc/todo.md
@@ -137,6 +137,7 @@
 - [x] newMemberの作成はcreateMemberUsecase側の責務とし、executeにeditedMemberとadministratorIdを渡す形に変更する
 - [x] accountIdを持っているメンバーは削除不可とする（削除ボタンを表示しない）
 - [x] メンバー削除時は、memberIdで紐づくテーブル（trip_participants,group_members,member_events）をすべて削除する（delete_member_usecaseで対応）
+- [ ] メール認証の有効化
 
 ## グループ管理画面
 

--- a/lib/domain/entities/auth_state.dart
+++ b/lib/domain/entities/auth_state.dart
@@ -1,7 +1,7 @@
 import 'package:equatable/equatable.dart';
 import 'user.dart';
 
-enum AuthStatus { loading, authenticated, unauthenticated, error }
+enum AuthStatus { loading, authenticated, unauthenticated, error, success }
 
 class AuthState extends Equatable {
   const AuthState._({required this.status, this.user, this.errorMessage});
@@ -16,6 +16,9 @@ class AuthState extends Equatable {
 
   const AuthState.error(String errorMessage)
     : this._(status: AuthStatus.error, errorMessage: errorMessage);
+
+  const AuthState.success(String message)
+      : this._(status: AuthStatus.success, errorMessage: message);
 
   final AuthStatus status;
   final User? user;

--- a/lib/domain/services/auth_service.dart
+++ b/lib/domain/services/auth_service.dart
@@ -32,5 +32,7 @@ abstract class AuthService {
 
   Future<void> validateCurrentUserToken();
 
+  Future<void> sendEmailVerification();
+
   Stream<User?> get authStateChanges;
 }

--- a/lib/infrastructure/services/firebase_auth_service.dart
+++ b/lib/infrastructure/services/firebase_auth_service.dart
@@ -148,6 +148,20 @@ class FirebaseAuthService implements AuthService {
   }
 
   @override
+  Future<void> sendEmailVerification() async {
+    final currentUser = _firebaseAuth.currentUser;
+    if (currentUser == null) {
+      throw Exception('現在のユーザーが存在しません');
+    }
+
+    try {
+      await currentUser.sendEmailVerification();
+    } catch (e) {
+      throw Exception('認証メールの送信に失敗しました: $e');
+    }
+  }
+
+  @override
   Stream<domain.User?> get authStateChanges {
     return _firebaseAuth.authStateChanges().map((firebaseUser) {
       return firebaseUser != null

--- a/lib/presentation/auth/auth_guard.dart
+++ b/lib/presentation/auth/auth_guard.dart
@@ -55,6 +55,7 @@ class _AuthGuardState extends State<AuthGuard> {
             return widget.child;
           case AuthStatus.unauthenticated:
           case AuthStatus.error:
+          case AuthStatus.success:
             return LoginPage(authManager: widget.authManager);
         }
       },

--- a/lib/presentation/auth/login_page.dart
+++ b/lib/presentation/auth/login_page.dart
@@ -84,30 +84,50 @@ class _LoginPageState extends State<LoginPage> {
                     if (widget.authManager.state.status == AuthStatus.loading)
                       const Center(child: CircularProgressIndicator())
                     else ...[
-                      if (widget.authManager.state.status == AuthStatus.error)
+                      if (widget.authManager.state.status == AuthStatus.error ||
+                          widget.authManager.state.status == AuthStatus.success)
                         Container(
                           padding: const EdgeInsets.all(12),
                           margin: const EdgeInsets.only(bottom: 16),
                           decoration: BoxDecoration(
-                            color: Colors.red.shade100,
+                            color: widget.authManager.state.status == AuthStatus.success 
+                                ? Colors.green.shade100 
+                                : Colors.red.shade100,
                             borderRadius: BorderRadius.circular(8),
-                            border: Border.all(color: Colors.red.shade300),
+                            border: Border.all(
+                              color: widget.authManager.state.status == AuthStatus.success 
+                                  ? Colors.green.shade300 
+                                  : Colors.red.shade300,
+                            ),
                           ),
                           child: Row(
                             children: [
-                              Icon(Icons.error, color: Colors.red.shade700),
+                              Icon(
+                                widget.authManager.state.status == AuthStatus.success 
+                                    ? Icons.check_circle 
+                                    : Icons.error, 
+                                color: widget.authManager.state.status == AuthStatus.success 
+                                    ? Colors.green.shade700 
+                                    : Colors.red.shade700,
+                              ),
                               const SizedBox(width: 8),
                               Expanded(
                                 child: Text(
                                   widget.authManager.state.errorMessage ??
                                       'エラーが発生しました',
-                                  style: TextStyle(color: Colors.red.shade700),
+                                  style: TextStyle(
+                                    color: widget.authManager.state.status == AuthStatus.success 
+                                        ? Colors.green.shade700 
+                                        : Colors.red.shade700,
+                                  ),
                                 ),
                               ),
                               IconButton(
                                 icon: Icon(
                                   Icons.close,
-                                  color: Colors.red.shade700,
+                                  color: widget.authManager.state.status == AuthStatus.success 
+                                      ? Colors.green.shade700 
+                                      : Colors.red.shade700,
                                 ),
                                 onPressed: () {
                                   widget.authManager.clearError();

--- a/lib/presentation/auth/signup_page.dart
+++ b/lib/presentation/auth/signup_page.dart
@@ -82,32 +82,50 @@ class _SignupPageState extends State<SignupPage> {
                       if (widget.authManager.state.status == AuthStatus.loading)
                         const Center(child: CircularProgressIndicator())
                       else ...[
-                        if (widget.authManager.state.status == AuthStatus.error)
+                        if (widget.authManager.state.status == AuthStatus.error ||
+                            widget.authManager.state.status == AuthStatus.success)
                           Container(
                             padding: const EdgeInsets.all(12),
                             margin: const EdgeInsets.only(bottom: 16),
                             decoration: BoxDecoration(
-                              color: Colors.red.shade100,
+                              color: widget.authManager.state.status == AuthStatus.success 
+                                  ? Colors.green.shade100 
+                                  : Colors.red.shade100,
                               borderRadius: BorderRadius.circular(8),
-                              border: Border.all(color: Colors.red.shade300),
+                              border: Border.all(
+                                color: widget.authManager.state.status == AuthStatus.success 
+                                    ? Colors.green.shade300 
+                                    : Colors.red.shade300,
+                              ),
                             ),
                             child: Row(
                               children: [
-                                Icon(Icons.error, color: Colors.red.shade700),
+                                Icon(
+                                  widget.authManager.state.status == AuthStatus.success 
+                                      ? Icons.check_circle 
+                                      : Icons.error, 
+                                  color: widget.authManager.state.status == AuthStatus.success 
+                                      ? Colors.green.shade700 
+                                      : Colors.red.shade700,
+                                ),
                                 const SizedBox(width: 8),
                                 Expanded(
                                   child: Text(
                                     widget.authManager.state.errorMessage ??
                                         'エラーが発生しました',
                                     style: TextStyle(
-                                      color: Colors.red.shade700,
+                                      color: widget.authManager.state.status == AuthStatus.success 
+                                          ? Colors.green.shade700 
+                                          : Colors.red.shade700,
                                     ),
                                   ),
                                 ),
                                 IconButton(
                                   icon: Icon(
                                     Icons.close,
-                                    color: Colors.red.shade700,
+                                    color: widget.authManager.state.status == AuthStatus.success 
+                                        ? Colors.green.shade700 
+                                        : Colors.red.shade700,
                                   ),
                                   onPressed: () {
                                     widget.authManager.clearError();

--- a/test/unit/application/managers/auth_manager_test.dart
+++ b/test/unit/application/managers/auth_manager_test.dart
@@ -182,6 +182,95 @@ void main() {
         controller.close();
       });
 
+      test('メール認証が未完了の場合、強制ログアウトしてerror状態になる', () async {
+        // arrange
+        const unverifiedUser = User(
+          id: 'user123',
+          loginId: 'test@example.com',
+          displayName: 'テストユーザー',
+          isVerified: false,
+        );
+
+        // authStateChangesでユーザー状態変更をシミュレート
+        final controller = StreamController<User?>();
+        when(
+          mockAuthService.authStateChanges,
+        ).thenAnswer((_) => controller.stream);
+
+        when(mockAuthService.signOut()).thenAnswer((_) async {});
+        when(mockAuthService.sendEmailVerification()).thenAnswer((_) async {});
+
+        await authManager.initialize();
+
+        // act - authStateChangesでメール未認証ユーザーをエミット
+        controller.add(unverifiedUser);
+
+        // authStateChangesリスナー内の非同期処理完了を待つ
+        await Future(() {});
+
+        // assert
+        verify(mockAuthService.sendEmailVerification()).called(1);
+        verify(mockAuthService.signOut()).called(1);
+        expect(authManager.state.status, AuthStatus.error);
+        expect(
+          authManager.state.errorMessage,
+          'メールアドレスの認証が完了していません。認証メールを再送しました。メールを確認して認証を完了してください。',
+        );
+
+        // act - ログアウト後にnullユーザーをエミット（signOutの結果）
+        controller.add(null);
+        await Future(() {});
+
+        // assert - エラー状態が保持されることを確認
+        expect(authManager.state.status, AuthStatus.error);
+        expect(
+          authManager.state.errorMessage,
+          'メールアドレスの認証が完了していません。認証メールを再送しました。メールを確認して認証を完了してください。',
+        );
+
+        controller.close();
+      });
+
+      test('メール認証が未完了でメール再送に失敗した場合、通常のエラーメッセージが表示される', () async {
+        // arrange
+        const unverifiedUser = User(
+          id: 'user123',
+          loginId: 'test@example.com',
+          displayName: 'テストユーザー',
+          isVerified: false,
+        );
+
+        // authStateChangesでユーザー状態変更をシミュレート
+        final controller = StreamController<User?>();
+        when(
+          mockAuthService.authStateChanges,
+        ).thenAnswer((_) => controller.stream);
+
+        when(mockAuthService.signOut()).thenAnswer((_) async {});
+        when(
+          mockAuthService.sendEmailVerification(),
+        ).thenThrow(Exception('メール送信失敗'));
+
+        await authManager.initialize();
+
+        // act - authStateChangesでメール未認証ユーザーをエミット
+        controller.add(unverifiedUser);
+
+        // authStateChangesリスナー内の非同期処理完了を待つ
+        await Future(() {});
+
+        // assert
+        verify(mockAuthService.sendEmailVerification()).called(1);
+        verify(mockAuthService.signOut()).called(1);
+        expect(authManager.state.status, AuthStatus.error);
+        expect(
+          authManager.state.errorMessage,
+          'メールアドレスの認証が完了していません。認証メールの送信に失敗しました。再度ログインしてください。',
+        );
+
+        controller.close();
+      });
+
       test(
         'GetOrCreateMemberUseCaseがfalseを返した場合、強制ログアウトしてerror状態になる',
         () async {
@@ -300,6 +389,8 @@ void main() {
             password: 'password123',
           ),
         ).thenAnswer((_) async => user);
+        when(mockAuthService.sendEmailVerification()).thenAnswer((_) async {});
+        when(mockAuthService.signOut()).thenAnswer((_) async {});
 
         await authManager.signup(
           email: 'test@example.com',
@@ -312,6 +403,52 @@ void main() {
             password: 'password123',
           ),
         ).called(1);
+        verify(mockAuthService.sendEmailVerification()).called(1);
+        verify(mockAuthService.signOut()).called(1);
+        expect(authManager.state.status, AuthStatus.success);
+        expect(
+          authManager.state.errorMessage,
+          'アカウントを作成しました。確認メールを送信しましたので、メールを確認して認証を完了してください。',
+        );
+      });
+
+      test('メール送信が失敗してもサインアップは継続される', () async {
+        const user = User(
+          id: 'user123',
+          loginId: 'test@example.com',
+          displayName: null,
+          isVerified: false,
+        );
+
+        when(
+          mockAuthService.createUserWithEmailAndPassword(
+            email: 'test@example.com',
+            password: 'password123',
+          ),
+        ).thenAnswer((_) async => user);
+        when(
+          mockAuthService.sendEmailVerification(),
+        ).thenThrow(Exception('メール送信失敗'));
+        when(mockAuthService.signOut()).thenAnswer((_) async {});
+
+        await authManager.signup(
+          email: 'test@example.com',
+          password: 'password123',
+        );
+
+        verify(
+          mockAuthService.createUserWithEmailAndPassword(
+            email: 'test@example.com',
+            password: 'password123',
+          ),
+        ).called(1);
+        verify(mockAuthService.sendEmailVerification()).called(1);
+        verify(mockAuthService.signOut()).called(1);
+        expect(authManager.state.status, AuthStatus.error);
+        expect(
+          authManager.state.errorMessage,
+          'アカウントを作成しました。確認メールの送信に失敗しました。再度ログインしてください。',
+        );
       });
 
       test('サインアップに失敗した場合、error状態になる', () async {
@@ -366,6 +503,37 @@ void main() {
         );
 
         expect(authManager.state.status, AuthStatus.error);
+
+        authManager.clearError();
+
+        expect(authManager.state.status, AuthStatus.unauthenticated);
+        expect(authManager.state.errorMessage, isNull);
+      });
+
+      test('成功状態をクリアできる', () async {
+        // サインアップ成功状態を作成
+        const user = User(
+          id: 'user123',
+          loginId: 'test@example.com',
+          displayName: null,
+          isVerified: false,
+        );
+
+        when(
+          mockAuthService.createUserWithEmailAndPassword(
+            email: 'test@example.com',
+            password: 'password123',
+          ),
+        ).thenAnswer((_) async => user);
+        when(mockAuthService.sendEmailVerification()).thenAnswer((_) async {});
+        when(mockAuthService.signOut()).thenAnswer((_) async {});
+
+        await authManager.signup(
+          email: 'test@example.com',
+          password: 'password123',
+        );
+
+        expect(authManager.state.status, AuthStatus.success);
 
         authManager.clearError();
 


### PR DESCRIPTION
以下の制御を追加する
- アカウントのメール確認が完了していない場合、
ログイン不可とする
- サインアップ時に確認メールを送信する