### PR TITLE
Use trip entry pins instead of GetPinsByTripIdUseCase

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -15,6 +15,7 @@
   - [x] getTripEntries→getTripEntriesByGroupIdに変更
   - [x] getで子エンティティも取得する
   - [x] save,update,deleteも子エンティティに対応する
+- [x] GetPinsByTripIdUseCaseの使用を廃止し、GetTripEntriesUsecaseで取得したpinsデータを使用する
 
 ## マップの表示
 

--- a/lib/infrastructure/repositories/firestore_trip_entry_repository.dart
+++ b/lib/infrastructure/repositories/firestore_trip_entry_repository.dart
@@ -186,10 +186,67 @@ class FirestoreTripEntryRepository implements TripEntryRepository {
       }
 
       final snapshot = await query.get();
+      final tripEntries = <TripEntry>[];
 
-      return snapshot.docs
-          .map((doc) => FirestoreTripEntryMapper.fromFirestore(doc))
-          .toList();
+      for (final doc in snapshot.docs) {
+        final pins = <Pin>[];
+
+        try {
+          final pinsSnapshot = await _firestore
+              .collection('pins')
+              .where('tripId', isEqualTo: doc.id)
+              .get();
+
+          for (final pinDoc in pinsSnapshot.docs) {
+            final pinId = pinDoc.data()['pinId'] as String? ?? '';
+
+            final pinDetailsSnapshot = await _firestore
+                .collection('pin_details')
+                .where('pinId', isEqualTo: pinId)
+                .get();
+
+            final pinDetails = pinDetailsSnapshot.docs
+                .map(
+                  (detailDoc) =>
+                      FirestorePinDetailMapper.fromFirestore(detailDoc),
+                )
+                .toList();
+
+            final pin = FirestorePinMapper.fromFirestore(
+              pinDoc,
+              details: pinDetails,
+            );
+            pins.add(pin);
+          }
+
+          pins.sort((a, b) {
+            final startA = a.visitStartDate;
+            final startB = b.visitStartDate;
+            if (startA == null && startB == null) {
+              return 0;
+            }
+            if (startA == null) {
+              return -1;
+            }
+            if (startB == null) {
+              return 1;
+            }
+            return startA.compareTo(startB);
+          });
+        } catch (e, stack) {
+          logger.e(
+            'FirestoreTripEntryRepository.getTripEntriesByGroupIdAndYear (pins): ${e.toString()}',
+            error: e,
+            stackTrace: stack,
+          );
+        }
+
+        tripEntries.add(
+          FirestoreTripEntryMapper.fromFirestore(doc, pins: pins),
+        );
+      }
+
+      return tripEntries;
     } catch (e, stack) {
       logger.e(
         'FirestoreTripEntryRepository.getTripEntriesByGroupIdAndYear: ${e.toString()}',

--- a/lib/presentation/features/trip/trip_management.dart
+++ b/lib/presentation/features/trip/trip_management.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:memora/application/dtos/pin/pin_dto.dart';
+import 'package:memora/application/mappers/pin_mapper.dart';
 import 'package:memora/application/usecases/trip/create_trip_entry_usecase.dart';
 import 'package:memora/application/usecases/trip/get_trip_entries_usecase.dart';
 import 'package:memora/application/usecases/trip/update_trip_entry_usecase.dart';
 import 'package:memora/application/usecases/trip/delete_trip_entry_usecase.dart';
 import 'package:memora/application/usecases/pin/create_pin_usecase.dart';
-import 'package:memora/application/usecases/pin/get_pins_by_trip_id_usecase.dart';
 import 'package:memora/application/usecases/pin/delete_pins_by_trip_id_usecase.dart';
 import 'package:memora/domain/entities/trip_entry.dart';
 import 'package:memora/domain/repositories/trip_entry_repository.dart';
@@ -44,7 +44,6 @@ class _TripManagementState extends State<TripManagement> {
   late final UpdateTripEntryUsecase _updateTripEntryUsecase;
   late final DeleteTripEntryUsecase _deleteTripEntryUsecase;
   CreatePinUseCase? _createPinUseCase;
-  GetPinsByTripIdUseCase? _getPinsByTripIdUseCase;
   DeletePinsByTripIdUseCase? _deletePinsByTripIdUseCase;
 
   List<TripEntry> _tripEntries = [];
@@ -63,7 +62,6 @@ class _TripManagementState extends State<TripManagement> {
     _updateTripEntryUsecase = UpdateTripEntryUsecase(tripEntryRepository);
     _deleteTripEntryUsecase = DeleteTripEntryUsecase(tripEntryRepository);
     _createPinUseCase = CreatePinUseCase(pinRepository);
-    _getPinsByTripIdUseCase = GetPinsByTripIdUseCase(pinRepository);
     _deletePinsByTripIdUseCase = DeletePinsByTripIdUseCase(pinRepository);
 
     _loadTripEntries();
@@ -198,21 +196,7 @@ class _TripManagementState extends State<TripManagement> {
   }
 
   Future<void> _showEditTripDialog(TripEntry tripEntry) async {
-    List<PinDto>? existingPins;
-    if (_getPinsByTripIdUseCase != null) {
-      try {
-        existingPins = await _getPinsByTripIdUseCase!.execute(tripEntry.id);
-      } catch (e, stack) {
-        logger.e(
-          '_TripManagementState._showEditTripDialog: ${e.toString()}',
-          error: e,
-          stackTrace: stack,
-        );
-        existingPins = [];
-      }
-    } else {
-      existingPins = [];
-    }
+    final existingPins = PinMapper.toDtoList(tripEntry.pins);
 
     if (!mounted) return;
 

--- a/test/unit/presentation/features/trip/trip_management_test.dart
+++ b/test/unit/presentation/features/trip/trip_management_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
+import 'package:memora/domain/entities/pin.dart';
 import 'package:memora/domain/entities/trip_entry.dart';
 import 'package:memora/domain/repositories/trip_entry_repository.dart';
 import 'package:memora/domain/repositories/pin_repository.dart';
@@ -16,10 +17,24 @@ void main() {
   late MockTripEntryRepository mockTripEntryRepository;
   late MockPinRepository mockPinRepository;
   late List<TripEntry> testTripEntries;
+  late Pin testPin;
 
   setUp(() {
     mockTripEntryRepository = MockTripEntryRepository();
     mockPinRepository = MockPinRepository();
+    testPin = Pin(
+      id: 'pin-1',
+      pinId: 'pin-1',
+      tripId: 'trip-1',
+      groupId: 'test-group-id',
+      latitude: 43.06417,
+      longitude: 141.34694,
+      locationName: '札幌駅',
+      visitStartDate: DateTime(2025, 7, 1, 9),
+      visitEndDate: DateTime(2025, 7, 1, 12),
+      visitMemo: '待ち合わせ',
+    );
+
     testTripEntries = [
       TripEntry(
         id: 'trip-1',
@@ -28,6 +43,7 @@ void main() {
         tripStartDate: DateTime(2025, 7, 1),
         tripEndDate: DateTime(2025, 7, 5),
         tripMemo: '夏の北海道を楽しむ',
+        pins: [testPin],
       ),
       TripEntry(
         id: 'trip-2',
@@ -257,13 +273,6 @@ void main() {
           orderBy: [const OrderBy('tripStartDate', descending: false)],
         ),
       ).thenAnswer((_) async => testTripEntries);
-      when(
-        mockPinRepository.getPinsByTripId(
-          'trip-1',
-          orderBy: [const OrderBy('visitStartDate', descending: false)],
-        ),
-      ).thenAnswer((_) async => []);
-
       // Act
       await tester.pumpWidget(
         MaterialApp(
@@ -290,6 +299,11 @@ void main() {
       // 編集モーダルが開いていることを確認
       expect(find.text('旅行編集'), findsOneWidget);
       expect(find.text('北海道旅行'), findsAtLeastNWidgets(1)); // モーダル内にも表示される
+      expect(find.text('札幌駅'), findsOneWidget);
+
+      verifyNever(
+        mockPinRepository.getPinsByTripId(any, orderBy: anyNamed('orderBy')),
+      );
     });
 
     testWidgets('旅行情報の更新ができること', (WidgetTester tester) async {
@@ -301,12 +315,6 @@ void main() {
           orderBy: [const OrderBy('tripStartDate', descending: false)],
         ),
       ).thenAnswer((_) async => testTripEntries);
-      when(
-        mockPinRepository.getPinsByTripId(
-          'trip-1',
-          orderBy: [const OrderBy('visitStartDate', descending: false)],
-        ),
-      ).thenAnswer((_) async => []);
       when(
         mockTripEntryRepository.updateTripEntry(any),
       ).thenAnswer((_) async {});


### PR DESCRIPTION
## Summary
- mark the repository todo for replacing GetPinsByTripIdUseCase usage
- load pin aggregates in FirestoreTripEntryRepository so GetTripEntriesUsecase returns pins
- pass trip entry pins to TripEditModal and update tests to confirm UI uses the loaded pins

## Testing
- ./check.sh

------
https://chatgpt.com/codex/tasks/task_e_68de83405e80833293862878440b1b4c