### PR TITLE
feat(top_page): _currentMember取得エラー時にログアウト処理を追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@
 
 ## アーキテクチャ
 
-※Robert C.Martinが提唱した**クリーンアーキテクチャの原則**に従います。
+Robert C.Martinが提唱した**クリーンアーキテクチャの原則**に従います。
 
 ### クリーンアーキテクチャの原則
 
@@ -75,7 +75,7 @@
 
 ## TDDワークフロー定義
 
-※Kent Beckの原著『Test-Driven Development: By Example』とその翻訳者であるt-wadaの解釈に従います。
+Kent Beckの原著『Test-Driven Development: By Example』とその翻訳者であるt-wadaの解釈に従います。
 
 ### Red - Green - Refactor サイクル
 
@@ -115,7 +115,7 @@
 
 ## リファクタリング定義
 
-※Martin Fowlerの著書『Refactoring: Improving the Design of Existing Code』に従います。
+Martin Fowlerの著書『Refactoring: Improving the Design of Existing Code』に従います。
 
 ### 基本原則
 
@@ -151,7 +151,7 @@
 
 ## コミット形式
 
-※Conventional Commits仕様に従います。
+Conventional Commits仕様に従います。
 
 ### 基本形式
 
@@ -265,6 +265,18 @@ BREAKING CHANGE: /api/v1/users を /api/v2/users に変更
 
 ### テストベストプラクティス
 
+- **テストでの例外発生**: テストで例外を発生させる場合は、必ず`test/helpers/test_exception.dart`の`TestException`を使用すること。`TestException`はログ出力を抑制するため、テスト実行時のノイズを減らすことができる
+
+  ```dart
+  // ❌ 避けるべき方法
+  when(mockUseCase.execute()).thenThrow(Exception('エラーメッセージ'));
+
+  // ✅ 推奨する方法
+  import '../../../helpers/test_exception.dart';
+
+  when(mockUseCase.execute()).thenThrow(TestException('エラーメッセージ'));
+  ```
+
 - **非同期テストの制御**: `Future.delayed`を使った待機は避ける。環境によって不安定になるため、`Completer`を使用してテストコードが非同期処理のタイミングを制御する
 
   ```dart
@@ -273,7 +285,7 @@ BREAKING CHANGE: /api/v1/users を /api/v2/users に変更
     await Future.delayed(const Duration(milliseconds: 100));
     return result;
   });
-  
+
   // ✅ 推奨する方法
   final completer = Completer<Result>();
   when(mockUseCase.execute()).thenAnswer((_) => completer.future);

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -265,6 +265,18 @@ BREAKING CHANGE: /api/v1/users を /api/v2/users に変更
 
 ### テストベストプラクティス
 
+- **テストでの例外発生**: テストで例外を発生させる場合は、必ず`test/helpers/test_exception.dart`の`TestException`を使用すること。`TestException`はログ出力を抑制するため、テスト実行時のノイズを減らすことができる
+
+  ```dart
+  // ❌ 避けるべき方法
+  when(mockUseCase.execute()).thenThrow(Exception('エラーメッセージ'));
+
+  // ✅ 推奨する方法
+  import '../../../helpers/test_exception.dart';
+
+  when(mockUseCase.execute()).thenThrow(TestException('エラーメッセージ'));
+  ```
+
 - **非同期テストの制御**: `Future.delayed`を使った待機は避ける。環境によって不安定になるため、`Completer`を使用してテストコードが非同期処理のタイミングを制御する
 
   ```dart
@@ -273,7 +285,7 @@ BREAKING CHANGE: /api/v1/users を /api/v2/users に変更
     await Future.delayed(const Duration(milliseconds: 100));
     return result;
   });
-  
+
   // ✅ 推奨する方法
   final completer = Completer<Result>();
   when(mockUseCase.execute()).thenAnswer((_) => completer.future);

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@
 
 ## アーキテクチャ
 
-※Robert C.Martinが提唱した**クリーンアーキテクチャの原則**に従います。
+Robert C.Martinが提唱した**クリーンアーキテクチャの原則**に従います。
 
 ### クリーンアーキテクチャの原則
 
@@ -75,7 +75,7 @@
 
 ## TDDワークフロー定義
 
-※Kent Beckの原著『Test-Driven Development: By Example』とその翻訳者であるt-wadaの解釈に従います。
+Kent Beckの原著『Test-Driven Development: By Example』とその翻訳者であるt-wadaの解釈に従います。
 
 ### Red - Green - Refactor サイクル
 
@@ -115,7 +115,7 @@
 
 ## リファクタリング定義
 
-※Martin Fowlerの著書『Refactoring: Improving the Design of Existing Code』に従います。
+Martin Fowlerの著書『Refactoring: Improving the Design of Existing Code』に従います。
 
 ### 基本原則
 
@@ -151,7 +151,7 @@
 
 ## コミット形式
 
-※Conventional Commits仕様に従います。
+Conventional Commits仕様に従います。
 
 ### 基本形式
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -84,6 +84,7 @@
   - [x] GroupTimelineNavigationNotifierクラスを作成する（lib/application/controllers/group_timeline_navigation_controller.dart）
   - [x] TopPageをリファクタリングしてコントローラーを使用する形に変更する
 - [x] トップページのヘッダ色をハンバーガーメニューのヘッダ色と合わせる
+- [x] _currentMember取得でエラーになった場合、showSnackBarでエラーを表示し、そのままログアウトする
 
 ## アカウント管理
 

--- a/lib/presentation/app/top_page.dart
+++ b/lib/presentation/app/top_page.dart
@@ -74,7 +74,17 @@ class _TopPageState extends State<TopPage> {
         error: e,
         stackTrace: stack,
       );
-      // エラー時はnullのまま
+      if (mounted) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (mounted) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('メンバー情報の取得に失敗しました。再度ログインしてください。')),
+            );
+            final container = ProviderScope.containerOf(context);
+            container.read(authNotifierProvider.notifier).logout();
+          }
+        });
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- _currentMember取得でエラーになった場合、showSnackBarでエラーを表示し、そのままログアウトする

## 変更内容

- `_loadCurrentMember`メソッドでエラー発生時にSnackBarでエラーメッセージを表示
- エラー発生時に自動的にログアウト処理を実行
- `TestException`を使用してテスト時のログノイズを削減
- `CLAUDE.md`に`TestException`使用のベストプラクティスを追加

## Test plan

- [x] `_currentMember`取得エラー時にSnackBarが表示されることを確認
- [x] エラー時にログアウト処理が実行されることを確認
- [x] テスト実行時にログノイズが削減されていることを確認
- [x] 全テストが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)