### PR TITLE
MemberDtoのリファクタリングとマッパー追加

### DIFF
--- a/lib/application/dtos/member/member_dto.dart
+++ b/lib/application/dtos/member/member_dto.dart
@@ -1,15 +1,133 @@
-class MemberDto {
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:equatable/equatable.dart';
+
+class MemberDto extends Equatable {
+  const MemberDto({
+    required this.id,
+    this.accountId,
+    this.ownerId,
+    this.hiraganaFirstName,
+    this.hiraganaLastName,
+    this.kanjiFirstName,
+    this.kanjiLastName,
+    this.firstName,
+    this.lastName,
+    required this.displayName,
+    this.type,
+    this.birthday,
+    this.gender,
+    this.email,
+    this.phoneNumber,
+    this.passportNumber,
+    this.passportExpiration,
+  });
+
   final String id;
+  final String? accountId;
+  final String? ownerId;
+  final String? hiraganaFirstName;
+  final String? hiraganaLastName;
+  final String? kanjiFirstName;
+  final String? kanjiLastName;
+  final String? firstName;
+  final String? lastName;
   final String displayName;
+  final String? type;
+  final DateTime? birthday;
+  final String? gender;
   final String? email;
+  final String? phoneNumber;
+  final String? passportNumber;
+  final String? passportExpiration;
 
-  MemberDto({required this.id, required this.displayName, this.email});
-
-  factory MemberDto.fromFirestore(Map<String, dynamic> data, String id) {
+  MemberDto copyWith({
+    String? id,
+    String? accountId,
+    String? ownerId,
+    String? hiraganaFirstName,
+    String? hiraganaLastName,
+    String? kanjiFirstName,
+    String? kanjiLastName,
+    String? firstName,
+    String? lastName,
+    String? displayName,
+    String? type,
+    DateTime? birthday,
+    String? gender,
+    String? email,
+    String? phoneNumber,
+    String? passportNumber,
+    String? passportExpiration,
+  }) {
     return MemberDto(
-      id: id,
-      displayName: data['displayName'] as String,
-      email: data['email'] as String?,
+      id: id ?? this.id,
+      accountId: accountId ?? this.accountId,
+      ownerId: ownerId ?? this.ownerId,
+      hiraganaFirstName: hiraganaFirstName ?? this.hiraganaFirstName,
+      hiraganaLastName: hiraganaLastName ?? this.hiraganaLastName,
+      kanjiFirstName: kanjiFirstName ?? this.kanjiFirstName,
+      kanjiLastName: kanjiLastName ?? this.kanjiLastName,
+      firstName: firstName ?? this.firstName,
+      lastName: lastName ?? this.lastName,
+      displayName: displayName ?? this.displayName,
+      type: type ?? this.type,
+      birthday: birthday ?? this.birthday,
+      gender: gender ?? this.gender,
+      email: email ?? this.email,
+      phoneNumber: phoneNumber ?? this.phoneNumber,
+      passportNumber: passportNumber ?? this.passportNumber,
+      passportExpiration: passportExpiration ?? this.passportExpiration,
     );
   }
+
+  factory MemberDto.fromFirestore(Map<String, dynamic> data, String id) {
+    final birthdayRaw = data['birthday'];
+    DateTime? birthday;
+    if (birthdayRaw is Timestamp) {
+      birthday = birthdayRaw.toDate();
+    } else if (birthdayRaw is DateTime) {
+      birthday = birthdayRaw;
+    }
+
+    return MemberDto(
+      id: id,
+      accountId: data['accountId'] as String?,
+      ownerId: data['ownerId'] as String?,
+      hiraganaFirstName: data['hiraganaFirstName'] as String?,
+      hiraganaLastName: data['hiraganaLastName'] as String?,
+      kanjiFirstName: data['kanjiFirstName'] as String?,
+      kanjiLastName: data['kanjiLastName'] as String?,
+      firstName: data['firstName'] as String?,
+      lastName: data['lastName'] as String?,
+      displayName: data['displayName'] as String? ?? '',
+      type: data['type'] as String?,
+      birthday: birthday,
+      gender: data['gender'] as String?,
+      email: data['email'] as String?,
+      phoneNumber: data['phoneNumber'] as String?,
+      passportNumber: data['passportNumber'] as String?,
+      passportExpiration: data['passportExpiration'] as String?,
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+        id,
+        accountId,
+        ownerId,
+        hiraganaFirstName,
+        hiraganaLastName,
+        kanjiFirstName,
+        kanjiLastName,
+        firstName,
+        lastName,
+        displayName,
+        type,
+        birthday,
+        gender,
+        email,
+        phoneNumber,
+        passportNumber,
+        passportExpiration,
+      ];
 }

--- a/lib/application/dtos/member/member_dto.dart
+++ b/lib/application/dtos/member/member_dto.dart
@@ -1,4 +1,3 @@
-import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:equatable/equatable.dart';
 
 class MemberDto extends Equatable {
@@ -80,54 +79,24 @@ class MemberDto extends Equatable {
     );
   }
 
-  factory MemberDto.fromFirestore(Map<String, dynamic> data, String id) {
-    final birthdayRaw = data['birthday'];
-    DateTime? birthday;
-    if (birthdayRaw is Timestamp) {
-      birthday = birthdayRaw.toDate();
-    } else if (birthdayRaw is DateTime) {
-      birthday = birthdayRaw;
-    }
-
-    return MemberDto(
-      id: id,
-      accountId: data['accountId'] as String?,
-      ownerId: data['ownerId'] as String?,
-      hiraganaFirstName: data['hiraganaFirstName'] as String?,
-      hiraganaLastName: data['hiraganaLastName'] as String?,
-      kanjiFirstName: data['kanjiFirstName'] as String?,
-      kanjiLastName: data['kanjiLastName'] as String?,
-      firstName: data['firstName'] as String?,
-      lastName: data['lastName'] as String?,
-      displayName: data['displayName'] as String? ?? '',
-      type: data['type'] as String?,
-      birthday: birthday,
-      gender: data['gender'] as String?,
-      email: data['email'] as String?,
-      phoneNumber: data['phoneNumber'] as String?,
-      passportNumber: data['passportNumber'] as String?,
-      passportExpiration: data['passportExpiration'] as String?,
-    );
-  }
-
   @override
   List<Object?> get props => [
-        id,
-        accountId,
-        ownerId,
-        hiraganaFirstName,
-        hiraganaLastName,
-        kanjiFirstName,
-        kanjiLastName,
-        firstName,
-        lastName,
-        displayName,
-        type,
-        birthday,
-        gender,
-        email,
-        phoneNumber,
-        passportNumber,
-        passportExpiration,
-      ];
+    id,
+    accountId,
+    ownerId,
+    hiraganaFirstName,
+    hiraganaLastName,
+    kanjiFirstName,
+    kanjiLastName,
+    firstName,
+    lastName,
+    displayName,
+    type,
+    birthday,
+    gender,
+    email,
+    phoneNumber,
+    passportNumber,
+    passportExpiration,
+  ];
 }

--- a/lib/application/mappers/member_mapper.dart
+++ b/lib/application/mappers/member_mapper.dart
@@ -1,7 +1,31 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import '../dtos/member/member_dto.dart';
 import '../../domain/entities/member.dart';
 
 class MemberMapper {
+  static MemberDto fromFirestore(DocumentSnapshot<Map<String, dynamic>> doc) {
+    final data = doc.data();
+    return MemberDto(
+      id: doc.id,
+      accountId: data?['accountId'] as String?,
+      ownerId: data?['ownerId'] as String?,
+      hiraganaFirstName: data?['hiraganaFirstName'] as String?,
+      hiraganaLastName: data?['hiraganaLastName'] as String?,
+      kanjiFirstName: data?['kanjiFirstName'] as String?,
+      kanjiLastName: data?['kanjiLastName'] as String?,
+      firstName: data?['firstName'] as String?,
+      lastName: data?['lastName'] as String?,
+      displayName: data?['displayName'] as String? ?? '',
+      type: data?['type'] as String?,
+      birthday: (data?['birthday'] as Timestamp?)?.toDate(),
+      gender: data?['gender'] as String?,
+      email: data?['email'] as String?,
+      phoneNumber: data?['phoneNumber'] as String?,
+      passportNumber: data?['passportNumber'] as String?,
+      passportExpiration: data?['passportExpiration'] as String?,
+    );
+  }
+
   static MemberDto toDto(Member entity) {
     return MemberDto(
       id: entity.id,

--- a/lib/application/mappers/member_mapper.dart
+++ b/lib/application/mappers/member_mapper.dart
@@ -1,0 +1,56 @@
+import '../dtos/member/member_dto.dart';
+import '../../domain/entities/member.dart';
+
+class MemberMapper {
+  static MemberDto toDto(Member entity) {
+    return MemberDto(
+      id: entity.id,
+      accountId: entity.accountId,
+      ownerId: entity.ownerId,
+      hiraganaFirstName: entity.hiraganaFirstName,
+      hiraganaLastName: entity.hiraganaLastName,
+      kanjiFirstName: entity.kanjiFirstName,
+      kanjiLastName: entity.kanjiLastName,
+      firstName: entity.firstName,
+      lastName: entity.lastName,
+      displayName: entity.displayName,
+      type: entity.type,
+      birthday: entity.birthday,
+      gender: entity.gender,
+      email: entity.email,
+      phoneNumber: entity.phoneNumber,
+      passportNumber: entity.passportNumber,
+      passportExpiration: entity.passportExpiration,
+    );
+  }
+
+  static Member toEntity(MemberDto dto) {
+    return Member(
+      id: dto.id,
+      accountId: dto.accountId,
+      ownerId: dto.ownerId,
+      hiraganaFirstName: dto.hiraganaFirstName,
+      hiraganaLastName: dto.hiraganaLastName,
+      kanjiFirstName: dto.kanjiFirstName,
+      kanjiLastName: dto.kanjiLastName,
+      firstName: dto.firstName,
+      lastName: dto.lastName,
+      displayName: dto.displayName,
+      type: dto.type,
+      birthday: dto.birthday,
+      gender: dto.gender,
+      email: dto.email,
+      phoneNumber: dto.phoneNumber,
+      passportNumber: dto.passportNumber,
+      passportExpiration: dto.passportExpiration,
+    );
+  }
+
+  static List<MemberDto> toDtoList(List<Member> entities) {
+    return entities.map(toDto).toList();
+  }
+
+  static List<Member> toEntityList(List<MemberDto> dtos) {
+    return dtos.map(toEntity).toList();
+  }
+}

--- a/lib/infrastructure/services/firestore_group_query_service.dart
+++ b/lib/infrastructure/services/firestore_group_query_service.dart
@@ -2,10 +2,14 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:memora/application/interfaces/group_query_service.dart';
 import 'package:memora/application/dtos/group/group_with_members_dto.dart';
 import 'package:memora/application/dtos/member/member_dto.dart';
+import 'package:memora/application/mappers/member_mapper.dart';
 import '../../core/app_logger.dart';
 
 class FirestoreGroupQueryService implements GroupQueryService {
-  final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+  final FirebaseFirestore _firestore;
+
+  FirestoreGroupQueryService({FirebaseFirestore? firestore})
+    : _firestore = firestore ?? FirebaseFirestore.instance;
 
   @override
   Future<List<GroupWithMembersDto>> getGroupsWithMembersByMemberId(
@@ -153,7 +157,7 @@ class FirestoreGroupQueryService implements GroupQueryService {
           .get();
 
       if (memberSnapshot.exists) {
-        members.add(MemberDto.fromFirestore(memberSnapshot.data()!, memberId));
+        members.add(MemberMapper.fromFirestore(memberSnapshot));
       }
     }
 

--- a/test/unit/application/mappers/member_mapper_test.dart
+++ b/test/unit/application/mappers/member_mapper_test.dart
@@ -1,0 +1,220 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memora/application/dtos/member/member_dto.dart';
+import 'package:memora/application/mappers/member_mapper.dart';
+import 'package:memora/domain/entities/member.dart';
+
+void main() {
+  group('MemberMapper', () {
+    test('MemberエンティティをMemberDtoに正しく変換する', () {
+      // Arrange
+      final member = Member(
+        id: 'member-1',
+        accountId: 'account-1',
+        ownerId: 'owner-1',
+        hiraganaFirstName: 'たろう',
+        hiraganaLastName: 'やまだ',
+        kanjiFirstName: '太郎',
+        kanjiLastName: '山田',
+        firstName: 'Taro',
+        lastName: 'Yamada',
+        displayName: 'タロちゃん',
+        type: 'family',
+        birthday: DateTime(1990, 1, 1),
+        gender: 'male',
+        email: 'taro@example.com',
+        phoneNumber: '09012345678',
+        passportNumber: 'AB1234567',
+        passportExpiration: '2030-01-01',
+      );
+
+      // Act
+      final dto = MemberMapper.toDto(member);
+
+      // Assert
+      expect(dto.id, 'member-1');
+      expect(dto.accountId, 'account-1');
+      expect(dto.ownerId, 'owner-1');
+      expect(dto.hiraganaFirstName, 'たろう');
+      expect(dto.hiraganaLastName, 'やまだ');
+      expect(dto.kanjiFirstName, '太郎');
+      expect(dto.kanjiLastName, '山田');
+      expect(dto.firstName, 'Taro');
+      expect(dto.lastName, 'Yamada');
+      expect(dto.displayName, 'タロちゃん');
+      expect(dto.type, 'family');
+      expect(dto.birthday, DateTime(1990, 1, 1));
+      expect(dto.gender, 'male');
+      expect(dto.email, 'taro@example.com');
+      expect(dto.phoneNumber, '09012345678');
+      expect(dto.passportNumber, 'AB1234567');
+      expect(dto.passportExpiration, '2030-01-01');
+    });
+
+    test('オプショナルプロパティがnullのMemberエンティティをDtoに変換する', () {
+      // Arrange
+      final member = Member(
+        id: 'member-2',
+        displayName: 'ハナコ',
+      );
+
+      // Act
+      final dto = MemberMapper.toDto(member);
+
+      // Assert
+      expect(dto.id, 'member-2');
+      expect(dto.accountId, isNull);
+      expect(dto.ownerId, isNull);
+      expect(dto.hiraganaFirstName, isNull);
+      expect(dto.hiraganaLastName, isNull);
+      expect(dto.kanjiFirstName, isNull);
+      expect(dto.kanjiLastName, isNull);
+      expect(dto.firstName, isNull);
+      expect(dto.lastName, isNull);
+      expect(dto.displayName, 'ハナコ');
+      expect(dto.type, isNull);
+      expect(dto.birthday, isNull);
+      expect(dto.gender, isNull);
+      expect(dto.email, isNull);
+      expect(dto.phoneNumber, isNull);
+      expect(dto.passportNumber, isNull);
+      expect(dto.passportExpiration, isNull);
+    });
+
+    test('MemberDtoをMemberエンティティに正しく変換する', () {
+      // Arrange
+      final dto = MemberDto(
+        id: 'member-3',
+        accountId: 'account-3',
+        ownerId: 'owner-3',
+        hiraganaFirstName: 'じろう',
+        hiraganaLastName: 'さとう',
+        kanjiFirstName: '次郎',
+        kanjiLastName: '佐藤',
+        firstName: 'Jiro',
+        lastName: 'Sato',
+        displayName: 'ジロー',
+        type: 'friend',
+        birthday: DateTime(1992, 2, 2),
+        gender: 'male',
+        email: 'jiro@example.com',
+        phoneNumber: '08098765432',
+        passportNumber: 'CD7654321',
+        passportExpiration: '2031-02-02',
+      );
+
+      // Act
+      final entity = MemberMapper.toEntity(dto);
+
+      // Assert
+      expect(entity.id, 'member-3');
+      expect(entity.accountId, 'account-3');
+      expect(entity.ownerId, 'owner-3');
+      expect(entity.hiraganaFirstName, 'じろう');
+      expect(entity.hiraganaLastName, 'さとう');
+      expect(entity.kanjiFirstName, '次郎');
+      expect(entity.kanjiLastName, '佐藤');
+      expect(entity.firstName, 'Jiro');
+      expect(entity.lastName, 'Sato');
+      expect(entity.displayName, 'ジロー');
+      expect(entity.type, 'friend');
+      expect(entity.birthday, DateTime(1992, 2, 2));
+      expect(entity.gender, 'male');
+      expect(entity.email, 'jiro@example.com');
+      expect(entity.phoneNumber, '08098765432');
+      expect(entity.passportNumber, 'CD7654321');
+      expect(entity.passportExpiration, '2031-02-02');
+    });
+
+    test('オプショナルプロパティがnullのDtoをエンティティに変換する', () {
+      // Arrange
+      final dto = MemberDto(
+        id: 'member-4',
+        displayName: 'ボブ',
+      );
+
+      // Act
+      final entity = MemberMapper.toEntity(dto);
+
+      // Assert
+      expect(entity.id, 'member-4');
+      expect(entity.accountId, isNull);
+      expect(entity.ownerId, isNull);
+      expect(entity.hiraganaFirstName, isNull);
+      expect(entity.hiraganaLastName, isNull);
+      expect(entity.kanjiFirstName, isNull);
+      expect(entity.kanjiLastName, isNull);
+      expect(entity.firstName, isNull);
+      expect(entity.lastName, isNull);
+      expect(entity.displayName, 'ボブ');
+      expect(entity.type, isNull);
+      expect(entity.birthday, isNull);
+      expect(entity.gender, isNull);
+      expect(entity.email, isNull);
+      expect(entity.phoneNumber, isNull);
+      expect(entity.passportNumber, isNull);
+      expect(entity.passportExpiration, isNull);
+    });
+
+    test('Memberエンティティのリストを正しくDtoリストに変換する', () {
+      // Arrange
+      final members = [
+        Member(
+          id: 'member-5',
+          displayName: 'ケン',
+        ),
+        Member(
+          id: 'member-6',
+          displayName: 'リナ',
+        ),
+      ];
+
+      // Act
+      final dtos = MemberMapper.toDtoList(members);
+
+      // Assert
+      expect(dtos.length, 2);
+      expect(dtos[0].id, 'member-5');
+      expect(dtos[0].displayName, 'ケン');
+      expect(dtos[1].id, 'member-6');
+      expect(dtos[1].displayName, 'リナ');
+    });
+
+    test('MemberDtoのリストを正しくエンティティリストに変換する', () {
+      // Arrange
+      final dtos = [
+        MemberDto(
+          id: 'member-7',
+          displayName: 'アヤ',
+        ),
+        MemberDto(
+          id: 'member-8',
+          displayName: 'ユウ',
+        ),
+      ];
+
+      // Act
+      final entities = MemberMapper.toEntityList(dtos);
+
+      // Assert
+      expect(entities.length, 2);
+      expect(entities[0].id, 'member-7');
+      expect(entities[0].displayName, 'アヤ');
+      expect(entities[1].id, 'member-8');
+      expect(entities[1].displayName, 'ユウ');
+    });
+
+    test('空のリストを変換する', () {
+      // Arrange
+      final emptyMemberList = <Member>[];
+      final emptyDtoList = <MemberDto>[];
+
+      // Act
+      final emptyDtoResult = MemberMapper.toDtoList(emptyMemberList);
+      final emptyEntityResult = MemberMapper.toEntityList(emptyDtoList);
+
+      // Assert
+      expect(emptyDtoResult, isEmpty);
+      expect(emptyEntityResult, isEmpty);
+    });
+  });
+}

--- a/test/unit/infrastructure/mappers/firestore_group_event_mapper_test.dart
+++ b/test/unit/infrastructure/mappers/firestore_group_event_mapper_test.dart
@@ -1,10 +1,13 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:memora/infrastructure/mappers/firestore_group_event_mapper.dart';
 import 'package:memora/domain/entities/group_event.dart';
-import '../repositories/firestore_group_event_repository_test.mocks.dart';
 
+import 'firestore_group_event_mapper_test.mocks.dart';
+
+@GenerateMocks([QueryDocumentSnapshot])
 void main() {
   group('FirestoreGroupEventMapper', () {
     test('FirestoreのDocumentSnapshotからGroupEventへ変換できる', () {

--- a/test/unit/infrastructure/mappers/firestore_group_mapper_test.dart
+++ b/test/unit/infrastructure/mappers/firestore_group_mapper_test.dart
@@ -1,10 +1,13 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:memora/infrastructure/mappers/firestore_group_mapper.dart';
 import 'package:memora/domain/entities/group.dart';
-import '../repositories/firestore_group_repository_test.mocks.dart';
 
+import 'firestore_group_mapper_test.mocks.dart';
+
+@GenerateMocks([QueryDocumentSnapshot])
 void main() {
   group('FirestoreGroupMapper', () {
     test('FirestoreのDocumentSnapshotからGroupへ変換できる', () {

--- a/test/unit/infrastructure/mappers/firestore_group_member_mapper_test.dart
+++ b/test/unit/infrastructure/mappers/firestore_group_member_mapper_test.dart
@@ -1,10 +1,13 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:memora/infrastructure/mappers/firestore_group_member_mapper.dart';
 import 'package:memora/domain/entities/group_member.dart';
-import '../repositories/firestore_group_member_repository_test.mocks.dart';
 
+import 'firestore_group_member_mapper_test.mocks.dart';
+
+@GenerateMocks([QueryDocumentSnapshot])
 void main() {
   group('FirestoreGroupMemberMapper', () {
     test('FirestoreのDocumentSnapshotからGroupMemberへ変換できる', () {

--- a/test/unit/infrastructure/mappers/firestore_member_event_mapper_test.dart
+++ b/test/unit/infrastructure/mappers/firestore_member_event_mapper_test.dart
@@ -1,10 +1,13 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:memora/infrastructure/mappers/firestore_member_event_mapper.dart';
 import 'package:memora/domain/entities/member_event.dart';
-import '../repositories/firestore_member_event_repository_test.mocks.dart';
 
+import 'firestore_member_event_mapper_test.mocks.dart';
+
+@GenerateMocks([QueryDocumentSnapshot])
 void main() {
   group('FirestoreMemberEventMapper', () {
     test('FirestoreのDocumentSnapshotからMemberEventへ変換できる', () {

--- a/test/unit/infrastructure/mappers/firestore_member_mapper_test.dart
+++ b/test/unit/infrastructure/mappers/firestore_member_mapper_test.dart
@@ -1,10 +1,13 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:memora/infrastructure/mappers/firestore_member_mapper.dart';
 import 'package:memora/domain/entities/member.dart';
-import '../repositories/firestore_member_repository_test.mocks.dart';
 
+import 'firestore_member_mapper_test.mocks.dart';
+
+@GenerateMocks([QueryDocumentSnapshot])
 void main() {
   group('FirestoreMemberMapper', () {
     test('FirestoreのDocumentSnapshotからMemberへ変換できる', () {

--- a/test/unit/infrastructure/mappers/firestore_pin_mapper_test.dart
+++ b/test/unit/infrastructure/mappers/firestore_pin_mapper_test.dart
@@ -1,8 +1,12 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:memora/infrastructure/mappers/firestore_pin_mapper.dart';
-import '../repositories/firestore_pin_repository_test.mocks.dart';
 
+import 'firestore_pin_mapper_test.mocks.dart';
+
+@GenerateMocks([QueryDocumentSnapshot])
 void main() {
   group('PinMapper', () {
     test('FirestoreのDocumentSnapshotからPinへ変換できる', () {

--- a/test/unit/infrastructure/mappers/firestore_trip_entry_mapper_test.dart
+++ b/test/unit/infrastructure/mappers/firestore_trip_entry_mapper_test.dart
@@ -1,10 +1,13 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:memora/infrastructure/mappers/firestore_trip_entry_mapper.dart';
 import 'package:memora/domain/entities/trip_entry.dart';
-import '../repositories/firestore_trip_entry_repository_test.mocks.dart';
 
+import 'firestore_trip_entry_mapper_test.mocks.dart';
+
+@GenerateMocks([QueryDocumentSnapshot])
 void main() {
   group('FirestoreTripEntryMapper', () {
     test('FirestoreのDocumentSnapshotからTripEntryへ変換できる', () {

--- a/test/unit/infrastructure/mappers/firestore_trip_participant_mapper_test.dart
+++ b/test/unit/infrastructure/mappers/firestore_trip_participant_mapper_test.dart
@@ -1,10 +1,13 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:memora/infrastructure/mappers/firestore_trip_participant_mapper.dart';
 import 'package:memora/domain/entities/trip_participant.dart';
-import '../repositories/firestore_trip_participant_repository_test.mocks.dart';
 
+import 'firestore_trip_participant_mapper_test.mocks.dart';
+
+@GenerateMocks([QueryDocumentSnapshot])
 void main() {
   group('FirestoreTripParticipantMapper', () {
     test('FirestoreのDocumentSnapshotからTripParticipantへ変換できる', () {

--- a/test/unit/infrastructure/services/firestore_group_query_service_test.dart
+++ b/test/unit/infrastructure/services/firestore_group_query_service_test.dart
@@ -1,0 +1,265 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:memora/infrastructure/services/firestore_group_query_service.dart';
+
+import 'firestore_group_query_service_test.mocks.dart';
+
+@GenerateMocks([
+  FirebaseFirestore,
+  CollectionReference,
+  Query,
+  QuerySnapshot,
+  QueryDocumentSnapshot,
+  DocumentReference,
+  DocumentSnapshot,
+])
+void main() {
+  group('FirestoreGroupQueryService', () {
+    late FirestoreGroupQueryService service;
+    late MockFirebaseFirestore mockFirestore;
+    late MockCollectionReference<Map<String, dynamic>> mockGroupsCollection;
+    late MockCollectionReference<Map<String, dynamic>>
+    mockGroupMembersCollection;
+    late MockCollectionReference<Map<String, dynamic>> mockMembersCollection;
+    late MockQuery<Map<String, dynamic>> mockQuery;
+    late MockQuerySnapshot<Map<String, dynamic>> mockQuerySnapshot;
+    late MockQueryDocumentSnapshot<Map<String, dynamic>>
+    mockQueryDocumentSnapshot;
+    late MockDocumentReference<Map<String, dynamic>> mockDocumentReference;
+    late MockDocumentSnapshot<Map<String, dynamic>> mockDocumentSnapshot;
+
+    setUp(() {
+      mockFirestore = MockFirebaseFirestore();
+      mockGroupsCollection = MockCollectionReference<Map<String, dynamic>>();
+      mockGroupMembersCollection =
+          MockCollectionReference<Map<String, dynamic>>();
+      mockMembersCollection = MockCollectionReference<Map<String, dynamic>>();
+      mockQuery = MockQuery<Map<String, dynamic>>();
+      mockQuerySnapshot = MockQuerySnapshot<Map<String, dynamic>>();
+      mockQueryDocumentSnapshot =
+          MockQueryDocumentSnapshot<Map<String, dynamic>>();
+      mockDocumentReference = MockDocumentReference<Map<String, dynamic>>();
+      mockDocumentSnapshot = MockDocumentSnapshot<Map<String, dynamic>>();
+
+      service = FirestoreGroupQueryService(firestore: mockFirestore);
+    });
+
+    group('getGroupsWithMembersByMemberId', () {
+      test('管理者グループとメンバーグループを正常に取得する', () async {
+        const memberId = 'member123';
+
+        // 管理者として参加しているグループのモック設定
+        when(
+          mockFirestore.collection('groups'),
+        ).thenReturn(mockGroupsCollection);
+        when(
+          mockGroupsCollection.where('ownerId', isEqualTo: memberId),
+        ).thenReturn(mockQuery);
+        when(mockQuery.get()).thenAnswer((_) async => mockQuerySnapshot);
+        when(mockQuerySnapshot.docs).thenReturn([mockQueryDocumentSnapshot]);
+        when(mockQueryDocumentSnapshot.id).thenReturn('group1');
+        when(
+          mockQueryDocumentSnapshot.data(),
+        ).thenReturn({'name': '管理者グループ', 'ownerId': memberId});
+
+        // メンバーとして参加しているグループのモック設定
+        final mockGroupMemberQuery = MockQuery<Map<String, dynamic>>();
+        final mockGroupMemberSnapshot =
+            MockQuerySnapshot<Map<String, dynamic>>();
+        final mockGroupMemberDoc =
+            MockQueryDocumentSnapshot<Map<String, dynamic>>();
+
+        when(
+          mockFirestore.collection('group_members'),
+        ).thenReturn(mockGroupMembersCollection);
+        when(
+          mockGroupMembersCollection.where('memberId', isEqualTo: memberId),
+        ).thenReturn(mockGroupMemberQuery);
+        when(
+          mockGroupMemberQuery.get(),
+        ).thenAnswer((_) async => mockGroupMemberSnapshot);
+        when(mockGroupMemberSnapshot.docs).thenReturn([mockGroupMemberDoc]);
+        when(mockGroupMemberDoc.data()).thenReturn({'groupId': 'group2'});
+
+        // グループ詳細の取得（group2）
+        final mockGroupDoc = MockDocumentSnapshot<Map<String, dynamic>>();
+        when(
+          mockGroupsCollection.doc('group2'),
+        ).thenReturn(mockDocumentReference);
+        when(mockDocumentReference.get()).thenAnswer((_) async => mockGroupDoc);
+        when(mockGroupDoc.exists).thenReturn(true);
+        when(
+          mockGroupDoc.data(),
+        ).thenReturn({'name': 'メンバーグループ', 'ownerId': 'other_owner'});
+
+        // グループのメンバー取得（group1）
+        final mockMemberQuery1 = MockQuery<Map<String, dynamic>>();
+        final mockMemberSnapshot1 = MockQuerySnapshot<Map<String, dynamic>>();
+        final mockMemberDoc1 =
+            MockQueryDocumentSnapshot<Map<String, dynamic>>();
+
+        when(
+          mockGroupMembersCollection.where('groupId', isEqualTo: 'group1'),
+        ).thenReturn(mockMemberQuery1);
+        when(
+          mockMemberQuery1.get(),
+        ).thenAnswer((_) async => mockMemberSnapshot1);
+        when(mockMemberSnapshot1.docs).thenReturn([mockMemberDoc1]);
+        when(mockMemberDoc1.data()).thenReturn({'memberId': 'member1'});
+
+        // グループのメンバー取得（group2）
+        final mockMemberQuery2 = MockQuery<Map<String, dynamic>>();
+        final mockMemberSnapshot2 = MockQuerySnapshot<Map<String, dynamic>>();
+        final mockMemberDoc2 =
+            MockQueryDocumentSnapshot<Map<String, dynamic>>();
+
+        when(
+          mockGroupMembersCollection.where('groupId', isEqualTo: 'group2'),
+        ).thenReturn(mockMemberQuery2);
+        when(
+          mockMemberQuery2.get(),
+        ).thenAnswer((_) async => mockMemberSnapshot2);
+        when(mockMemberSnapshot2.docs).thenReturn([mockMemberDoc2]);
+        when(mockMemberDoc2.data()).thenReturn({'memberId': 'member2'});
+
+        // メンバー詳細の取得
+        when(
+          mockFirestore.collection('members'),
+        ).thenReturn(mockMembersCollection);
+
+        final mockMemberDocRef1 = MockDocumentReference<Map<String, dynamic>>();
+        final mockMemberSnapshot1Detail =
+            MockDocumentSnapshot<Map<String, dynamic>>();
+        when(
+          mockMembersCollection.doc('member1'),
+        ).thenReturn(mockMemberDocRef1);
+        when(
+          mockMemberDocRef1.get(),
+        ).thenAnswer((_) async => mockMemberSnapshot1Detail);
+        when(mockMemberSnapshot1Detail.exists).thenReturn(true);
+        when(mockMemberSnapshot1Detail.id).thenReturn('member1');
+        when(
+          mockMemberSnapshot1Detail.data(),
+        ).thenReturn({'displayName': 'メンバー1'});
+
+        final mockMemberDocRef2 = MockDocumentReference<Map<String, dynamic>>();
+        final mockMemberSnapshot2Detail =
+            MockDocumentSnapshot<Map<String, dynamic>>();
+        when(
+          mockMembersCollection.doc('member2'),
+        ).thenReturn(mockMemberDocRef2);
+        when(
+          mockMemberDocRef2.get(),
+        ).thenAnswer((_) async => mockMemberSnapshot2Detail);
+        when(mockMemberSnapshot2Detail.exists).thenReturn(true);
+        when(mockMemberSnapshot2Detail.id).thenReturn('member2');
+        when(
+          mockMemberSnapshot2Detail.data(),
+        ).thenReturn({'displayName': 'メンバー2'});
+
+        final result = await service.getGroupsWithMembersByMemberId(memberId);
+
+        expect(result, hasLength(2));
+        expect(result[0].groupId, 'group1');
+        expect(result[0].groupName, '管理者グループ');
+        expect(result[1].groupId, 'group2');
+        expect(result[1].groupName, 'メンバーグループ');
+      });
+
+      test('例外が発生した場合、空のリストを返す', () async {
+        const memberId = 'member123';
+
+        when(
+          mockFirestore.collection('groups'),
+        ).thenReturn(mockGroupsCollection);
+        when(
+          mockGroupsCollection.where('ownerId', isEqualTo: memberId),
+        ).thenThrow(Exception('Firestore error'));
+
+        final result = await service.getGroupsWithMembersByMemberId(memberId);
+
+        expect(result, isEmpty);
+      });
+    });
+
+    group('getManagedGroupsWithMembersByOwnerId', () {
+      test('指定されたオーナーIDで管理しているグループとメンバー情報を正常に取得する', () async {
+        const ownerId = 'owner123';
+
+        // 管理者として参加しているグループのモック設定
+        when(
+          mockFirestore.collection('groups'),
+        ).thenReturn(mockGroupsCollection);
+        when(
+          mockGroupsCollection.where('ownerId', isEqualTo: ownerId),
+        ).thenReturn(mockQuery);
+        when(mockQuery.get()).thenAnswer((_) async => mockQuerySnapshot);
+        when(mockQuerySnapshot.docs).thenReturn([mockQueryDocumentSnapshot]);
+        when(mockQueryDocumentSnapshot.id).thenReturn('group1');
+        when(
+          mockQueryDocumentSnapshot.data(),
+        ).thenReturn({'name': '管理者グループ', 'ownerId': ownerId});
+
+        // グループのメンバー取得
+        final mockMemberQuery = MockQuery<Map<String, dynamic>>();
+        final mockMemberSnapshot = MockQuerySnapshot<Map<String, dynamic>>();
+        final mockMemberDoc = MockQueryDocumentSnapshot<Map<String, dynamic>>();
+
+        when(
+          mockFirestore.collection('group_members'),
+        ).thenReturn(mockGroupMembersCollection);
+        when(
+          mockGroupMembersCollection.where('groupId', isEqualTo: 'group1'),
+        ).thenReturn(mockMemberQuery);
+        when(mockMemberQuery.get()).thenAnswer((_) async => mockMemberSnapshot);
+        when(mockMemberSnapshot.docs).thenReturn([mockMemberDoc]);
+        when(mockMemberDoc.data()).thenReturn({'memberId': 'member1'});
+
+        // メンバー詳細の取得
+        when(
+          mockFirestore.collection('members'),
+        ).thenReturn(mockMembersCollection);
+        when(
+          mockMembersCollection.doc('member1'),
+        ).thenReturn(mockDocumentReference);
+        when(
+          mockDocumentReference.get(),
+        ).thenAnswer((_) async => mockDocumentSnapshot);
+        when(mockDocumentSnapshot.exists).thenReturn(true);
+        when(mockDocumentSnapshot.id).thenReturn('member1');
+        when(
+          mockDocumentSnapshot.data(),
+        ).thenReturn({'displayName': 'テストメンバー'});
+
+        final result = await service.getManagedGroupsWithMembersByOwnerId(
+          ownerId,
+        );
+
+        expect(result, hasLength(1));
+        expect(result[0].groupId, 'group1');
+        expect(result[0].groupName, '管理者グループ');
+        expect(result[0].members, hasLength(1));
+        expect(result[0].members[0].displayName, 'テストメンバー');
+      });
+
+      test('例外が発生した場合、空のリストを返す', () async {
+        const ownerId = 'owner123';
+
+        when(
+          mockFirestore.collection('groups'),
+        ).thenReturn(mockGroupsCollection);
+        when(
+          mockGroupsCollection.where('ownerId', isEqualTo: ownerId),
+        ).thenThrow(Exception('Firestore error'));
+
+        final result = await service.getManagedGroupsWithMembersByOwnerId(
+          ownerId,
+        );
+
+        expect(result, isEmpty);
+      });
+    });
+  });
+}

--- a/test/unit/presentation/features/timeline/group_list_test.dart
+++ b/test/unit/presentation/features/timeline/group_list_test.dart
@@ -106,7 +106,7 @@ void main() {
 
     testWidgets('エラーが発生した場合、エラー状態が表示される', (WidgetTester tester) async {
       // Arrange
-      when(mockUsecase.execute(testMember)).thenThrow(Exception('テストエラー'));
+      when(mockUsecase.execute(testMember)).thenThrow(Exception('エラーテスト'));
 
       // Act
       await tester.pumpWidget(createTestWidget());
@@ -121,7 +121,7 @@ void main() {
       WidgetTester tester,
     ) async {
       // Arrange
-      when(mockUsecase.execute(testMember)).thenThrow(Exception('テストエラー'));
+      when(mockUsecase.execute(testMember)).thenThrow(Exception('エラーテスト'));
 
       // Act
       await tester.pumpWidget(createTestWidget());

--- a/test/unit/presentation/features/trip/trip_management_test.dart
+++ b/test/unit/presentation/features/trip/trip_management_test.dart
@@ -264,6 +264,12 @@ void main() {
           orderBy: [const OrderBy('tripStartDate', descending: false)],
         ),
       ).thenAnswer((_) async => testTripEntries);
+      when(
+        mockPinRepository.getPinsByTripId(
+          'trip-1',
+          orderBy: [const OrderBy('visitStartDate', descending: false)],
+        ),
+      ).thenAnswer((_) async => []);
 
       // Act
       await tester.pumpWidget(
@@ -303,6 +309,12 @@ void main() {
           orderBy: [const OrderBy('tripStartDate', descending: false)],
         ),
       ).thenAnswer((_) async => testTripEntries);
+      when(
+        mockPinRepository.getPinsByTripId(
+          'trip-1',
+          orderBy: [const OrderBy('visitStartDate', descending: false)],
+        ),
+      ).thenAnswer((_) async => []);
       when(
         mockTripEntryRepository.updateTripEntry(any),
       ).thenAnswer((_) async {});


### PR DESCRIPTION
## Summary
- MemberDtoをPinDtoの構造に合わせてEquatable対応やcopyWithを追加
- Firestoreからのデータ変換で各種プロパティをサポート
- Memberエンティティとの相互変換を行うMemberMapperとユニットテストを追加

## Testing
- ./check.sh (dartコマンドが存在せず失敗)


------
https://chatgpt.com/codex/tasks/task_e_68c9808e975c833294b3e3bad1ce71bb