### PR TITLE
refactor: getTripEntryByIdでpin/pinDetailを取得するように変更

### DIFF
--- a/docs/er_diagram.md
+++ b/docs/er_diagram.md
@@ -17,7 +17,7 @@ erDiagram
     }
     pins {
         string id PK
-        string pinId "NOT NULL"
+        string pinId UK "NOT NULL"
         string tripId FK
         string groupId FK
         number latitude "NOT NULL"

--- a/docs/er_diagram.md
+++ b/docs/er_diagram.md
@@ -105,5 +105,5 @@ erDiagram
     members ||--o{ groups : "id → ownerId"
     members ||--o{ member_invitations : "id → inviteeId"
     members ||--o{ member_invitations : "id → inviterId"
-    pins ||--o{ pin_details : "id → pinId"
+    pins ||--o{ pin_details : "pinId → pinId"
 ```

--- a/docs/er_diagram.md
+++ b/docs/er_diagram.md
@@ -27,6 +27,14 @@ erDiagram
         timestamp visitEndDate
         string visitMemo
     }
+    pin_details {
+        string id PK
+        string pinId FK "NOT NULL"
+        string name
+        timestamp startDate
+        timestamp endDate
+        string memo
+    }
     groups {
         string id PK
         string ownerId FK "NOT NULL"
@@ -97,4 +105,5 @@ erDiagram
     members ||--o{ groups : "id → ownerId"
     members ||--o{ member_invitations : "id → inviteeId"
     members ||--o{ member_invitations : "id → inviterId"
+    pins ||--o{ pin_details : "id → pinId"
 ```

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -12,7 +12,8 @@
 - [x] GetManagedGroupsWithMembersUsecaseをリファクタリングしてリポジトリの単一メソッドを使用する
 - [x] GroupをルートエンティティとしてGroupMemberを内部エンティティに加える
 - [x] TripEntryの集約に訪問場所と詳細予定を追加しリポジトリを対応させる
-- [x] getTripEntries→getTripEntriesByGroupIdに変更
+  - [x] getTripEntries→getTripEntriesByGroupIdに変更
+  - [x] getで子エンティティも取得する
 
 ## マップの表示
 

--- a/lib/domain/repositories/trip_entry_repository.dart
+++ b/lib/domain/repositories/trip_entry_repository.dart
@@ -5,8 +5,8 @@ abstract class TripEntryRepository {
   Future<String> saveTripEntry(TripEntry tripEntry);
   Future<void> updateTripEntry(TripEntry tripEntry);
   Future<void> deleteTripEntry(String tripId);
-  Future<List<TripEntry>> getTripEntriesByGroupId(String groupId);
   Future<TripEntry?> getTripEntryById(String tripId);
+  Future<List<TripEntry>> getTripEntriesByGroupId(String groupId);
   Future<List<TripEntry>> getTripEntriesByGroupIdAndYear(
     String groupId,
     int year, {

--- a/lib/infrastructure/mappers/firestore_group_mapper.dart
+++ b/lib/infrastructure/mappers/firestore_group_mapper.dart
@@ -1,14 +1,19 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:memora/domain/entities/group.dart';
+import 'package:memora/domain/entities/group_member.dart';
 
 class FirestoreGroupMapper {
-  static Group fromFirestore(DocumentSnapshot<Map<String, dynamic>> doc) {
+  static Group fromFirestore(
+    DocumentSnapshot<Map<String, dynamic>> doc, {
+    List<GroupMember>? members,
+  }) {
     final data = doc.data();
     return Group(
       id: doc.id,
       ownerId: data?['ownerId'] as String? ?? '',
       name: data?['name'] as String? ?? '',
       memo: data?['memo'] as String?,
+      members: members ?? const [],
     );
   }
 

--- a/lib/infrastructure/mappers/firestore_pin_mapper.dart
+++ b/lib/infrastructure/mappers/firestore_pin_mapper.dart
@@ -1,8 +1,12 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:memora/domain/entities/pin.dart';
+import 'package:memora/domain/entities/pin_detail.dart';
 
 class FirestorePinMapper {
-  static Pin fromFirestore(DocumentSnapshot<Map<String, dynamic>> doc) {
+  static Pin fromFirestore(
+    DocumentSnapshot<Map<String, dynamic>> doc, {
+    List<PinDetail>? details,
+  }) {
     final data = doc.data();
     return Pin(
       id: doc.id,
@@ -19,7 +23,7 @@ class FirestorePinMapper {
           ? (data!['visitEndDate'] as Timestamp).toDate()
           : null,
       visitMemo: data?['visitMemo'] as String?,
-      details: const [],
+      details: details ?? const [],
     );
   }
 

--- a/lib/infrastructure/mappers/firestore_pin_mapper.dart
+++ b/lib/infrastructure/mappers/firestore_pin_mapper.dart
@@ -1,12 +1,8 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:memora/domain/entities/pin.dart';
-import 'package:memora/domain/entities/pin_detail.dart';
 
 class FirestorePinMapper {
-  static Pin fromFirestore(
-    DocumentSnapshot<Map<String, dynamic>> doc, {
-    List<PinDetail>? details,
-  }) {
+  static Pin fromFirestore(DocumentSnapshot<Map<String, dynamic>> doc) {
     final data = doc.data();
     return Pin(
       id: doc.id,
@@ -23,7 +19,7 @@ class FirestorePinMapper {
           ? (data!['visitEndDate'] as Timestamp).toDate()
           : null,
       visitMemo: data?['visitMemo'] as String?,
-      details: details ?? const [],
+      details: const [],
     );
   }
 

--- a/lib/infrastructure/mappers/firestore_pin_mapper.dart
+++ b/lib/infrastructure/mappers/firestore_pin_mapper.dart
@@ -1,8 +1,12 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:memora/domain/entities/pin.dart';
+import 'package:memora/domain/entities/pin_detail.dart';
 
 class FirestorePinMapper {
-  static Pin fromFirestore(DocumentSnapshot<Map<String, dynamic>> doc) {
+  static Pin fromFirestore(
+    DocumentSnapshot<Map<String, dynamic>> doc, {
+    List<PinDetail>? details,
+  }) {
     final data = doc.data();
     return Pin(
       id: doc.id,
@@ -19,6 +23,7 @@ class FirestorePinMapper {
           ? (data!['visitEndDate'] as Timestamp).toDate()
           : null,
       visitMemo: data?['visitMemo'] as String?,
+      details: details ?? const [],
     );
   }
 

--- a/lib/infrastructure/mappers/firestore_trip_entry_mapper.dart
+++ b/lib/infrastructure/mappers/firestore_trip_entry_mapper.dart
@@ -1,8 +1,12 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:memora/domain/entities/pin.dart';
 import 'package:memora/domain/entities/trip_entry.dart';
 
 class FirestoreTripEntryMapper {
-  static TripEntry fromFirestore(DocumentSnapshot<Map<String, dynamic>> doc) {
+  static TripEntry fromFirestore(
+    DocumentSnapshot<Map<String, dynamic>> doc, {
+    List<Pin>? pins,
+  }) {
     final data = doc.data();
     return TripEntry(
       id: doc.id,
@@ -13,6 +17,7 @@ class FirestoreTripEntryMapper {
       tripEndDate:
           (data?['tripEndDate'] as Timestamp?)?.toDate() ?? DateTime.now(),
       tripMemo: data?['tripMemo'] as String?,
+      pins: pins ?? const [],
     );
   }
 

--- a/lib/infrastructure/repositories/firestore_group_repository.dart
+++ b/lib/infrastructure/repositories/firestore_group_repository.dart
@@ -139,18 +139,17 @@ class FirestoreGroupRepository implements GroupRepository {
       if (!doc.exists) {
         return null;
       }
-      final group = FirestoreGroupMapper.fromFirestore(doc);
 
       final groupMembersSnapshot = await _firestore
           .collection('group_members')
-          .where('groupId', isEqualTo: group.id)
+          .where('groupId', isEqualTo: doc.id)
           .get();
 
       final groupMembers = groupMembersSnapshot.docs
           .map((doc) => FirestoreGroupMemberMapper.fromFirestore(doc))
           .toList();
 
-      return group.copyWith(members: groupMembers);
+      return FirestoreGroupMapper.fromFirestore(doc, members: groupMembers);
     } catch (e, stack) {
       logger.e(
         'FirestoreGroupRepository.getGroups: ${e.toString()}',

--- a/lib/infrastructure/repositories/firestore_trip_entry_repository.dart
+++ b/lib/infrastructure/repositories/firestore_trip_entry_repository.dart
@@ -52,9 +52,11 @@ class FirestoreTripEntryRepository implements TripEntryRepository {
 
       final pins = <Pin>[];
       for (final pinDoc in pinsSnapshot.docs) {
+        final pinId = pinDoc.data()['pinId'] as String? ?? '';
+
         final pinDetailsSnapshot = await _firestore
             .collection('pin_details')
-            .where('pinId', isEqualTo: pinDoc.id)
+            .where('pinId', isEqualTo: pinId)
             .get();
 
         final pinDetails = pinDetailsSnapshot.docs

--- a/lib/infrastructure/repositories/firestore_trip_entry_repository.dart
+++ b/lib/infrastructure/repositories/firestore_trip_entry_repository.dart
@@ -52,11 +52,9 @@ class FirestoreTripEntryRepository implements TripEntryRepository {
 
       final pins = <Pin>[];
       for (final pinDoc in pinsSnapshot.docs) {
-        final pinId = pinDoc.data()['pinId'] as String? ?? '';
-
         final pinDetailsSnapshot = await _firestore
             .collection('pin_details')
-            .where('pinId', isEqualTo: pinId)
+            .where('pinId', isEqualTo: pinDoc.id)
             .get();
 
         final pinDetails = pinDetailsSnapshot.docs

--- a/lib/infrastructure/repositories/firestore_trip_entry_repository.dart
+++ b/lib/infrastructure/repositories/firestore_trip_entry_repository.dart
@@ -43,8 +43,6 @@ class FirestoreTripEntryRepository implements TripEntryRepository {
         return null;
       }
 
-      final tripEntry = FirestoreTripEntryMapper.fromFirestore(doc);
-
       final pinsSnapshot = await _firestore
           .collection('pins')
           .where('tripId', isEqualTo: tripId)
@@ -72,7 +70,7 @@ class FirestoreTripEntryRepository implements TripEntryRepository {
         pins.add(pin);
       }
 
-      return tripEntry.copyWith(pins: pins);
+      return FirestoreTripEntryMapper.fromFirestore(doc, pins: pins);
     } catch (e, stack) {
       logger.e(
         'FirestoreTripEntryRepository.getTripEntryById: ${e.toString()}',

--- a/lib/infrastructure/repositories/firestore_trip_entry_repository.dart
+++ b/lib/infrastructure/repositories/firestore_trip_entry_repository.dart
@@ -45,7 +45,6 @@ class FirestoreTripEntryRepository implements TripEntryRepository {
 
       final tripEntry = FirestoreTripEntryMapper.fromFirestore(doc);
 
-      // TripEntryに紐づくPinを取得
       final pinsSnapshot = await _firestore
           .collection('pins')
           .where('tripId', isEqualTo: tripId)
@@ -55,7 +54,6 @@ class FirestoreTripEntryRepository implements TripEntryRepository {
       for (final pinDoc in pinsSnapshot.docs) {
         final pinId = pinDoc.data()['pinId'] as String? ?? '';
 
-        // 各Pinに紐づくPinDetailを取得
         final pinDetailsSnapshot = await _firestore
             .collection('pin_details')
             .where('pinId', isEqualTo: pinId)

--- a/lib/infrastructure/repositories/firestore_trip_entry_repository.dart
+++ b/lib/infrastructure/repositories/firestore_trip_entry_repository.dart
@@ -67,8 +67,7 @@ class FirestoreTripEntryRepository implements TripEntryRepository {
 
         final pin = FirestorePinMapper.fromFirestore(
           pinDoc,
-          details: pinDetails,
-        );
+        ).copyWith(details: pinDetails);
         pins.add(pin);
       }
 

--- a/lib/infrastructure/repositories/firestore_trip_entry_repository.dart
+++ b/lib/infrastructure/repositories/firestore_trip_entry_repository.dart
@@ -67,7 +67,8 @@ class FirestoreTripEntryRepository implements TripEntryRepository {
 
         final pin = FirestorePinMapper.fromFirestore(
           pinDoc,
-        ).copyWith(details: pinDetails);
+          details: pinDetails,
+        );
         pins.add(pin);
       }
 

--- a/test/unit/infrastructure/mappers/firestore_group_mapper_test.dart
+++ b/test/unit/infrastructure/mappers/firestore_group_mapper_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:memora/domain/entities/group_member.dart';
 import 'package:memora/infrastructure/mappers/firestore_group_mapper.dart';
 import 'package:memora/domain/entities/group.dart';
 
@@ -23,6 +24,7 @@ void main() {
       expect(group.ownerId, 'admin001');
       expect(group.name, 'テストグループ');
       expect(group.memo, 'テストメモ');
+      expect(group.members, isEmpty);
     });
 
     test('nullableなフィールドがnullの場合でも変換できる', () {
@@ -38,6 +40,7 @@ void main() {
       expect(group.ownerId, 'admin002');
       expect(group.name, 'テストグループ2');
       expect(group.memo, null);
+      expect(group.members, isEmpty);
     });
 
     test('Firestoreのデータがnullの場合はデフォルト値に変換される', () {
@@ -51,6 +54,7 @@ void main() {
       expect(group.ownerId, '');
       expect(group.name, '');
       expect(group.memo, isNull);
+      expect(group.members, isEmpty);
     });
 
     test('GroupからFirestoreのMapへ変換できる', () {
@@ -93,6 +97,50 @@ void main() {
       expect(data['name'], '');
       expect(data['memo'], null);
       expect(data['createdAt'], isA<FieldValue>());
+    });
+
+    test('membersパラメータを指定した場合にGroupにメンバーが含まれる', () {
+      final mockDoc = MockQueryDocumentSnapshot<Map<String, dynamic>>();
+      when(mockDoc.id).thenReturn('group005');
+      when(
+        mockDoc.data(),
+      ).thenReturn({'ownerId': 'admin005', 'name': 'メンバー付きグループ', 'memo': 'メモ'});
+
+      final members = [
+        const GroupMember(
+          groupId: 'group005',
+          memberId: 'member001',
+          isAdministrator: true,
+        ),
+        const GroupMember(
+          groupId: 'group005',
+          memberId: 'member002',
+          isAdministrator: false,
+        ),
+      ];
+
+      final group = FirestoreGroupMapper.fromFirestore(
+        mockDoc,
+        members: members,
+      );
+
+      expect(group.members, hasLength(2));
+      expect(group.members[0].memberId, 'member001');
+      expect(group.members[0].isAdministrator, true);
+      expect(group.members[1].memberId, 'member002');
+      expect(group.members[1].isAdministrator, false);
+    });
+
+    test('membersパラメータを指定しない場合は空のリストになる', () {
+      final mockDoc = MockQueryDocumentSnapshot<Map<String, dynamic>>();
+      when(mockDoc.id).thenReturn('group006');
+      when(
+        mockDoc.data(),
+      ).thenReturn({'ownerId': 'admin006', 'name': 'メンバー無しグループ'});
+
+      final group = FirestoreGroupMapper.fromFirestore(mockDoc);
+
+      expect(group.members, isEmpty);
     });
   });
 }

--- a/test/unit/infrastructure/mappers/firestore_pin_mapper_test.dart
+++ b/test/unit/infrastructure/mappers/firestore_pin_mapper_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:memora/domain/entities/pin.dart';
+import 'package:memora/domain/entities/pin_detail.dart';
 import 'package:memora/infrastructure/mappers/firestore_pin_mapper.dart';
 
 import 'firestore_pin_mapper_test.mocks.dart';
@@ -157,6 +158,63 @@ void main() {
       expect(map['visitEndDate'], isNull);
       expect(map['visitMemo'], isNull);
       expect(map['createdAt'], isA<FieldValue>());
+    });
+
+    test('detailsパラメータを指定した場合にPinに詳細予定が含まれる', () {
+      final mockDoc = MockQueryDocumentSnapshot<Map<String, dynamic>>();
+      when(mockDoc.id).thenReturn('pin007');
+      when(mockDoc.data()).thenReturn({
+        'pinId': 'pin-doc-007',
+        'tripId': 'trip007',
+        'groupId': 'group007',
+        'latitude': 35.681236,
+        'longitude': 139.767125,
+        'locationName': '東京駅',
+        'visitStartDate': Timestamp.fromDate(DateTime(2024, 1, 1, 10)),
+        'visitEndDate': Timestamp.fromDate(DateTime(2024, 1, 1, 12)),
+        'visitMemo': '集合場所',
+      });
+
+      final details = [
+        PinDetail(
+          pinId: 'pin-doc-007',
+          name: '詳細1',
+          startDate: DateTime(2024, 1, 1, 10, 30),
+          endDate: DateTime(2024, 1, 1, 11),
+          memo: 'メモ1',
+        ),
+        PinDetail(
+          pinId: 'pin-doc-007',
+          name: '詳細2',
+          startDate: DateTime(2024, 1, 1, 11),
+          endDate: DateTime(2024, 1, 1, 11, 30),
+          memo: 'メモ2',
+        ),
+      ];
+
+      final pin = FirestorePinMapper.fromFirestore(mockDoc, details: details);
+
+      expect(pin.details, hasLength(2));
+      expect(pin.details[0].name, '詳細1');
+      expect(pin.details[0].startDate, DateTime(2024, 1, 1, 10, 30));
+      expect(pin.details[1].name, '詳細2');
+      expect(pin.details[1].startDate, DateTime(2024, 1, 1, 11));
+    });
+
+    test('detailsパラメータを指定しない場合は空のリストになる', () {
+      final mockDoc = MockQueryDocumentSnapshot<Map<String, dynamic>>();
+      when(mockDoc.id).thenReturn('pin008');
+      when(mockDoc.data()).thenReturn({
+        'pinId': 'pin-doc-008',
+        'tripId': 'trip008',
+        'groupId': 'group008',
+        'latitude': 35.681236,
+        'longitude': 139.767125,
+      });
+
+      final pin = FirestorePinMapper.fromFirestore(mockDoc);
+
+      expect(pin.details, isEmpty);
     });
   });
 }

--- a/test/unit/infrastructure/repositories/firestore_trip_entry_repository_test.dart
+++ b/test/unit/infrastructure/repositories/firestore_trip_entry_repository_test.dart
@@ -76,90 +76,33 @@ void main() {
       },
     );
 
-    test(
-      'getTripEntriesByGroupIdがFirestoreからTripEntryのリストをpinとpin_detailsも含めて返す',
-      () async {
-        const groupId = 'group001';
-        final mockQuery = MockQuery<Map<String, dynamic>>();
-        final mockPinsCollection =
-            MockCollectionReference<Map<String, dynamic>>();
-        final mockPinsQuery = MockQuery<Map<String, dynamic>>();
-        final mockPinsSnapshot = MockQuerySnapshot<Map<String, dynamic>>();
-        final mockPinDoc = MockQueryDocumentSnapshot<Map<String, dynamic>>();
-        final mockPinDetailsCollection =
-            MockCollectionReference<Map<String, dynamic>>();
-        final mockPinDetailsQuery = MockQuery<Map<String, dynamic>>();
-        final mockPinDetailsSnapshot =
-            MockQuerySnapshot<Map<String, dynamic>>();
-        final mockPinDetailDoc =
-            MockQueryDocumentSnapshot<Map<String, dynamic>>();
+    test('getTripEntriesByGroupIdがFirestoreからTripEntryのリストを返す', () async {
+      const groupId = 'group001';
+      final mockQuery = MockQuery<Map<String, dynamic>>();
 
-        when(
-          mockCollection.where('groupId', isEqualTo: groupId),
-        ).thenReturn(mockQuery);
-        when(mockQuery.get()).thenAnswer((_) async => mockQuerySnapshot);
-        when(mockQuerySnapshot.docs).thenReturn([mockDoc1]);
-        when(mockDoc1.id).thenReturn('trip001');
-        when(mockDoc1.data()).thenReturn({
-          'groupId': 'group001',
-          'tripName': 'テスト旅行1',
-          'tripStartDate': Timestamp.fromDate(DateTime(2025, 6, 1)),
-          'tripEndDate': Timestamp.fromDate(DateTime(2025, 6, 10)),
-          'tripMemo': 'テストメモ1',
-        });
+      when(
+        mockCollection.where('groupId', isEqualTo: groupId),
+      ).thenReturn(mockQuery);
+      when(mockQuery.get()).thenAnswer((_) async => mockQuerySnapshot);
+      when(mockQuerySnapshot.docs).thenReturn([mockDoc1]);
+      when(mockDoc1.id).thenReturn('trip001');
+      when(mockDoc1.data()).thenReturn({
+        'groupId': 'group001',
+        'tripName': 'テスト旅行1',
+        'tripStartDate': Timestamp.fromDate(DateTime(2025, 6, 1)),
+        'tripEndDate': Timestamp.fromDate(DateTime(2025, 6, 10)),
+        'tripMemo': 'テストメモ1',
+      });
 
-        when(mockFirestore.collection('pins')).thenReturn(mockPinsCollection);
-        when(
-          mockPinsCollection.where('tripId', isEqualTo: 'trip001'),
-        ).thenReturn(mockPinsQuery);
-        when(mockPinsQuery.get()).thenAnswer((_) async => mockPinsSnapshot);
-        when(mockPinsSnapshot.docs).thenReturn([mockPinDoc]);
-        when(mockPinDoc.id).thenReturn('pin001');
-        when(mockPinDoc.data()).thenReturn({
-          'pinId': 'pin001',
-          'tripId': 'trip001',
-          'groupId': 'group001',
-          'latitude': 35.6812,
-          'longitude': 139.7671,
-          'locationName': 'テスト場所',
-          'visitStartDate': Timestamp.fromDate(DateTime(2025, 6, 2, 10)),
-          'visitEndDate': Timestamp.fromDate(DateTime(2025, 6, 2, 15)),
-          'visitMemo': 'テスト訪問メモ',
-        });
+      final result = await repository.getTripEntriesByGroupId(groupId);
 
-        when(
-          mockFirestore.collection('pin_details'),
-        ).thenReturn(mockPinDetailsCollection);
-        when(
-          mockPinDetailsCollection.where('pinId', isEqualTo: 'pin001'),
-        ).thenReturn(mockPinDetailsQuery);
-        when(
-          mockPinDetailsQuery.get(),
-        ).thenAnswer((_) async => mockPinDetailsSnapshot);
-        when(mockPinDetailsSnapshot.docs).thenReturn([mockPinDetailDoc]);
-        when(mockPinDetailDoc.id).thenReturn('detail001');
-        when(mockPinDetailDoc.data()).thenReturn({
-          'pinId': 'pin001',
-          'name': 'テスト詳細予定',
-          'startDate': Timestamp.fromDate(DateTime(2025, 6, 2, 11)),
-          'endDate': Timestamp.fromDate(DateTime(2025, 6, 2, 13)),
-          'memo': 'テスト詳細メモ',
-        });
-
-        final result = await repository.getTripEntriesByGroupId(groupId);
-
-        expect(result.length, 1);
-        expect(result[0].id, 'trip001');
-        expect(result[0].groupId, 'group001');
-        expect(result[0].tripName, 'テスト旅行1');
-        expect(result[0].tripMemo, 'テストメモ1');
-        expect(result[0].pins.length, 1);
-        expect(result[0].pins[0].id, 'pin001');
-        expect(result[0].pins[0].locationName, 'テスト場所');
-        expect(result[0].pins[0].details.length, 1);
-        expect(result[0].pins[0].details[0].name, 'テスト詳細予定');
-      },
-    );
+      expect(result.length, 1);
+      expect(result[0].id, 'trip001');
+      expect(result[0].groupId, 'group001');
+      expect(result[0].tripName, 'テスト旅行1');
+      expect(result[0].tripMemo, 'テストメモ1');
+      expect(result[0].pins, isEmpty);
+    });
 
     test('getTripEntriesByGroupIdがエラー時に空のリストを返す', () async {
       when(mockCollection.get()).thenThrow(TestException('Firestore error'));
@@ -182,10 +125,21 @@ void main() {
       verify(mockDocRef.delete()).called(1);
     });
 
-    test('getTripEntryByIdが特定の旅行を返す', () async {
+    test('getTripEntryByIdが特定の旅行をpinとpin_detailsも含めて返す', () async {
       const tripId = 'trip001';
       final mockDocRef = MockDocumentReference<Map<String, dynamic>>();
       final mockDocSnapshot = MockDocumentSnapshot<Map<String, dynamic>>();
+      final mockPinsCollection =
+          MockCollectionReference<Map<String, dynamic>>();
+      final mockPinsQuery = MockQuery<Map<String, dynamic>>();
+      final mockPinsSnapshot = MockQuerySnapshot<Map<String, dynamic>>();
+      final mockPinDoc = MockQueryDocumentSnapshot<Map<String, dynamic>>();
+      final mockPinDetailsCollection =
+          MockCollectionReference<Map<String, dynamic>>();
+      final mockPinDetailsQuery = MockQuery<Map<String, dynamic>>();
+      final mockPinDetailsSnapshot = MockQuerySnapshot<Map<String, dynamic>>();
+      final mockPinDetailDoc =
+          MockQueryDocumentSnapshot<Map<String, dynamic>>();
 
       when(mockCollection.doc(tripId)).thenReturn(mockDocRef);
       when(mockDocRef.get()).thenAnswer((_) async => mockDocSnapshot);
@@ -199,13 +153,55 @@ void main() {
         'tripMemo': 'テストメモ',
       });
 
+      when(mockFirestore.collection('pins')).thenReturn(mockPinsCollection);
+      when(
+        mockPinsCollection.where('tripId', isEqualTo: tripId),
+      ).thenReturn(mockPinsQuery);
+      when(mockPinsQuery.get()).thenAnswer((_) async => mockPinsSnapshot);
+      when(mockPinsSnapshot.docs).thenReturn([mockPinDoc]);
+      when(mockPinDoc.id).thenReturn('pin001');
+      when(mockPinDoc.data()).thenReturn({
+        'pinId': 'pin001',
+        'tripId': tripId,
+        'groupId': 'group001',
+        'latitude': 35.6812,
+        'longitude': 139.7671,
+        'locationName': 'テスト場所',
+        'visitStartDate': Timestamp.fromDate(DateTime(2025, 6, 2, 10)),
+        'visitEndDate': Timestamp.fromDate(DateTime(2025, 6, 2, 15)),
+        'visitMemo': 'テスト訪問メモ',
+      });
+
+      when(
+        mockFirestore.collection('pin_details'),
+      ).thenReturn(mockPinDetailsCollection);
+      when(
+        mockPinDetailsCollection.where('pinId', isEqualTo: 'pin001'),
+      ).thenReturn(mockPinDetailsQuery);
+      when(
+        mockPinDetailsQuery.get(),
+      ).thenAnswer((_) async => mockPinDetailsSnapshot);
+      when(mockPinDetailsSnapshot.docs).thenReturn([mockPinDetailDoc]);
+      when(mockPinDetailDoc.id).thenReturn('detail001');
+      when(mockPinDetailDoc.data()).thenReturn({
+        'pinId': 'pin001',
+        'name': 'テスト詳細予定',
+        'startDate': Timestamp.fromDate(DateTime(2025, 6, 2, 11)),
+        'endDate': Timestamp.fromDate(DateTime(2025, 6, 2, 13)),
+        'memo': 'テスト詳細メモ',
+      });
+
       final result = await repository.getTripEntryById(tripId);
 
       expect(result, isNotNull);
       expect(result!.id, tripId);
       expect(result.groupId, 'group001');
       expect(result.tripName, 'テスト旅行');
-      expect(result.pins, isEmpty);
+      expect(result.pins.length, 1);
+      expect(result.pins[0].id, 'pin001');
+      expect(result.pins[0].locationName, 'テスト場所');
+      expect(result.pins[0].details.length, 1);
+      expect(result.pins[0].details[0].name, 'テスト詳細予定');
     });
 
     test('getTripEntryByIdが存在しない旅行でnullを返す', () async {

--- a/test/unit/infrastructure/repositories/firestore_trip_entry_repository_test.dart
+++ b/test/unit/infrastructure/repositories/firestore_trip_entry_repository_test.dart
@@ -76,33 +76,90 @@ void main() {
       },
     );
 
-    test('getTripEntriesByGroupIdがFirestoreからTripEntryのリストを返す', () async {
-      const groupId = 'group001';
-      final mockQuery = MockQuery<Map<String, dynamic>>();
+    test(
+      'getTripEntriesByGroupIdがFirestoreからTripEntryのリストをpinとpin_detailsも含めて返す',
+      () async {
+        const groupId = 'group001';
+        final mockQuery = MockQuery<Map<String, dynamic>>();
+        final mockPinsCollection =
+            MockCollectionReference<Map<String, dynamic>>();
+        final mockPinsQuery = MockQuery<Map<String, dynamic>>();
+        final mockPinsSnapshot = MockQuerySnapshot<Map<String, dynamic>>();
+        final mockPinDoc = MockQueryDocumentSnapshot<Map<String, dynamic>>();
+        final mockPinDetailsCollection =
+            MockCollectionReference<Map<String, dynamic>>();
+        final mockPinDetailsQuery = MockQuery<Map<String, dynamic>>();
+        final mockPinDetailsSnapshot =
+            MockQuerySnapshot<Map<String, dynamic>>();
+        final mockPinDetailDoc =
+            MockQueryDocumentSnapshot<Map<String, dynamic>>();
 
-      when(
-        mockCollection.where('groupId', isEqualTo: groupId),
-      ).thenReturn(mockQuery);
-      when(mockQuery.get()).thenAnswer((_) async => mockQuerySnapshot);
-      when(mockQuerySnapshot.docs).thenReturn([mockDoc1]);
-      when(mockDoc1.id).thenReturn('trip001');
-      when(mockDoc1.data()).thenReturn({
-        'groupId': 'group001',
-        'tripName': 'テスト旅行1',
-        'tripStartDate': Timestamp.fromDate(DateTime(2025, 6, 1)),
-        'tripEndDate': Timestamp.fromDate(DateTime(2025, 6, 10)),
-        'tripMemo': 'テストメモ1',
-      });
+        when(
+          mockCollection.where('groupId', isEqualTo: groupId),
+        ).thenReturn(mockQuery);
+        when(mockQuery.get()).thenAnswer((_) async => mockQuerySnapshot);
+        when(mockQuerySnapshot.docs).thenReturn([mockDoc1]);
+        when(mockDoc1.id).thenReturn('trip001');
+        when(mockDoc1.data()).thenReturn({
+          'groupId': 'group001',
+          'tripName': 'テスト旅行1',
+          'tripStartDate': Timestamp.fromDate(DateTime(2025, 6, 1)),
+          'tripEndDate': Timestamp.fromDate(DateTime(2025, 6, 10)),
+          'tripMemo': 'テストメモ1',
+        });
 
-      final result = await repository.getTripEntriesByGroupId(groupId);
+        when(mockFirestore.collection('pins')).thenReturn(mockPinsCollection);
+        when(
+          mockPinsCollection.where('tripId', isEqualTo: 'trip001'),
+        ).thenReturn(mockPinsQuery);
+        when(mockPinsQuery.get()).thenAnswer((_) async => mockPinsSnapshot);
+        when(mockPinsSnapshot.docs).thenReturn([mockPinDoc]);
+        when(mockPinDoc.id).thenReturn('pin001');
+        when(mockPinDoc.data()).thenReturn({
+          'pinId': 'pin001',
+          'tripId': 'trip001',
+          'groupId': 'group001',
+          'latitude': 35.6812,
+          'longitude': 139.7671,
+          'locationName': 'テスト場所',
+          'visitStartDate': Timestamp.fromDate(DateTime(2025, 6, 2, 10)),
+          'visitEndDate': Timestamp.fromDate(DateTime(2025, 6, 2, 15)),
+          'visitMemo': 'テスト訪問メモ',
+        });
 
-      expect(result.length, 1);
-      expect(result[0].id, 'trip001');
-      expect(result[0].groupId, 'group001');
-      expect(result[0].tripName, 'テスト旅行1');
-      expect(result[0].tripMemo, 'テストメモ1');
-      expect(result[0].pins, isEmpty);
-    });
+        when(
+          mockFirestore.collection('pin_details'),
+        ).thenReturn(mockPinDetailsCollection);
+        when(
+          mockPinDetailsCollection.where('pinId', isEqualTo: 'pin001'),
+        ).thenReturn(mockPinDetailsQuery);
+        when(
+          mockPinDetailsQuery.get(),
+        ).thenAnswer((_) async => mockPinDetailsSnapshot);
+        when(mockPinDetailsSnapshot.docs).thenReturn([mockPinDetailDoc]);
+        when(mockPinDetailDoc.id).thenReturn('detail001');
+        when(mockPinDetailDoc.data()).thenReturn({
+          'pinId': 'pin001',
+          'name': 'テスト詳細予定',
+          'startDate': Timestamp.fromDate(DateTime(2025, 6, 2, 11)),
+          'endDate': Timestamp.fromDate(DateTime(2025, 6, 2, 13)),
+          'memo': 'テスト詳細メモ',
+        });
+
+        final result = await repository.getTripEntriesByGroupId(groupId);
+
+        expect(result.length, 1);
+        expect(result[0].id, 'trip001');
+        expect(result[0].groupId, 'group001');
+        expect(result[0].tripName, 'テスト旅行1');
+        expect(result[0].tripMemo, 'テストメモ1');
+        expect(result[0].pins.length, 1);
+        expect(result[0].pins[0].id, 'pin001');
+        expect(result[0].pins[0].locationName, 'テスト場所');
+        expect(result[0].pins[0].details.length, 1);
+        expect(result[0].pins[0].details[0].name, 'テスト詳細予定');
+      },
+    );
 
     test('getTripEntriesByGroupIdがエラー時に空のリストを返す', () async {
       when(mockCollection.get()).thenThrow(TestException('Firestore error'));


### PR DESCRIPTION
## 変更内容

- `getTripEntryById`でpin及びpinDetailを取得するように実装
- `getTripEntriesByGroupId`は元のシンプルな実装に戻した
- 各TripEntryは関連するPinとその子のPinDetailを含むようになった
- テストも変更に合わせて更新

## 関連するTODO

該当なし（前回のコンテキストからの継続作業）

🤖 Generated with [Claude Code](https://claude.com/claude-code)