### PR TITLE
refactor(top_page): 画面遷移制御をコントローラーに分離

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -66,6 +66,10 @@
   - [x] 変更：グループが存在しない場合は、グループ作成ボタンが表示される→「グループがありません」のラベル表示のみ
   - [x] 変更：トップページというメニューは廃止し、グループ年表のメニューからGroupMemberに遷移する
 - [x] 並び替え：メニューの並びを「メンバー設定」と「グループ設定」の順番を入れ替える
+- [x] 画面遷移制御をコントローラーに分離する
+  - [x] NavigationControllerクラスを作成する（lib/application/controllers/navigation_controller.dart）
+  - [x] GroupTimelineNavigationControllerクラスを作成する（lib/application/controllers/group_timeline_navigation_controller.dart）
+  - [x] TopPageをリファクタリングしてコントローラーを使用する形に変更する
 
 ## アカウント管理
 

--- a/lib/application/controllers/group_timeline_navigation_controller.dart
+++ b/lib/application/controllers/group_timeline_navigation_controller.dart
@@ -1,0 +1,135 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:memora/application/usecases/get_groups_with_members_usecase.dart';
+import 'package:memora/presentation/features/timeline/group_timeline.dart';
+
+enum GroupTimelineScreenState { groupList, timeline, tripManagement }
+
+class GroupTimelineNavigationState {
+  final GroupTimelineScreenState currentScreen;
+  final String? selectedGroupId;
+  final int? selectedYear;
+  final GroupTimeline? groupTimelineInstance;
+  final VoidCallback? refreshGroupTimeline;
+
+  const GroupTimelineNavigationState({
+    required this.currentScreen,
+    this.selectedGroupId,
+    this.selectedYear,
+    this.groupTimelineInstance,
+    this.refreshGroupTimeline,
+  });
+
+  GroupTimelineNavigationState copyWith({
+    GroupTimelineScreenState? currentScreen,
+    String? selectedGroupId,
+    int? selectedYear,
+    GroupTimeline? groupTimelineInstance,
+    VoidCallback? refreshGroupTimeline,
+    bool clearGroupId = false,
+    bool clearYear = false,
+    bool clearInstance = false,
+    bool clearRefresh = false,
+  }) {
+    return GroupTimelineNavigationState(
+      currentScreen: currentScreen ?? this.currentScreen,
+      selectedGroupId: clearGroupId
+          ? null
+          : (selectedGroupId ?? this.selectedGroupId),
+      selectedYear: clearYear ? null : (selectedYear ?? this.selectedYear),
+      groupTimelineInstance: clearInstance
+          ? null
+          : (groupTimelineInstance ?? this.groupTimelineInstance),
+      refreshGroupTimeline: clearRefresh
+          ? null
+          : (refreshGroupTimeline ?? this.refreshGroupTimeline),
+    );
+  }
+}
+
+class GroupTimelineNavigationController
+    extends StateNotifier<GroupTimelineNavigationState> {
+  GroupTimelineNavigationController()
+    : super(
+        const GroupTimelineNavigationState(
+          currentScreen: GroupTimelineScreenState.groupList,
+        ),
+      );
+
+  void showGroupList() {
+    state = state.copyWith(
+      currentScreen: GroupTimelineScreenState.groupList,
+      clearInstance: true,
+    );
+  }
+
+  void showGroupTimeline(GroupWithMembers groupWithMembers) {
+    void refreshCallback() {
+      // リフレッシュ用のコールバック（必要に応じて実装）
+    }
+
+    final groupTimeline = GroupTimeline(
+      groupWithMembers: groupWithMembers,
+      onBackPressed: showGroupList,
+      onTripManagementSelected: showTripManagement,
+      onSetRefreshCallback: (callback) {
+        Future(() {
+          state = state.copyWith(refreshGroupTimeline: callback);
+        });
+      },
+    );
+
+    state = state.copyWith(
+      currentScreen: GroupTimelineScreenState.timeline,
+      groupTimelineInstance: groupTimeline,
+      refreshGroupTimeline: refreshCallback,
+    );
+  }
+
+  void showTripManagement(String groupId, int year) {
+    state = state.copyWith(
+      currentScreen: GroupTimelineScreenState.tripManagement,
+      selectedGroupId: groupId,
+      selectedYear: year,
+    );
+  }
+
+  void backFromTripManagement() {
+    state = state.copyWith(
+      currentScreen: GroupTimelineScreenState.timeline,
+      clearGroupId: true,
+      clearYear: true,
+    );
+
+    state.refreshGroupTimeline?.call();
+  }
+
+  void resetToGroupList() {
+    state = state.copyWith(
+      currentScreen: GroupTimelineScreenState.groupList,
+      clearGroupId: true,
+      clearYear: true,
+      clearInstance: true,
+      clearRefresh: true,
+    );
+  }
+
+  int getStackIndex() {
+    switch (state.currentScreen) {
+      case GroupTimelineScreenState.groupList:
+        return 0;
+      case GroupTimelineScreenState.timeline:
+        return 1;
+      case GroupTimelineScreenState.tripManagement:
+        return 2;
+    }
+  }
+}
+
+final groupTimelineNavigationControllerProvider =
+    StateNotifierProvider<
+      GroupTimelineNavigationController,
+      GroupTimelineNavigationState
+    >((ref) {
+      return GroupTimelineNavigationController();
+    });

--- a/lib/application/controllers/navigation_controller.dart
+++ b/lib/application/controllers/navigation_controller.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+enum NavigationItem {
+  groupTimeline,
+  mapDisplay,
+  groupManagement,
+  memberManagement,
+  settings,
+  accountSettings,
+}
+
+class NavigationState {
+  final NavigationItem selectedItem;
+
+  const NavigationState({required this.selectedItem});
+
+  NavigationState copyWith({NavigationItem? selectedItem}) {
+    return NavigationState(selectedItem: selectedItem ?? this.selectedItem);
+  }
+}
+
+class NavigationController extends StateNotifier<NavigationState> {
+  NavigationController()
+    : super(const NavigationState(selectedItem: NavigationItem.groupTimeline));
+
+  void selectItem(NavigationItem item) {
+    state = state.copyWith(selectedItem: item);
+  }
+}
+
+final navigationControllerProvider =
+    StateNotifierProvider<NavigationController, NavigationState>((ref) {
+      return NavigationController();
+    });

--- a/test/unit/application/controllers/group_timeline_navigation_controller_test.dart
+++ b/test/unit/application/controllers/group_timeline_navigation_controller_test.dart
@@ -1,0 +1,196 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:memora/application/controllers/group_timeline_navigation_controller.dart';
+import 'package:memora/application/usecases/get_groups_with_members_usecase.dart';
+import 'package:memora/domain/entities/group.dart';
+import 'package:memora/domain/entities/member.dart';
+
+void main() {
+  group('GroupTimelineNavigationController', () {
+    late ProviderContainer container;
+
+    final testGroup = Group(
+      id: 'test-group',
+      administratorId: 'admin1',
+      name: 'テストグループ',
+    );
+
+    final testMembers = [
+      Member(
+        id: 'member1',
+        displayName: '山田太郎',
+        kanjiFirstName: '太郎',
+        kanjiLastName: '山田',
+      ),
+    ];
+
+    final testGroupWithMembers = GroupWithMembers(
+      group: testGroup,
+      members: testMembers,
+    );
+
+    setUp(() {
+      container = ProviderContainer();
+    });
+
+    tearDown(() {
+      container.dispose();
+    });
+
+    test('初期状態でグループ一覧画面が選択されている', () {
+      // Act
+      final state = container.read(groupTimelineNavigationControllerProvider);
+
+      // Assert
+      expect(state.currentScreen, GroupTimelineScreenState.groupList);
+      expect(state.selectedGroupId, isNull);
+      expect(state.selectedYear, isNull);
+      expect(state.groupTimelineInstance, isNull);
+      expect(state.refreshGroupTimeline, isNull);
+    });
+
+    test('グループ一覧画面に遷移できる', () {
+      // Arrange
+      final notifier = container.read(
+        groupTimelineNavigationControllerProvider.notifier,
+      );
+
+      // Act
+      notifier.showGroupList();
+
+      // Assert
+      final state = container.read(groupTimelineNavigationControllerProvider);
+      expect(state.currentScreen, GroupTimelineScreenState.groupList);
+      expect(state.groupTimelineInstance, isNull);
+    });
+
+    test('グループ年表画面に遷移できる', () {
+      // Arrange
+      final notifier = container.read(
+        groupTimelineNavigationControllerProvider.notifier,
+      );
+
+      // Act
+      notifier.showGroupTimeline(testGroupWithMembers);
+
+      // Assert
+      final state = container.read(groupTimelineNavigationControllerProvider);
+      expect(state.currentScreen, GroupTimelineScreenState.timeline);
+      expect(state.groupTimelineInstance, isNotNull);
+    });
+
+    test('旅行管理画面に遷移できる', () {
+      // Arrange
+      final notifier = container.read(
+        groupTimelineNavigationControllerProvider.notifier,
+      );
+      const testGroupId = 'test-group-123';
+      const testYear = 2024;
+
+      // Act
+      notifier.showTripManagement(testGroupId, testYear);
+
+      // Assert
+      final state = container.read(groupTimelineNavigationControllerProvider);
+      expect(state.currentScreen, GroupTimelineScreenState.tripManagement);
+      expect(state.selectedGroupId, testGroupId);
+      expect(state.selectedYear, testYear);
+    });
+
+    test('旅行管理画面から戻ることができる', () {
+      // Arrange
+      final notifier = container.read(
+        groupTimelineNavigationControllerProvider.notifier,
+      );
+
+      // 旅行管理画面に遷移
+      notifier.showTripManagement('test-group', 2024);
+
+      // Act
+      notifier.backFromTripManagement();
+
+      // Assert
+      final state = container.read(groupTimelineNavigationControllerProvider);
+      expect(state.currentScreen, GroupTimelineScreenState.timeline);
+      expect(state.selectedGroupId, isNull);
+      expect(state.selectedYear, isNull);
+    });
+
+    test('グループ一覧にリセットできる', () {
+      // Arrange
+      final notifier = container.read(
+        groupTimelineNavigationControllerProvider.notifier,
+      );
+
+      // 年表画面に遷移（リフレッシュコールバックは自動設定される）
+      notifier.showGroupTimeline(testGroupWithMembers);
+
+      // Act
+      notifier.resetToGroupList();
+
+      // Assert
+      final state = container.read(groupTimelineNavigationControllerProvider);
+      expect(state.currentScreen, GroupTimelineScreenState.groupList);
+      expect(state.selectedGroupId, isNull);
+      expect(state.selectedYear, isNull);
+      expect(state.groupTimelineInstance, isNull);
+      expect(state.refreshGroupTimeline, isNull);
+    });
+
+    test('スタックインデックスを正しく取得できる', () {
+      // Arrange
+      final notifier = container.read(
+        groupTimelineNavigationControllerProvider.notifier,
+      );
+
+      // グループ一覧の場合
+      expect(notifier.getStackIndex(), 0);
+
+      // 年表画面の場合
+      notifier.showGroupTimeline(testGroupWithMembers);
+      expect(notifier.getStackIndex(), 1);
+
+      // 旅行管理画面の場合
+      notifier.showTripManagement('test-group', 2024);
+      expect(notifier.getStackIndex(), 2);
+    });
+
+    test('年表表示時にリフレッシュコールバックが自動設定される', () {
+      // Arrange
+      final notifier = container.read(
+        groupTimelineNavigationControllerProvider.notifier,
+      );
+
+      // Act
+      notifier.showGroupTimeline(testGroupWithMembers);
+
+      // Assert
+      final state = container.read(groupTimelineNavigationControllerProvider);
+      expect(state.refreshGroupTimeline, isNotNull);
+    });
+
+    test('状態の変更が通知される', () {
+      // Arrange
+      final notifier = container.read(
+        groupTimelineNavigationControllerProvider.notifier,
+      );
+      var notificationCount = 0;
+
+      container.listen<GroupTimelineNavigationState>(
+        groupTimelineNavigationControllerProvider,
+        (previous, next) {
+          notificationCount++;
+        },
+      );
+
+      // Act
+      notifier.showGroupTimeline(testGroupWithMembers);
+      notifier.showTripManagement('test-group', 2024);
+      notifier.backFromTripManagement();
+      notifier.resetToGroupList();
+
+      // Assert
+      expect(notificationCount, 4);
+    });
+  });
+}

--- a/test/unit/application/controllers/navigation_controller_test.dart
+++ b/test/unit/application/controllers/navigation_controller_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:memora/application/controllers/navigation_controller.dart';
+
+void main() {
+  group('NavigationController', () {
+    late ProviderContainer container;
+
+    setUp(() {
+      container = ProviderContainer();
+    });
+
+    tearDown(() {
+      container.dispose();
+    });
+
+    test('初期状態でグループ年表が選択されている', () {
+      // Act
+      final state = container.read(navigationControllerProvider);
+
+      // Assert
+      expect(state.selectedItem, NavigationItem.groupTimeline);
+    });
+
+    test('ナビゲーション項目を変更できる', () {
+      // Arrange
+      final notifier = container.read(navigationControllerProvider.notifier);
+
+      // Act
+      notifier.selectItem(NavigationItem.mapDisplay);
+
+      // Assert
+      final state = container.read(navigationControllerProvider);
+      expect(state.selectedItem, NavigationItem.mapDisplay);
+    });
+
+    test('すべてのナビゲーション項目に変更できる', () {
+      // Arrange
+      final notifier = container.read(navigationControllerProvider.notifier);
+      final testItems = [
+        NavigationItem.groupTimeline,
+        NavigationItem.mapDisplay,
+        NavigationItem.groupManagement,
+        NavigationItem.memberManagement,
+        NavigationItem.settings,
+        NavigationItem.accountSettings,
+      ];
+
+      for (final item in testItems) {
+        // Act
+        notifier.selectItem(item);
+
+        // Assert
+        final state = container.read(navigationControllerProvider);
+        expect(state.selectedItem, item);
+      }
+    });
+
+    test('状態の変更が通知される', () {
+      // Arrange
+      final notifier = container.read(navigationControllerProvider.notifier);
+      var notificationCount = 0;
+
+      container.listen<NavigationState>(navigationControllerProvider, (
+        previous,
+        next,
+      ) {
+        notificationCount++;
+      });
+
+      // Act
+      notifier.selectItem(NavigationItem.mapDisplay);
+      notifier.selectItem(NavigationItem.settings);
+
+      // Assert
+      expect(notificationCount, 2);
+    });
+  });
+}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- NavigationControllerクラスを作成してメイン画面選択を管理
- GroupTimelineNavigationControllerクラスを作成してグループ年表内の遷移を管理  
- TopPageをリファクタリングしてUI表示に責務を集中
- 対応するユニットテストを作成・修正
- クリーンアーキテクチャに従いApplication層にコントローラーを配置

## Test plan
- [x] NavigationControllerのユニットテストを作成・実行
- [x] GroupTimelineNavigationControllerのユニットテストを作成・実行
- [x] 既存のTopPageテストを修正して実行
- [x] 静的コード解析でエラーなしを確認
- [x] StateNotifierの状態更新エラーを修正

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)