### PR TITLE
feat(map): ログインユーザーが所属するグループのピンを地図に表示

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -22,7 +22,7 @@
 
 - [x] ~~起動時に現在地に移動~~→仕様変更により廃止
 - [x] 地図表示画面はMapViewを直接表示するのではなく、mapDisplayウィジェットを表示してその上にMapViewを生成する形にする
-- [x] PinQueryServiceのgetPinsByMemberIdを使用してログインユーザーが所属するグループに紐づくpinsを取得する
+- [x] PinQueryServiceのgetPinsByMemberIdを使用してログインユーザー(ユーザーIDに紐づくmember)が所属するグループに紐づくpinsを取得する
   - [x] 取得したpinsをマップにmarkerで表示する
   - [x] markerタップでpin内容を表示するが、変更/削除は不可とする
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -22,6 +22,9 @@
 
 - [x] ~~起動時に現在地に移動~~→仕様変更により廃止
 - [x] 地図表示画面はMapViewを直接表示するのではなく、mapDisplayウィジェットを表示してその上にMapViewを生成する形にする
+- [x] PinQueryServiceのgetPinsByMemberIdを使用してログインユーザーが所属するグループに紐づくpinsを取得する
+  - [x] 取得したpinsをマップにmarkerで表示する
+  - [x] markerタップでpin内容を表示するが、変更/削除は不可とする
 
 ## マップピンのポップアップメニュー表示
 
@@ -41,9 +44,6 @@
   - [x] Firebaseから該当ピンを削除する処理
   - [x] マップ上から該当ピンを削除
   - [x] markerIdで紐づけて削除する
-- [x] PinQueryServiceのgetPinsByMemberIdを使用してログインユーザーが所属するグループに紐づくpinsを取得する
-  - [x] 取得したpinsをマップにmarkerで表示する
-  - [x] markerタップでpin内容を表示するが、変更/削除は不可とする
 
 ## マップの検索機能追加
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -41,6 +41,9 @@
   - [x] Firebaseから該当ピンを削除する処理
   - [x] マップ上から該当ピンを削除
   - [x] markerIdで紐づけて削除する
+- [x] PinQueryServiceのgetPinsByMemberIdを使用してログインユーザーが所属するグループに紐づくpinsを取得する
+  - [x] 取得したpinsをマップにmarkerで表示する
+  - [x] markerタップでpin内容を表示するが、変更/削除は不可とする
 
 ## マップの検索機能追加
 

--- a/lib/presentation/app/top_page.dart
+++ b/lib/presentation/app/top_page.dart
@@ -175,7 +175,13 @@ class _TopPageState extends State<TopPage> {
       case NavigationItem.groupTimeline:
         return _buildGroupTimelineStack(ref);
       case NavigationItem.mapDisplay:
-        return MapScreen(isTestEnvironment: widget.isTestEnvironment);
+        if (_currentMember == null) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        return MapScreen(
+          member: _currentMember!,
+          isTestEnvironment: widget.isTestEnvironment,
+        );
       case NavigationItem.groupManagement:
         if (_currentMember == null) {
           return const Center(child: CircularProgressIndicator());

--- a/lib/presentation/features/map/map_screen.dart
+++ b/lib/presentation/features/map/map_screen.dart
@@ -4,10 +4,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:memora/application/dtos/pin/pin_dto.dart';
 import 'package:memora/application/interfaces/pin_query_service.dart';
 import 'package:memora/domain/entities/member.dart';
-import 'package:memora/domain/value_objects/location.dart';
 import 'package:memora/infrastructure/services/firestore_pin_query_service.dart';
 import 'package:memora/presentation/shared/map_views/map_view_factory.dart';
-import 'package:memora/presentation/shared/sheets/pin_detail_bottom_sheet.dart';
 
 final pinQueryServiceProvider = Provider<PinQueryService>((ref) {
   return FirestorePinQueryService(firestore: FirebaseFirestore.instance);
@@ -48,43 +46,14 @@ class _MapScreenState extends ConsumerState<MapScreen> {
     }
   }
 
-  void _onMapLongTapped(Location location) {
-    // WIP
-  }
-
-  void _onMarkerTapped(PinDto pin) {
-    showModalBottomSheet(
-      context: context,
-      isScrollControlled: true,
-      builder: (context) => PinDetailBottomSheet(
-        pin: pin,
-        onClose: () => Navigator.pop(context),
-        onUpdate: null,
-        onDelete: null,
-      ),
-    );
-  }
-
-  void _onMarkerUpdated(PinDto pin) {
-    // WIP
-  }
-
-  void _onMarkerDeleted(String pinId) {
-    // WIP
-  }
-
   @override
   Widget build(BuildContext context) {
     final mapViewType = widget.isTestEnvironment
         ? MapViewType.placeholder
         : MapViewType.google;
 
-    return MapViewFactory.create(mapViewType).createMapView(
-      pins: _pins,
-      onMapLongTapped: _onMapLongTapped,
-      onMarkerTapped: _onMarkerTapped,
-      onMarkerUpdated: _onMarkerUpdated,
-      onMarkerDeleted: _onMarkerDeleted,
-    );
+    return MapViewFactory.create(
+      mapViewType,
+    ).createMapView(pins: _pins, isReadOnly: true);
   }
 }

--- a/lib/presentation/features/map/map_screen.dart
+++ b/lib/presentation/features/map/map_screen.dart
@@ -3,9 +3,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:memora/application/dtos/pin/pin_dto.dart';
 import 'package:memora/application/interfaces/pin_query_service.dart';
+import 'package:memora/domain/entities/member.dart';
 import 'package:memora/domain/value_objects/location.dart';
 import 'package:memora/infrastructure/services/firestore_pin_query_service.dart';
-import 'package:memora/presentation/notifiers/auth_notifier.dart';
 import 'package:memora/presentation/shared/map_views/map_view_factory.dart';
 import 'package:memora/presentation/shared/sheets/pin_detail_bottom_sheet.dart';
 
@@ -14,9 +14,14 @@ final pinQueryServiceProvider = Provider<PinQueryService>((ref) {
 });
 
 class MapScreen extends ConsumerStatefulWidget {
+  final Member member;
   final bool isTestEnvironment;
 
-  const MapScreen({super.key, this.isTestEnvironment = false});
+  const MapScreen({
+    super.key,
+    required this.member,
+    this.isTestEnvironment = false,
+  });
 
   @override
   ConsumerState<MapScreen> createState() => _MapScreenState();
@@ -34,13 +39,8 @@ class _MapScreenState extends ConsumerState<MapScreen> {
   }
 
   Future<void> _loadPins() async {
-    final authState = ref.read(authNotifierProvider);
-    if (authState.user == null) {
-      return;
-    }
-
     final pinQueryService = ref.read(pinQueryServiceProvider);
-    final pins = await pinQueryService.getPinsByMemberId(authState.user!.id);
+    final pins = await pinQueryService.getPinsByMemberId(widget.member.id);
     if (mounted) {
       setState(() {
         _pins = pins;

--- a/lib/presentation/features/map/map_screen.dart
+++ b/lib/presentation/features/map/map_screen.dart
@@ -1,19 +1,68 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:memora/application/dtos/pin/pin_dto.dart';
+import 'package:memora/application/interfaces/pin_query_service.dart';
 import 'package:memora/domain/value_objects/location.dart';
+import 'package:memora/infrastructure/services/firestore_pin_query_service.dart';
+import 'package:memora/presentation/notifiers/auth_notifier.dart';
 import 'package:memora/presentation/shared/map_views/map_view_factory.dart';
+import 'package:memora/presentation/shared/sheets/pin_detail_bottom_sheet.dart';
 
-class MapScreen extends StatelessWidget {
+final pinQueryServiceProvider = Provider<PinQueryService>((ref) {
+  return FirestorePinQueryService(firestore: FirebaseFirestore.instance);
+});
+
+class MapScreen extends ConsumerStatefulWidget {
   final bool isTestEnvironment;
 
   const MapScreen({super.key, this.isTestEnvironment = false});
+
+  @override
+  ConsumerState<MapScreen> createState() => _MapScreenState();
+}
+
+class _MapScreenState extends ConsumerState<MapScreen> {
+  List<PinDto> _pins = [];
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _loadPins();
+    });
+  }
+
+  Future<void> _loadPins() async {
+    final authState = ref.read(authNotifierProvider);
+    if (authState.user == null) {
+      return;
+    }
+
+    final pinQueryService = ref.read(pinQueryServiceProvider);
+    final pins = await pinQueryService.getPinsByMemberId(authState.user!.id);
+    if (mounted) {
+      setState(() {
+        _pins = pins;
+      });
+    }
+  }
 
   void _onMapLongTapped(Location location) {
     // WIP
   }
 
   void _onMarkerTapped(PinDto pin) {
-    // WIP
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      builder: (context) => PinDetailBottomSheet(
+        pin: pin,
+        onClose: () => Navigator.pop(context),
+        onUpdate: null,
+        onDelete: null,
+      ),
+    );
   }
 
   void _onMarkerUpdated(PinDto pin) {
@@ -26,12 +75,12 @@ class MapScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final mapViewType = isTestEnvironment
+    final mapViewType = widget.isTestEnvironment
         ? MapViewType.placeholder
         : MapViewType.google;
 
     return MapViewFactory.create(mapViewType).createMapView(
-      pins: const [],
+      pins: _pins,
       onMapLongTapped: _onMapLongTapped,
       onMarkerTapped: _onMarkerTapped,
       onMarkerUpdated: _onMarkerUpdated,

--- a/lib/presentation/shared/map_views/google_map_view.dart
+++ b/lib/presentation/shared/map_views/google_map_view.dart
@@ -17,6 +17,7 @@ class GoogleMapView extends ConsumerWidget {
   final Function(PinDto)? onMarkerUpdated;
   final Function(String)? onMarkerDeleted;
   final PinDto? selectedPin;
+  final bool isReadOnly;
 
   const GoogleMapView({
     super.key,
@@ -26,6 +27,7 @@ class GoogleMapView extends ConsumerWidget {
     this.onMarkerUpdated,
     this.onMarkerDeleted,
     this.selectedPin,
+    this.isReadOnly = false,
   });
 
   @override
@@ -37,6 +39,7 @@ class GoogleMapView extends ConsumerWidget {
       onMarkerUpdated: onMarkerUpdated,
       onMarkerDeleted: onMarkerDeleted,
       selectedPin: selectedPin,
+      isReadOnly: isReadOnly,
     );
   }
 }
@@ -48,6 +51,7 @@ class _GoogleMapViewWidget extends ConsumerStatefulWidget {
   final Function(PinDto)? onMarkerUpdated;
   final Function(String)? onMarkerDeleted;
   final PinDto? selectedPin;
+  final bool isReadOnly;
 
   const _GoogleMapViewWidget({
     required this.pins,
@@ -56,6 +60,7 @@ class _GoogleMapViewWidget extends ConsumerStatefulWidget {
     this.onMarkerUpdated,
     this.onMarkerDeleted,
     this.selectedPin,
+    this.isReadOnly = false,
   });
 
   @override
@@ -263,8 +268,8 @@ class _GoogleMapViewWidgetState extends ConsumerState<_GoogleMapViewWidget> {
 
     return PinDetailBottomSheet(
       pin: _selectedPin!,
-      onUpdate: _onMarkerUpdate,
-      onDelete: _onMarkerDelete,
+      onUpdate: widget.isReadOnly ? null : _onMarkerUpdate,
+      onDelete: widget.isReadOnly ? null : _onMarkerDelete,
       onClose: _hidePinDetailBottomSheet,
     );
   }

--- a/lib/presentation/shared/map_views/google_map_view_builder.dart
+++ b/lib/presentation/shared/map_views/google_map_view_builder.dart
@@ -15,6 +15,7 @@ class GoogleMapViewBuilder implements MapViewBuilder {
     Function(PinDto)? onMarkerUpdated,
     Function(String)? onMarkerDeleted,
     PinDto? selectedPin,
+    bool isReadOnly = false,
   }) {
     return GoogleMapView(
       pins: pins,
@@ -23,6 +24,7 @@ class GoogleMapViewBuilder implements MapViewBuilder {
       onMarkerUpdated: onMarkerUpdated,
       onMarkerDeleted: onMarkerDeleted,
       selectedPin: selectedPin,
+      isReadOnly: isReadOnly,
     );
   }
 }

--- a/lib/presentation/shared/map_views/map_view_builder.dart
+++ b/lib/presentation/shared/map_views/map_view_builder.dart
@@ -10,5 +10,6 @@ abstract class MapViewBuilder {
     Function(PinDto)? onMarkerUpdated,
     Function(String)? onMarkerDeleted,
     PinDto? selectedPin,
+    bool isReadOnly = false,
   });
 }

--- a/lib/presentation/shared/map_views/placeholder_map_view_builder.dart
+++ b/lib/presentation/shared/map_views/placeholder_map_view_builder.dart
@@ -15,6 +15,7 @@ class PlaceholderMapViewBuilder implements MapViewBuilder {
     Function(PinDto)? onMarkerUpdated,
     Function(String)? onMarkerDeleted,
     PinDto? selectedPin,
+    bool isReadOnly = false,
   }) {
     return const PlaceholderMapView();
   }

--- a/lib/presentation/shared/sheets/pin_detail_bottom_sheet.dart
+++ b/lib/presentation/shared/sheets/pin_detail_bottom_sheet.dart
@@ -212,6 +212,8 @@ class _PinDetailBottomSheetState extends State<PinDetailBottomSheet> {
     );
   }
 
+  bool get isReadOnly => widget.onUpdate == null;
+
   @override
   Widget build(BuildContext context) {
     return DraggableScrollableSheet(
@@ -297,8 +299,6 @@ class _PinDetailBottomSheetState extends State<PinDetailBottomSheet> {
     required IconData icon,
     Key? testKey,
   }) {
-    final isReadOnly = widget.onUpdate == null;
-
     return InkWell(
       key: testKey,
       onTap: isReadOnly ? null : onTap,
@@ -429,7 +429,7 @@ class _PinDetailBottomSheetState extends State<PinDetailBottomSheet> {
               constraints: const BoxConstraints(),
               padding: EdgeInsets.zero,
               icon: const Icon(Icons.refresh),
-              onPressed: _isLoadingLocation
+              onPressed: (_isLoadingLocation || isReadOnly)
                   ? null
                   : () => _loadLocationName(forceRefresh: true),
               color: Colors.grey[600],
@@ -442,8 +442,6 @@ class _PinDetailBottomSheetState extends State<PinDetailBottomSheet> {
   }
 
   Widget _buildMemoField() {
-    final isReadOnly = widget.onUpdate == null;
-
     return TextFormField(
       key: const Key('visitMemoField'),
       minLines: 4,

--- a/lib/presentation/shared/sheets/pin_detail_bottom_sheet.dart
+++ b/lib/presentation/shared/sheets/pin_detail_bottom_sheet.dart
@@ -297,23 +297,29 @@ class _PinDetailBottomSheetState extends State<PinDetailBottomSheet> {
     required IconData icon,
     Key? testKey,
   }) {
+    final isReadOnly = widget.onUpdate == null;
+
     return InkWell(
       key: testKey,
-      onTap: onTap,
+      onTap: isReadOnly ? null : onTap,
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 16),
         decoration: BoxDecoration(
           border: Border.all(color: Colors.black54),
           borderRadius: BorderRadius.circular(4),
+          color: isReadOnly ? Colors.grey[100] : null,
         ),
         child: Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
             Text(
               value,
-              style: const TextStyle(color: Colors.black, fontSize: 16),
+              style: TextStyle(
+                color: isReadOnly ? Colors.black54 : Colors.black,
+                fontSize: 16,
+              ),
             ),
-            Icon(icon, color: Colors.black54),
+            Icon(icon, color: isReadOnly ? Colors.grey : Colors.black54),
           ],
         ),
       ),
@@ -436,24 +442,35 @@ class _PinDetailBottomSheetState extends State<PinDetailBottomSheet> {
   }
 
   Widget _buildMemoField() {
+    final isReadOnly = widget.onUpdate == null;
+
     return TextFormField(
       key: const Key('visitMemoField'),
       minLines: 4,
       maxLines: null,
       controller: memoController,
-      decoration: const InputDecoration(
+      readOnly: isReadOnly,
+      decoration: InputDecoration(
         labelText: 'メモ',
-        border: OutlineInputBorder(),
+        border: const OutlineInputBorder(),
+        fillColor: isReadOnly ? Colors.grey[100] : null,
+        filled: isReadOnly,
       ),
     );
   }
 
   Widget _buildActionButtons() {
+    if (widget.onUpdate == null && widget.onDelete == null) {
+      return const SizedBox.shrink();
+    }
+
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
-        ElevatedButton(onPressed: _handleDelete, child: const Text('削除')),
-        ElevatedButton(onPressed: _handleUpdate, child: const Text('更新')),
+        if (widget.onDelete != null)
+          ElevatedButton(onPressed: _handleDelete, child: const Text('削除')),
+        if (widget.onUpdate != null)
+          ElevatedButton(onPressed: _handleUpdate, child: const Text('更新')),
       ],
     );
   }

--- a/test/unit/presentation/app/top_page_test.dart
+++ b/test/unit/presentation/app/top_page_test.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:memora/application/interfaces/pin_query_service.dart';
 import 'package:memora/application/usecases/group/get_groups_with_members_usecase.dart';
 import 'package:memora/application/usecases/member/get_current_member_usecase.dart';
+import 'package:memora/presentation/features/map/map_screen.dart';
 import 'package:memora/presentation/notifiers/auth_notifier.dart';
 import 'package:memora/presentation/notifiers/group_timeline_navigation_notifier.dart';
 import 'package:memora/presentation/notifiers/navigation_notifier.dart';
@@ -39,6 +41,7 @@ class _TestGroupTimelineNavigationNotifier
   GetGroupsWithMembersUsecase,
   GetCurrentMemberUseCase,
   AuthNotifier,
+  PinQueryService,
 ])
 void main() {
   late MockGetGroupsWithMembersUsecase mockUsecase;
@@ -96,11 +99,17 @@ void main() {
       ),
     );
 
+    final mockPinQueryService = MockPinQueryService();
+    when(
+      mockPinQueryService.getPinsByMemberId(any),
+    ).thenAnswer((_) async => []);
+
     return ProviderScope(
       overrides: [
         authNotifierProvider.overrideWith((ref) {
           return FakeAuthNotifier.authenticated();
         }),
+        pinQueryServiceProvider.overrideWithValue(mockPinQueryService),
       ],
       child: MaterialApp(
         home: TopPage(

--- a/test/unit/presentation/features/map/map_screen_test.dart
+++ b/test/unit/presentation/features/map/map_screen_test.dart
@@ -1,16 +1,30 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:memora/application/dtos/pin/pin_dto.dart';
+import 'package:memora/application/interfaces/pin_query_service.dart';
 import 'package:memora/presentation/features/map/map_screen.dart';
+import 'package:memora/presentation/notifiers/auth_notifier.dart';
 import 'package:memora/presentation/shared/map_views/placeholder_map_view.dart';
 import 'package:memora/presentation/shared/map_views/google_map_view.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
 
+import '../../../../helpers/fake_auth_notifier.dart';
+import 'map_screen_test.mocks.dart';
+
+@GenerateMocks([PinQueryService])
 void main() {
   group('MapScreen', () {
     testWidgets('テスト環境の場合、PlaceholderMapViewを表示する', (tester) async {
       await tester.pumpWidget(
-        const ProviderScope(
-          child: MaterialApp(
+        ProviderScope(
+          overrides: [
+            authNotifierProvider.overrideWith(
+              (ref) => FakeAuthNotifier.unauthenticated(),
+            ),
+          ],
+          child: const MaterialApp(
             home: Scaffold(body: MapScreen(isTestEnvironment: true)),
           ),
         ),
@@ -21,14 +35,61 @@ void main() {
 
     testWidgets('本番環境の場合、GoogleMapViewを表示する', (tester) async {
       await tester.pumpWidget(
-        const ProviderScope(
-          child: MaterialApp(
+        ProviderScope(
+          overrides: [
+            authNotifierProvider.overrideWith(
+              (ref) => FakeAuthNotifier.unauthenticated(),
+            ),
+          ],
+          child: const MaterialApp(
             home: Scaffold(body: MapScreen(isTestEnvironment: false)),
           ),
         ),
       );
 
       expect(find.byType(GoogleMapView), findsOneWidget);
+    });
+
+    testWidgets('ログインユーザーのmemberIdでPinQueryServiceからpinsを取得する', (tester) async {
+      final mockPinQueryService = MockPinQueryService();
+      final testPins = [
+        const PinDto(
+          pinId: 'pin1',
+          groupId: 'group1',
+          latitude: 35.6812,
+          longitude: 139.7671,
+          locationName: '東京駅',
+        ),
+        const PinDto(
+          pinId: 'pin2',
+          groupId: 'group1',
+          latitude: 34.6937,
+          longitude: 135.5023,
+          locationName: '大阪駅',
+        ),
+      ];
+
+      when(
+        mockPinQueryService.getPinsByMemberId('test-member-id'),
+      ).thenAnswer((_) async => testPins);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            authNotifierProvider.overrideWith(
+              (ref) => FakeAuthNotifier.authenticated(userId: 'test-member-id'),
+            ),
+            pinQueryServiceProvider.overrideWithValue(mockPinQueryService),
+          ],
+          child: const MaterialApp(
+            home: Scaffold(body: MapScreen(isTestEnvironment: true)),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      verify(mockPinQueryService.getPinsByMemberId('test-member-id')).called(1);
     });
   });
 }

--- a/test/unit/presentation/features/map/map_screen_test.dart
+++ b/test/unit/presentation/features/map/map_screen_test.dart
@@ -3,50 +3,63 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:memora/application/dtos/pin/pin_dto.dart';
 import 'package:memora/application/interfaces/pin_query_service.dart';
+import 'package:memora/domain/entities/member.dart';
 import 'package:memora/presentation/features/map/map_screen.dart';
-import 'package:memora/presentation/notifiers/auth_notifier.dart';
 import 'package:memora/presentation/shared/map_views/placeholder_map_view.dart';
 import 'package:memora/presentation/shared/map_views/google_map_view.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 
-import '../../../../helpers/fake_auth_notifier.dart';
 import 'map_screen_test.mocks.dart';
 
 @GenerateMocks([PinQueryService])
 void main() {
+  const testMember = Member(id: 'test-member-id', displayName: 'テストメンバー');
+
   group('MapScreen', () {
     testWidgets('テスト環境の場合、PlaceholderMapViewを表示する', (tester) async {
+      final mockPinQueryService = MockPinQueryService();
+      when(
+        mockPinQueryService.getPinsByMemberId(any),
+      ).thenAnswer((_) async => []);
+
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
-            authNotifierProvider.overrideWith(
-              (ref) => FakeAuthNotifier.unauthenticated(),
-            ),
+            pinQueryServiceProvider.overrideWithValue(mockPinQueryService),
           ],
           child: const MaterialApp(
-            home: Scaffold(body: MapScreen(isTestEnvironment: true)),
+            home: Scaffold(
+              body: MapScreen(member: testMember, isTestEnvironment: true),
+            ),
           ),
         ),
       );
 
+      await tester.pumpAndSettle();
       expect(find.byType(PlaceholderMapView), findsOneWidget);
     });
 
     testWidgets('本番環境の場合、GoogleMapViewを表示する', (tester) async {
+      final mockPinQueryService = MockPinQueryService();
+      when(
+        mockPinQueryService.getPinsByMemberId(any),
+      ).thenAnswer((_) async => []);
+
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
-            authNotifierProvider.overrideWith(
-              (ref) => FakeAuthNotifier.unauthenticated(),
-            ),
+            pinQueryServiceProvider.overrideWithValue(mockPinQueryService),
           ],
           child: const MaterialApp(
-            home: Scaffold(body: MapScreen(isTestEnvironment: false)),
+            home: Scaffold(
+              body: MapScreen(member: testMember, isTestEnvironment: false),
+            ),
           ),
         ),
       );
 
+      await tester.pumpAndSettle();
       expect(find.byType(GoogleMapView), findsOneWidget);
     });
 
@@ -76,13 +89,12 @@ void main() {
       await tester.pumpWidget(
         ProviderScope(
           overrides: [
-            authNotifierProvider.overrideWith(
-              (ref) => FakeAuthNotifier.authenticated(userId: 'test-member-id'),
-            ),
             pinQueryServiceProvider.overrideWithValue(mockPinQueryService),
           ],
           child: const MaterialApp(
-            home: Scaffold(body: MapScreen(isTestEnvironment: true)),
+            home: Scaffold(
+              body: MapScreen(member: testMember, isTestEnvironment: true),
+            ),
           ),
         ),
       );

--- a/test/unit/presentation/shared/map_views/google_map_view_test.dart
+++ b/test/unit/presentation/shared/map_views/google_map_view_test.dart
@@ -439,5 +439,48 @@ void main() {
       expect(find.text('ピン1のメモ'), findsNothing);
       expect(find.text('ピン2のメモ'), findsOneWidget);
     });
+
+    testWidgets('isReadOnlyがtrueの場合、全ての編集機能が無効化される', (
+      WidgetTester tester,
+    ) async {
+      const testPin = PinDto(
+        pinId: 'pin1',
+        latitude: 35.681236,
+        longitude: 139.767125,
+        locationName: '東京駅',
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(
+              body: GoogleMapView(pins: const [testPin], isReadOnly: true),
+            ),
+          ),
+        ),
+      );
+
+      // マーカーをタップしてボトムシートを表示
+      final googleMap = tester.widget<GoogleMap>(find.byType(GoogleMap));
+      final marker = googleMap.markers.first;
+      marker.onTap!();
+      await tester.pumpAndSettle();
+
+      // ボトムシート自体は表示される
+      expect(find.byType(PinDetailBottomSheet), findsOneWidget);
+
+      // 更新・削除ボタンが表示されない
+      expect(find.text('更新'), findsNothing);
+      expect(find.text('削除'), findsNothing);
+
+      // 現在地再取得ボタンが無効化されている
+      final refreshButton = tester.widget<IconButton>(
+        find.descendant(
+          of: find.byType(PinDetailBottomSheet),
+          matching: find.widgetWithIcon(IconButton, Icons.refresh),
+        ),
+      );
+      expect(refreshButton.onPressed, isNull);
+    });
   });
 }

--- a/test/unit/presentation/shared/sheets/pin_detail_bottom_sheet_test.dart
+++ b/test/unit/presentation/shared/sheets/pin_detail_bottom_sheet_test.dart
@@ -35,7 +35,12 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
-            body: PinDetailBottomSheet(pin: defaultPin, onClose: () {}),
+            body: PinDetailBottomSheet(
+              pin: defaultPin,
+              onClose: () {},
+              onUpdate: (_) {},
+              onDelete: (_) {},
+            ),
           ),
         ),
       );

--- a/test/unit/presentation/shared/sheets/pin_detail_bottom_sheet_test.dart
+++ b/test/unit/presentation/shared/sheets/pin_detail_bottom_sheet_test.dart
@@ -529,6 +529,7 @@ void main() {
             body: PinDetailBottomSheet(
               pin: pinWithLocationName,
               onClose: () {},
+              onUpdate: (pin) {},
               reverseGeocodingService: mockNearbyLocationService,
             ),
           ),
@@ -549,6 +550,55 @@ void main() {
       // ローディング状態の確認
       await tester.pump();
       expect(find.text('新しい場所名'), findsOneWidget);
+    });
+
+    testWidgets('読み取り専用モードでは全ての編集機能が無効化される', (WidgetTester tester) async {
+      final mockNearbyLocationService = MockNearbyLocationService();
+      final pin = PinDto(
+        pinId: 'test-pin-id',
+        latitude: 35.681236,
+        longitude: 139.767125,
+        locationName: '東京駅',
+        visitStartDate: DateTime(2025, 1, 15, 10, 30),
+        visitMemo: 'テストメモ',
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: PinDetailBottomSheet(
+              pin: pin,
+              onClose: () {},
+              reverseGeocodingService: mockNearbyLocationService,
+            ),
+          ),
+        ),
+      );
+
+      // 現在地再取得アイコンをタップしても処理が呼ばれない
+      final refreshIconFinder = find.byIcon(Icons.refresh);
+      await tester.tap(refreshIconFinder);
+      await tester.pump();
+      verifyNever(mockNearbyLocationService.getLocationName(any));
+
+      // 日付・時間フィールドが無効化されている
+      final visitStartDateField = tester.widget<InkWell>(
+        find.byKey(const Key('visitStartDateField')),
+      );
+      expect(visitStartDateField.onTap, isNull);
+
+      // メモフィールドが読み取り専用になっている
+      final editableText = tester.widget<EditableText>(
+        find.descendant(
+          of: find.byKey(const Key('visitMemoField')),
+          matching: find.byType(EditableText),
+        ),
+      );
+      expect(editableText.readOnly, isTrue);
+
+      // 更新・削除ボタンが表示されない
+      expect(find.text('更新'), findsNothing);
+      expect(find.text('削除'), findsNothing);
     });
 
     testWidgets('更新ボタンタップ時に取得した場所名もPinに含まれる', (WidgetTester tester) async {


### PR DESCRIPTION
## 概要

- PinQueryServiceのgetPinsByMemberIdを使用してログインユーザーが所属するグループに紐づくpinsを取得する
- 取得したpinsをマップにmarkerで表示する
- markerタップでpin内容を表示するが、変更/削除は不可とする

## 変更内容

- MapScreenでPinQueryServiceのgetPinsByMemberIdを使用してピンを取得
- 取得したピンをマップにマーカーとして表示
- マーカータップ時にPinDetailBottomSheetを表示（読み取り専用）
- PinDetailBottomSheetを読み取り専用モードに対応
  - onUpdateとonDeleteがnullの場合はアクションボタンを非表示
  - 読み取り専用時は日時フィールドとメモフィールドを編集不可に設定
- 関連するテストを追加・修正

## テスト

- すべてのテストが通過することを確認済み（573テスト）
- フォーマットおよび静的解析もパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)