### PR TITLE
fix(ui): グループ編集モーダルでメンバー選択後にフォーカスを外す

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -196,6 +196,7 @@
 - [x] グループ削除時は、groupIdで紐づくテーブル（group_members,group_events,trip_entries）をすべて削除する（delete_group_usecaseで対応）
 - [x] グループ削除時は、groupIdで紐づくtrip_entriesが削除されるため、tripIdで紐づくpinsとtrip_participantsも削除する（delete_group_usecaseで対応）
 - [x] グループ編集モーダルのメンバー追加・変更UIをプルダウン選択に変更する
+- [x] グループ編集モーダルでメンバー選択後にフォーカスを外す
 
 ## グループ年表画面
 

--- a/lib/presentation/features/group/group_edit_modal.dart
+++ b/lib/presentation/features/group/group_edit_modal.dart
@@ -403,6 +403,14 @@ class _GroupEditModalState extends State<GroupEditModal> {
 
     if (selectedMemberId != null) {
       onSelected(selectedMemberId);
+      // メンバー選択後にフォーカスを外す（setStateの後に実行）
+      if (mounted) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (mounted) {
+            FocusScope.of(context).unfocus();
+          }
+        });
+      }
     }
   }
 


### PR DESCRIPTION
## 概要
- [x] グループ編集モーダルでメンバー選択後にフォーカスを外す

## 修正内容
グループ編集モーダルで「追加」ボタンや「変更」ボタンでメンバーを選択した後、前の入力項目にフォーカスが戻ってキーボードが表示される問題を修正しました。

## 解決方法
`WidgetsBinding.instance.addPostFrameCallback`を使用して、`setState`によるUI再構築が完了した後にフォーカスを外すようにしました。これにより、UIの更新後にフォーカスが戻ってしまう問題を回避できます。

## 動作確認
- [x] メンバー追加後にフォーカスが外れることを確認
- [x] メンバー変更後にフォーカスが外れることを確認
- [x] キーボードが表示されないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)