### PR TITLE
fix: グループ編集モーダルのフォーカス制御を調整

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -196,6 +196,7 @@
 - [x] グループ削除時は、groupIdで紐づくテーブル（group_members,group_events,trip_entries）をすべて削除する（delete_group_usecaseで対応）
 - [x] グループ削除時は、groupIdで紐づくtrip_entriesが削除されるため、tripIdで紐づくpinsとtrip_participantsも削除する（delete_group_usecaseで対応）
 - [x] グループ編集モーダルのメンバー追加・変更UIをプルダウン選択に変更する
+- [x] グループ編集モーダルでメンバー選択後にフォーカスを外す
 
 ## グループ年表画面
 

--- a/lib/presentation/features/group/group_edit_modal.dart
+++ b/lib/presentation/features/group/group_edit_modal.dart
@@ -201,17 +201,25 @@ class _GroupEditModalState extends State<GroupEditModal> {
         label: const Text('追加'),
         onPressed: addableMembers.isEmpty
             ? null
-            : () => _showMemberSelectionMenu(buttonContext, addableMembers, (
-                selectedMemberId,
-              ) {
-                setState(() {
-                  final updatedMembers = List<GroupMember>.from(_group.members);
-                  updatedMembers.add(
-                    GroupMember(groupId: _group.id, memberId: selectedMemberId),
-                  );
-                  _group = _group.copyWith(members: updatedMembers);
+            : () {
+                FocusScope.of(buttonContext).unfocus();
+                _showMemberSelectionMenu(buttonContext, addableMembers, (
+                  selectedMemberId,
+                ) {
+                  setState(() {
+                    final updatedMembers = List<GroupMember>.from(
+                      _group.members,
+                    );
+                    updatedMembers.add(
+                      GroupMember(
+                        groupId: _group.id,
+                        memberId: selectedMemberId,
+                      ),
+                    );
+                    _group = _group.copyWith(members: updatedMembers);
+                  });
                 });
-              }),
+              },
       ),
     );
   }
@@ -226,18 +234,23 @@ class _GroupEditModalState extends State<GroupEditModal> {
         tooltip: 'メンバーを変更',
         onPressed: changeCandidates.isEmpty
             ? null
-            : () => _showMemberSelectionMenu(buttonContext, changeCandidates, (
-                selectedMemberId,
-              ) {
-                setState(() {
-                  final updatedMembers = List<GroupMember>.from(_group.members);
-                  updatedMembers[index] = GroupMember(
-                    groupId: _group.id,
-                    memberId: selectedMemberId,
-                  );
-                  _group = _group.copyWith(members: updatedMembers);
+            : () {
+                FocusScope.of(buttonContext).unfocus();
+                _showMemberSelectionMenu(buttonContext, changeCandidates, (
+                  selectedMemberId,
+                ) {
+                  setState(() {
+                    final updatedMembers = List<GroupMember>.from(
+                      _group.members,
+                    );
+                    updatedMembers[index] = GroupMember(
+                      groupId: _group.id,
+                      memberId: selectedMemberId,
+                    );
+                    _group = _group.copyWith(members: updatedMembers);
+                  });
                 });
-              }),
+              },
       ),
     );
   }
@@ -283,6 +296,7 @@ class _GroupEditModalState extends State<GroupEditModal> {
     List<Member> candidates,
     ValueChanged<String> onSelected,
   ) async {
+    FocusScope.of(anchorContext).unfocus();
     final selectedMemberId = await showModalBottomSheet<String>(
       context: context,
       isScrollControlled: true,
@@ -432,6 +446,7 @@ class _GroupEditModalState extends State<GroupEditModal> {
   }
 
   void _handleSave() {
+    FocusScope.of(context).unfocus();
     if (_formKey.currentState!.validate()) {
       final updatedGroup = _group.copyWith(
         name: _nameController.text,

--- a/lib/presentation/features/member/member_edit_modal.dart
+++ b/lib/presentation/features/member/member_edit_modal.dart
@@ -228,7 +228,7 @@ class _MemberEditModalState extends State<MemberEditModal> {
 
   Widget _buildGenderField() {
     return DropdownButtonFormField<String>(
-      initialValue: _gender,
+      value: _gender,
       decoration: const InputDecoration(
         labelText: '性別',
         border: OutlineInputBorder(),


### PR DESCRIPTION
## Summary
- [x] グループ編集モーダルでメンバー選択後にフォーカスを外す
- メンバー追加・変更のボタン押下時にフォーカスを解除してモーダル操作後にキーボードが復活しないように修正
- 保存操作でもフォーカスを外すようにし、性別ドロップダウンの初期値指定を `value` に変更

## Testing
- ./check.sh

------
https://chatgpt.com/codex/tasks/task_e_68d0b88443ec8332989d348e9a5a53ed