### PR TITLE
feat: FirestorePinQueryServiceを追加

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -16,6 +16,7 @@
   - [x] getで子エンティティも取得する
   - [x] save,update,deleteも子エンティティに対応する
 - [x] GetPinsByTripIdUseCaseの使用を廃止し、GetTripEntriesUsecaseで取得したpinsデータを使用する
+- [x] FirestorePinQueryServiceを作成し、自分が所属するグループに紐づくピンを取得する
 
 ## マップの表示
 

--- a/lib/application/interfaces/pin_query_service.dart
+++ b/lib/application/interfaces/pin_query_service.dart
@@ -1,0 +1,5 @@
+import 'package:memora/application/dtos/pin/pin_dto.dart';
+
+abstract class PinQueryService {
+  Future<List<PinDto>> getPinsByMemberId(String memberId);
+}

--- a/lib/infrastructure/services/firestore_pin_query_service.dart
+++ b/lib/infrastructure/services/firestore_pin_query_service.dart
@@ -1,0 +1,96 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:memora/application/dtos/pin/pin_dto.dart';
+import 'package:memora/application/interfaces/pin_query_service.dart';
+import 'package:memora/core/app_logger.dart';
+
+class FirestorePinQueryService implements PinQueryService {
+  FirestorePinQueryService({FirebaseFirestore? firestore})
+    : _firestore = firestore ?? FirebaseFirestore.instance;
+
+  final FirebaseFirestore _firestore;
+
+  @override
+  Future<List<PinDto>> getPinsByMemberId(String memberId) async {
+    try {
+      final groupIds = await _getGroupIdsByMemberId(memberId);
+      if (groupIds.isEmpty) {
+        return [];
+      }
+
+      final List<PinDto> pins = [];
+      for (final groupId in groupIds) {
+        final groupPins = await _getPinsByGroupId(groupId);
+        pins.addAll(groupPins);
+      }
+
+      return pins;
+    } catch (e, stack) {
+      logger.e(
+        'FirestorePinQueryService.getPinsByMemberId: ${e.toString()}',
+        error: e,
+        stackTrace: stack,
+      );
+      return [];
+    }
+  }
+
+  Future<List<String>> _getGroupIdsByMemberId(String memberId) async {
+    final List<String> groupIds = [];
+    final Set<String> groupIdSet = {};
+
+    final adminGroupsSnapshot = await _firestore
+        .collection('groups')
+        .where('ownerId', isEqualTo: memberId)
+        .get();
+
+    for (final doc in adminGroupsSnapshot.docs) {
+      if (groupIdSet.add(doc.id)) {
+        groupIds.add(doc.id);
+      }
+    }
+
+    final memberGroupsSnapshot = await _firestore
+        .collection('group_members')
+        .where('memberId', isEqualTo: memberId)
+        .get();
+
+    for (final doc in memberGroupsSnapshot.docs) {
+      final data = doc.data();
+      final groupId = data['groupId'] as String?;
+      if (groupId != null && groupId.isNotEmpty && groupIdSet.add(groupId)) {
+        groupIds.add(groupId);
+      }
+    }
+
+    return groupIds;
+  }
+
+  Future<List<PinDto>> _getPinsByGroupId(String groupId) async {
+    final pinsSnapshot = await _firestore
+        .collection('pins')
+        .where('groupId', isEqualTo: groupId)
+        .get();
+
+    return pinsSnapshot.docs.map((doc) {
+      final data = doc.data();
+      return PinDto(
+        pinId: data['pinId'] as String? ?? doc.id,
+        tripId: data['tripId'] as String?,
+        groupId: data['groupId'] as String? ?? groupId,
+        latitude: (data['latitude'] as num?)?.toDouble() ?? 0.0,
+        longitude: (data['longitude'] as num?)?.toDouble() ?? 0.0,
+        locationName: data['locationName'] as String?,
+        visitStartDate: _timestampToDateTime(data['visitStartDate']),
+        visitEndDate: _timestampToDateTime(data['visitEndDate']),
+        visitMemo: data['visitMemo'] as String?,
+      );
+    }).toList();
+  }
+
+  DateTime? _timestampToDateTime(dynamic value) {
+    if (value is Timestamp) {
+      return value.toDate();
+    }
+    return null;
+  }
+}

--- a/test/unit/infrastructure/services/firestore_pin_query_service_test.dart
+++ b/test/unit/infrastructure/services/firestore_pin_query_service_test.dart
@@ -1,0 +1,150 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memora/infrastructure/services/firestore_pin_query_service.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+
+import '../../../helpers/test_exception.dart';
+
+import 'firestore_pin_query_service_test.mocks.dart';
+
+@GenerateMocks([
+  FirebaseFirestore,
+  CollectionReference,
+  Query,
+  QuerySnapshot,
+  QueryDocumentSnapshot,
+])
+void main() {
+  group('FirestorePinQueryService', () {
+    late FirestorePinQueryService service;
+    late MockFirebaseFirestore mockFirestore;
+    late MockCollectionReference<Map<String, dynamic>> mockGroupsCollection;
+    late MockCollectionReference<Map<String, dynamic>>
+    mockGroupMembersCollection;
+    late MockCollectionReference<Map<String, dynamic>> mockPinsCollection;
+
+    setUp(() {
+      mockFirestore = MockFirebaseFirestore();
+      mockGroupsCollection = MockCollectionReference<Map<String, dynamic>>();
+      mockGroupMembersCollection =
+          MockCollectionReference<Map<String, dynamic>>();
+      mockPinsCollection = MockCollectionReference<Map<String, dynamic>>();
+
+      service = FirestorePinQueryService(firestore: mockFirestore);
+    });
+
+    group('getPinsByMemberId', () {
+      test('自分が所属するグループに紐づくピンを取得できる', () async {
+        const memberId = 'member123';
+
+        when(
+          mockFirestore.collection('groups'),
+        ).thenReturn(mockGroupsCollection);
+        final mockAdminGroupsQuery = MockQuery<Map<String, dynamic>>();
+        when(
+          mockGroupsCollection.where('ownerId', isEqualTo: memberId),
+        ).thenReturn(mockAdminGroupsQuery);
+        final mockAdminGroupsSnapshot =
+            MockQuerySnapshot<Map<String, dynamic>>();
+        when(
+          mockAdminGroupsQuery.get(),
+        ).thenAnswer((_) async => mockAdminGroupsSnapshot);
+        final mockAdminGroupDoc =
+            MockQueryDocumentSnapshot<Map<String, dynamic>>();
+        when(mockAdminGroupsSnapshot.docs).thenReturn([mockAdminGroupDoc]);
+        when(mockAdminGroupDoc.id).thenReturn('group1');
+
+        when(
+          mockFirestore.collection('group_members'),
+        ).thenReturn(mockGroupMembersCollection);
+        final mockMemberGroupsQuery = MockQuery<Map<String, dynamic>>();
+        when(
+          mockGroupMembersCollection.where('memberId', isEqualTo: memberId),
+        ).thenReturn(mockMemberGroupsQuery);
+        final mockMemberGroupsSnapshot =
+            MockQuerySnapshot<Map<String, dynamic>>();
+        when(
+          mockMemberGroupsQuery.get(),
+        ).thenAnswer((_) async => mockMemberGroupsSnapshot);
+        final mockMemberGroupDoc =
+            MockQueryDocumentSnapshot<Map<String, dynamic>>();
+        when(mockMemberGroupsSnapshot.docs).thenReturn([mockMemberGroupDoc]);
+        when(mockMemberGroupDoc.data()).thenReturn({'groupId': 'group2'});
+
+        when(mockFirestore.collection('pins')).thenReturn(mockPinsCollection);
+
+        final mockGroup1PinsQuery = MockQuery<Map<String, dynamic>>();
+        when(
+          mockPinsCollection.where('groupId', isEqualTo: 'group1'),
+        ).thenReturn(mockGroup1PinsQuery);
+        final mockGroup1PinsSnapshot =
+            MockQuerySnapshot<Map<String, dynamic>>();
+        when(
+          mockGroup1PinsQuery.get(),
+        ).thenAnswer((_) async => mockGroup1PinsSnapshot);
+        final mockGroup1PinDoc =
+            MockQueryDocumentSnapshot<Map<String, dynamic>>();
+        when(mockGroup1PinsSnapshot.docs).thenReturn([mockGroup1PinDoc]);
+        when(mockGroup1PinDoc.data()).thenReturn({
+          'pinId': 'pin1',
+          'tripId': 'trip1',
+          'groupId': 'group1',
+          'latitude': 35.0,
+          'longitude': 139.0,
+          'locationName': '東京駅',
+          'visitStartDate': Timestamp.fromDate(DateTime(2024, 1, 1)),
+          'visitEndDate': Timestamp.fromDate(DateTime(2024, 1, 2)),
+          'visitMemo': 'メモ1',
+        });
+
+        final mockGroup2PinsQuery = MockQuery<Map<String, dynamic>>();
+        when(
+          mockPinsCollection.where('groupId', isEqualTo: 'group2'),
+        ).thenReturn(mockGroup2PinsQuery);
+        final mockGroup2PinsSnapshot =
+            MockQuerySnapshot<Map<String, dynamic>>();
+        when(
+          mockGroup2PinsQuery.get(),
+        ).thenAnswer((_) async => mockGroup2PinsSnapshot);
+        final mockGroup2PinDoc =
+            MockQueryDocumentSnapshot<Map<String, dynamic>>();
+        when(mockGroup2PinsSnapshot.docs).thenReturn([mockGroup2PinDoc]);
+        when(mockGroup2PinDoc.data()).thenReturn({
+          'pinId': 'pin2',
+          'tripId': 'trip2',
+          'groupId': 'group2',
+          'latitude': 36.0,
+          'longitude': 140.0,
+          'locationName': '京都駅',
+          'visitStartDate': Timestamp.fromDate(DateTime(2024, 2, 1)),
+          'visitEndDate': Timestamp.fromDate(DateTime(2024, 2, 2)),
+          'visitMemo': 'メモ2',
+        });
+
+        final result = await service.getPinsByMemberId(memberId);
+
+        expect(result, hasLength(2));
+        expect(result[0].pinId, 'pin1');
+        expect(result[0].groupId, 'group1');
+        expect(result[0].visitStartDate, DateTime(2024, 1, 1));
+        expect(result[0].visitEndDate, DateTime(2024, 1, 2));
+        expect(result[1].pinId, 'pin2');
+        expect(result[1].groupId, 'group2');
+        expect(result[1].locationName, '京都駅');
+      });
+
+      test('例外が発生した場合は空のリストを返す', () async {
+        const memberId = 'member123';
+
+        when(
+          mockFirestore.collection('groups'),
+        ).thenThrow(TestException('Firestore error'));
+
+        final result = await service.getPinsByMemberId(memberId);
+
+        expect(result, isEmpty);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- FirestorePinQueryServiceを追加して所属グループに紐づくピンを取得できるようにした
- 所属グループを判定するためのクエリ処理と取得結果のマッピングを実装した
- FirestorePinQueryServiceの振る舞いを検証するテストを追加した

## Testing
- ./check.sh

## Related ToDo
- FirestorePinQueryServiceを作成し、自分が所属するグループに紐づくピンを取得する

------
https://chatgpt.com/codex/tasks/task_e_68e1f94b021083329131dd0c8a7207b3