### PR TITLE
feat: enable repository factory based DB switching

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -337,11 +337,11 @@
 - [x] GroupDtoを作成する
   - [x] GroupMemberDtoとGroupEventDtoも作成し、GroupDtoにリストとして保持する
   - [x] マッパーも用意する
-- [ ] Repository Factoryパターンを導入してDB切り替えを可能にする
+- [x] Repository Factoryパターンを導入してDB切り替えを可能にする
   - [x] DatabaseTypeのenumとRiverpod Providerを作成
   - [x] RepositoryFactoryを実装
   - [x] MemberManagementでRepositoryFactoryを使用するように変更
-  - [ ] 他の処理にも適用
+  - [x] 他の処理にも適用
 
 ## 全体
 

--- a/lib/infrastructure/factories/repository_factory.dart
+++ b/lib/infrastructure/factories/repository_factory.dart
@@ -15,7 +15,12 @@ import 'package:memora/infrastructure/repositories/firestore_member_repository.d
 import 'package:memora/infrastructure/repositories/firestore_trip_entry_repository.dart';
 
 class RepositoryFactory {
-  static T create<T extends Object>({required WidgetRef ref}) {
+  static T create<T extends Object>({required Ref ref}) {
+    final dbType = ref.read(databaseTypeProvider);
+    return _createRepositoryByType<T>(dbType);
+  }
+
+  static T createWithWidgetRef<T extends Object>({required WidgetRef ref}) {
     final dbType = ref.read(databaseTypeProvider);
     return _createRepositoryByType<T>(dbType);
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,7 @@ import 'package:logger/logger.dart';
 import 'package:memora/core/app_logger.dart';
 import 'package:memora/domain/repositories/member_repository.dart';
 import 'package:memora/application/interfaces/group_query_service.dart';
+import 'package:memora/infrastructure/factories/repository_factory.dart';
 import 'package:memora/infrastructure/services/firestore_group_query_service.dart';
 import 'firebase_options.dart';
 import 'presentation/app/top_page.dart';
@@ -40,7 +41,7 @@ Future<void> main() async {
 
       SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky);
 
-      runApp(const MyApp());
+      runApp(const ProviderScope(child: MyApp()));
     },
     (error, stack) {
       FirebaseCrashlytics.instance.recordError(error, stack, fatal: true);
@@ -48,14 +49,14 @@ Future<void> main() async {
   );
 }
 
-class MyApp extends StatefulWidget {
+class MyApp extends ConsumerStatefulWidget {
   const MyApp({super.key});
 
   @override
-  State<MyApp> createState() => _MyAppState();
+  ConsumerState<MyApp> createState() => _MyAppState();
 }
 
-class _MyAppState extends State<MyApp> {
+class _MyAppState extends ConsumerState<MyApp> {
   late final AuthService authService;
   late final MemberRepository memberRepository;
   late final GroupQueryService groupQueryService;
@@ -66,7 +67,7 @@ class _MyAppState extends State<MyApp> {
   void initState() {
     super.initState();
     authService = FirebaseAuthService();
-    memberRepository = FirestoreMemberRepository();
+    memberRepository = RepositoryFactory.create<MemberRepository>(ref: ref);
 
     groupQueryService = FirestoreGroupQueryService();
     getGroupsWithMembersUsecase = GetGroupsWithMembersUsecase(

--- a/lib/presentation/features/group/group_management.dart
+++ b/lib/presentation/features/group/group_management.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:memora/application/usecases/group/get_group_by_id_usecase.dart';
 import 'package:memora/application/interfaces/group_query_service.dart';
 import 'package:memora/application/dtos/group/group_with_members_dto.dart';
@@ -14,15 +15,12 @@ import 'package:memora/domain/repositories/group_repository.dart';
 import 'package:memora/domain/repositories/group_event_repository.dart';
 import 'package:memora/domain/repositories/member_repository.dart';
 import 'package:memora/domain/repositories/trip_entry_repository.dart';
-import 'package:memora/infrastructure/repositories/firestore_group_repository.dart';
-import 'package:memora/infrastructure/repositories/firestore_group_event_repository.dart';
-import 'package:memora/infrastructure/repositories/firestore_member_repository.dart';
-import 'package:memora/infrastructure/repositories/firestore_trip_entry_repository.dart';
+import 'package:memora/infrastructure/factories/repository_factory.dart';
 import 'package:memora/presentation/shared/dialogs/delete_confirm_dialog.dart';
 import 'group_edit_modal.dart';
 import 'package:memora/core/app_logger.dart';
 
-class GroupManagement extends StatefulWidget {
+class GroupManagement extends ConsumerStatefulWidget {
   final Member member;
   final GroupRepository? groupRepository;
   final GroupEventRepository? groupEventRepository;
@@ -41,10 +39,10 @@ class GroupManagement extends StatefulWidget {
   });
 
   @override
-  State<GroupManagement> createState() => _GroupManagementState();
+  ConsumerState<GroupManagement> createState() => _GroupManagementState();
 }
 
-class _GroupManagementState extends State<GroupManagement> {
+class _GroupManagementState extends ConsumerState<GroupManagement> {
   late final GetGroupByIdUsecase _getGroupByIdUsecase;
   late final GetManagedGroupsWithMembersUsecase
   _getManagedGroupsWithMembersUsecase;
@@ -61,15 +59,19 @@ class _GroupManagementState extends State<GroupManagement> {
     super.initState();
 
     final groupRepository =
-        widget.groupRepository ?? FirestoreGroupRepository();
+        widget.groupRepository ??
+        RepositoryFactory.createWithWidgetRef<GroupRepository>(ref: ref);
     final groupEventRepository =
-        widget.groupEventRepository ?? FirestoreGroupEventRepository();
+        widget.groupEventRepository ??
+        RepositoryFactory.createWithWidgetRef<GroupEventRepository>(ref: ref);
     final groupQueryService =
         widget.groupQueryService ?? FirestoreGroupQueryService();
     final memberRepository =
-        widget.memberRepository ?? FirestoreMemberRepository();
+        widget.memberRepository ??
+        RepositoryFactory.createWithWidgetRef<MemberRepository>(ref: ref);
     final tripEntryRepository =
-        widget.tripEntryRepository ?? FirestoreTripEntryRepository();
+        widget.tripEntryRepository ??
+        RepositoryFactory.createWithWidgetRef<TripEntryRepository>(ref: ref);
 
     _getGroupByIdUsecase = GetGroupByIdUsecase(groupRepository);
     _getManagedGroupsWithMembersUsecase = GetManagedGroupsWithMembersUsecase(

--- a/lib/presentation/features/member/member_management.dart
+++ b/lib/presentation/features/member/member_management.dart
@@ -55,16 +55,18 @@ class _MemberManagementState extends ConsumerState<MemberManagement> {
 
     final memberRepository =
         widget.memberRepository ??
-        RepositoryFactory.create<MemberRepository>(ref: ref);
+        RepositoryFactory.createWithWidgetRef<MemberRepository>(ref: ref);
     final groupRepository =
         widget.groupRepository ??
-        RepositoryFactory.create<GroupRepository>(ref: ref);
+        RepositoryFactory.createWithWidgetRef<GroupRepository>(ref: ref);
     final memberEventRepository =
         widget.memberEventRepository ??
-        RepositoryFactory.create<MemberEventRepository>(ref: ref);
+        RepositoryFactory.createWithWidgetRef<MemberEventRepository>(ref: ref);
     final memberInvitationRepository =
         widget.memberInvitationRepository ??
-        RepositoryFactory.create<MemberInvitationRepository>(ref: ref);
+        RepositoryFactory.createWithWidgetRef<MemberInvitationRepository>(
+          ref: ref,
+        );
 
     _getManagedMembersUsecase = GetManagedMembersUsecase(memberRepository);
     _createMemberUsecase = CreateMemberUsecase(memberRepository);

--- a/lib/presentation/features/timeline/group_timeline.dart
+++ b/lib/presentation/features/timeline/group_timeline.dart
@@ -1,10 +1,11 @@
 import 'dart:async';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:memora/application/usecases/trip/get_trip_entries_usecase.dart';
 import 'package:memora/domain/repositories/trip_entry_repository.dart';
 import 'package:memora/application/dtos/group/group_with_members_dto.dart';
-import 'package:memora/infrastructure/repositories/firestore_trip_entry_repository.dart';
+import 'package:memora/infrastructure/factories/repository_factory.dart';
 import 'package:memora/core/formatters/japanese_era_formatter.dart';
 import 'package:memora/domain/entities/trip_entry.dart';
 import 'package:memora/presentation/shared/displays/trip_cell.dart';
@@ -17,7 +18,7 @@ class _VerticalDragGestureRecognizer extends VerticalDragGestureRecognizer {
   }
 }
 
-class GroupTimeline extends StatefulWidget {
+class GroupTimeline extends ConsumerStatefulWidget {
   final GroupWithMembersDto groupWithMembers;
   final VoidCallback? onBackPressed;
   final Function(String groupId, int year)? onTripManagementSelected;
@@ -34,10 +35,10 @@ class GroupTimeline extends StatefulWidget {
   });
 
   @override
-  State<GroupTimeline> createState() => _GroupTimelineState();
+  ConsumerState<GroupTimeline> createState() => _GroupTimelineState();
 }
 
-class _GroupTimelineState extends State<GroupTimeline> {
+class _GroupTimelineState extends ConsumerState<GroupTimeline> {
   late final GetTripEntriesUsecase _getTripEntriesUsecase;
   static const int _initialYearRange = 5;
   static const int _yearRangeIncrement = 5;
@@ -77,7 +78,8 @@ class _GroupTimelineState extends State<GroupTimeline> {
     super.initState();
 
     final tripEntryRepository =
-        widget.tripEntryRepository ?? FirestoreTripEntryRepository();
+        widget.tripEntryRepository ??
+        RepositoryFactory.createWithWidgetRef<TripEntryRepository>(ref: ref);
 
     _getTripEntriesUsecase = GetTripEntriesUsecase(tripEntryRepository);
     final totalDataRows = 2 + widget.groupWithMembers.members.length;

--- a/lib/presentation/features/trip/trip_management.dart
+++ b/lib/presentation/features/trip/trip_management.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:memora/application/mappers/pin_mapper.dart';
 import 'package:memora/application/usecases/trip/create_trip_entry_usecase.dart';
 import 'package:memora/application/usecases/trip/get_trip_entries_usecase.dart';
@@ -7,12 +8,12 @@ import 'package:memora/application/usecases/trip/get_trip_entry_by_id_usecase.da
 import 'package:memora/application/usecases/trip/delete_trip_entry_usecase.dart';
 import 'package:memora/domain/entities/trip_entry.dart';
 import 'package:memora/domain/repositories/trip_entry_repository.dart';
-import 'package:memora/infrastructure/repositories/firestore_trip_entry_repository.dart';
+import 'package:memora/infrastructure/factories/repository_factory.dart';
 import 'package:memora/presentation/shared/dialogs/delete_confirm_dialog.dart';
 import 'trip_edit_modal.dart';
 import 'package:memora/core/app_logger.dart';
 
-class TripManagement extends StatefulWidget {
+class TripManagement extends ConsumerStatefulWidget {
   final String groupId;
   final int year;
   final VoidCallback? onBackPressed;
@@ -29,10 +30,10 @@ class TripManagement extends StatefulWidget {
   });
 
   @override
-  State<TripManagement> createState() => _TripManagementState();
+  ConsumerState<TripManagement> createState() => _TripManagementState();
 }
 
-class _TripManagementState extends State<TripManagement> {
+class _TripManagementState extends ConsumerState<TripManagement> {
   late final GetTripEntriesUsecase _getTripEntriesUsecase;
   late final CreateTripEntryUsecase _createTripEntryUsecase;
   late final UpdateTripEntryUsecase _updateTripEntryUsecase;
@@ -47,7 +48,8 @@ class _TripManagementState extends State<TripManagement> {
     super.initState();
 
     final tripEntryRepository =
-        widget.tripEntryRepository ?? FirestoreTripEntryRepository();
+        widget.tripEntryRepository ??
+        RepositoryFactory.createWithWidgetRef<TripEntryRepository>(ref: ref);
 
     _getTripEntriesUsecase = GetTripEntriesUsecase(tripEntryRepository);
     _createTripEntryUsecase = CreateTripEntryUsecase(tripEntryRepository);

--- a/lib/presentation/notifiers/auth_notifier.dart
+++ b/lib/presentation/notifiers/auth_notifier.dart
@@ -6,8 +6,7 @@ import 'package:memora/application/interfaces/auth_service.dart';
 import 'package:memora/domain/repositories/member_repository.dart';
 import 'package:memora/domain/repositories/member_invitation_repository.dart';
 import 'package:memora/infrastructure/services/firebase_auth_service.dart';
-import 'package:memora/infrastructure/repositories/firestore_member_repository.dart';
-import 'package:memora/infrastructure/repositories/firestore_member_invitation_repository.dart';
+import 'package:memora/infrastructure/factories/repository_factory.dart';
 import 'package:memora/application/usecases/member/check_member_exists_usecase.dart';
 import 'package:memora/application/usecases/member/create_member_from_user_usecase.dart';
 import 'package:memora/application/usecases/member/accept_invitation_usecase.dart';
@@ -18,12 +17,12 @@ final authServiceProvider = Provider<AuthService>((ref) {
 });
 
 final memberRepositoryProvider = Provider<MemberRepository>((ref) {
-  return FirestoreMemberRepository();
+  return RepositoryFactory.create<MemberRepository>(ref: ref);
 });
 
 final memberInvitationRepositoryProvider = Provider<MemberInvitationRepository>(
   (ref) {
-    return FirestoreMemberInvitationRepository();
+    return RepositoryFactory.create<MemberInvitationRepository>(ref: ref);
   },
 );
 

--- a/test/unit/presentation/features/group/group_management_test.dart
+++ b/test/unit/presentation/features/group/group_management_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:memora/domain/entities/group.dart';
 import 'package:memora/domain/entities/trip_entry.dart';
@@ -90,15 +91,17 @@ void main() {
 
       // Act
       await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: GroupManagement(
-              member: testMember,
-              groupRepository: mockGroupRepository,
-              groupEventRepository: mockGroupEventRepository,
-              groupQueryService: mockGroupQueryService,
-              memberRepository: mockMemberRepository,
-              tripEntryRepository: mockTripEntryRepository,
+        ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(
+              body: GroupManagement(
+                member: testMember,
+                groupRepository: mockGroupRepository,
+                groupEventRepository: mockGroupEventRepository,
+                groupQueryService: mockGroupQueryService,
+                memberRepository: mockMemberRepository,
+                tripEntryRepository: mockTripEntryRepository,
+              ),
             ),
           ),
         ),
@@ -131,15 +134,17 @@ void main() {
 
       // Act
       await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: GroupManagement(
-              member: testMember,
-              groupRepository: mockGroupRepository,
-              groupEventRepository: mockGroupEventRepository,
-              groupQueryService: mockGroupQueryService,
-              memberRepository: mockMemberRepository,
-              tripEntryRepository: mockTripEntryRepository,
+        ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(
+              body: GroupManagement(
+                member: testMember,
+                groupRepository: mockGroupRepository,
+                groupEventRepository: mockGroupEventRepository,
+                groupQueryService: mockGroupQueryService,
+                memberRepository: mockMemberRepository,
+                tripEntryRepository: mockTripEntryRepository,
+              ),
             ),
           ),
         ),
@@ -163,15 +168,17 @@ void main() {
 
       // Act
       await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: GroupManagement(
-              member: testMember,
-              groupRepository: mockGroupRepository,
-              groupEventRepository: mockGroupEventRepository,
-              groupQueryService: mockGroupQueryService,
-              memberRepository: mockMemberRepository,
-              tripEntryRepository: mockTripEntryRepository,
+        ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(
+              body: GroupManagement(
+                member: testMember,
+                groupRepository: mockGroupRepository,
+                groupEventRepository: mockGroupEventRepository,
+                groupQueryService: mockGroupQueryService,
+                memberRepository: mockMemberRepository,
+                tripEntryRepository: mockTripEntryRepository,
+              ),
             ),
           ),
         ),
@@ -194,15 +201,17 @@ void main() {
 
       // Act
       await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: GroupManagement(
-              member: testMember,
-              groupRepository: mockGroupRepository,
-              groupEventRepository: mockGroupEventRepository,
-              groupQueryService: mockGroupQueryService,
-              memberRepository: mockMemberRepository,
-              tripEntryRepository: mockTripEntryRepository,
+        ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(
+              body: GroupManagement(
+                member: testMember,
+                groupRepository: mockGroupRepository,
+                groupEventRepository: mockGroupEventRepository,
+                groupQueryService: mockGroupQueryService,
+                memberRepository: mockMemberRepository,
+                tripEntryRepository: mockTripEntryRepository,
+              ),
             ),
           ),
         ),
@@ -229,15 +238,17 @@ void main() {
 
       // Act
       await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: GroupManagement(
-              member: testMember,
-              groupRepository: mockGroupRepository,
-              groupEventRepository: mockGroupEventRepository,
-              groupQueryService: mockGroupQueryService,
-              memberRepository: mockMemberRepository,
-              tripEntryRepository: mockTripEntryRepository,
+        ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(
+              body: GroupManagement(
+                member: testMember,
+                groupRepository: mockGroupRepository,
+                groupEventRepository: mockGroupEventRepository,
+                groupQueryService: mockGroupQueryService,
+                memberRepository: mockMemberRepository,
+                tripEntryRepository: mockTripEntryRepository,
+              ),
             ),
           ),
         ),
@@ -273,15 +284,17 @@ void main() {
 
       // Act
       await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: GroupManagement(
-              member: testMember,
-              groupRepository: mockGroupRepository,
-              groupEventRepository: mockGroupEventRepository,
-              groupQueryService: mockGroupQueryService,
-              memberRepository: mockMemberRepository,
-              tripEntryRepository: mockTripEntryRepository,
+        ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(
+              body: GroupManagement(
+                member: testMember,
+                groupRepository: mockGroupRepository,
+                groupEventRepository: mockGroupEventRepository,
+                groupQueryService: mockGroupQueryService,
+                memberRepository: mockMemberRepository,
+                tripEntryRepository: mockTripEntryRepository,
+              ),
             ),
           ),
         ),
@@ -314,15 +327,17 @@ void main() {
 
       // Act
       await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: GroupManagement(
-              member: testMember,
-              groupRepository: mockGroupRepository,
-              groupEventRepository: mockGroupEventRepository,
-              groupQueryService: mockGroupQueryService,
-              memberRepository: mockMemberRepository,
-              tripEntryRepository: mockTripEntryRepository,
+        ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(
+              body: GroupManagement(
+                member: testMember,
+                groupRepository: mockGroupRepository,
+                groupEventRepository: mockGroupEventRepository,
+                groupQueryService: mockGroupQueryService,
+                memberRepository: mockMemberRepository,
+                tripEntryRepository: mockTripEntryRepository,
+              ),
             ),
           ),
         ),
@@ -360,15 +375,17 @@ void main() {
 
       // Act
       await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: GroupManagement(
-              member: testMember,
-              groupRepository: mockGroupRepository,
-              groupEventRepository: mockGroupEventRepository,
-              groupQueryService: mockGroupQueryService,
-              memberRepository: mockMemberRepository,
-              tripEntryRepository: mockTripEntryRepository,
+        ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(
+              body: GroupManagement(
+                member: testMember,
+                groupRepository: mockGroupRepository,
+                groupEventRepository: mockGroupEventRepository,
+                groupQueryService: mockGroupQueryService,
+                memberRepository: mockMemberRepository,
+                tripEntryRepository: mockTripEntryRepository,
+              ),
             ),
           ),
         ),
@@ -429,15 +446,17 @@ void main() {
 
       // Act
       await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: GroupManagement(
-              member: testMember,
-              groupRepository: mockGroupRepository,
-              groupEventRepository: mockGroupEventRepository,
-              groupQueryService: mockGroupQueryService,
-              memberRepository: mockMemberRepository,
-              tripEntryRepository: mockTripEntryRepository,
+        ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(
+              body: GroupManagement(
+                member: testMember,
+                groupRepository: mockGroupRepository,
+                groupEventRepository: mockGroupEventRepository,
+                groupQueryService: mockGroupQueryService,
+                memberRepository: mockMemberRepository,
+                tripEntryRepository: mockTripEntryRepository,
+              ),
             ),
           ),
         ),

--- a/test/unit/presentation/features/timeline/group_timeline_test.dart
+++ b/test/unit/presentation/features/timeline/group_timeline_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:memora/application/dtos/group/group_with_members_dto.dart';
 import 'package:memora/application/dtos/member/member_dto.dart';
@@ -42,14 +43,17 @@ void main() {
   });
 
   Widget createTestWidget({TripEntryRepository? tripEntryRepository}) {
-    return MaterialApp(
-      home: Scaffold(
-        body: SizedBox(
-          width: 1200, // より広い画面サイズを設定
-          height: 800,
-          child: GroupTimeline(
-            groupWithMembers: testGroupWithMembers,
-            tripEntryRepository: tripEntryRepository ?? mockTripEntryRepository,
+    return ProviderScope(
+      child: MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 1200, // より広い画面サイズを設定
+            height: 800,
+            child: GroupTimeline(
+              groupWithMembers: testGroupWithMembers,
+              tripEntryRepository:
+                  tripEntryRepository ?? mockTripEntryRepository,
+            ),
           ),
         ),
       ),

--- a/test/unit/presentation/features/trip/trip_management_test.dart
+++ b/test/unit/presentation/features/trip/trip_management_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
@@ -70,14 +71,16 @@ void main() {
 
       // Act
       await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: TripManagement(
-              groupId: testGroupId,
-              year: testYear,
-              onBackPressed: null,
-              tripEntryRepository: mockTripEntryRepository,
-              isTestEnvironment: true,
+        ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(
+              body: TripManagement(
+                groupId: testGroupId,
+                year: testYear,
+                onBackPressed: null,
+                tripEntryRepository: mockTripEntryRepository,
+                isTestEnvironment: true,
+              ),
             ),
           ),
         ),
@@ -123,14 +126,16 @@ void main() {
 
       // Act
       await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: TripManagement(
-              groupId: testGroupId,
-              year: testYear,
-              onBackPressed: null,
-              tripEntryRepository: mockTripEntryRepository,
-              isTestEnvironment: true,
+        ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(
+              body: TripManagement(
+                groupId: testGroupId,
+                year: testYear,
+                onBackPressed: null,
+                tripEntryRepository: mockTripEntryRepository,
+                isTestEnvironment: true,
+              ),
             ),
           ),
         ),
@@ -160,14 +165,16 @@ void main() {
 
       // Act
       await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: TripManagement(
-              groupId: testGroupId,
-              year: testYear,
-              onBackPressed: null,
-              tripEntryRepository: mockTripEntryRepository,
-              isTestEnvironment: true,
+        ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(
+              body: TripManagement(
+                groupId: testGroupId,
+                year: testYear,
+                onBackPressed: null,
+                tripEntryRepository: mockTripEntryRepository,
+                isTestEnvironment: true,
+              ),
             ),
           ),
         ),
@@ -192,14 +199,16 @@ void main() {
 
       // Act
       await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: TripManagement(
-              groupId: testGroupId,
-              year: testYear,
-              onBackPressed: null,
-              tripEntryRepository: mockTripEntryRepository,
-              isTestEnvironment: true,
+        ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(
+              body: TripManagement(
+                groupId: testGroupId,
+                year: testYear,
+                onBackPressed: null,
+                tripEntryRepository: mockTripEntryRepository,
+                isTestEnvironment: true,
+              ),
             ),
           ),
         ),
@@ -226,14 +235,16 @@ void main() {
 
       // Act
       await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: TripManagement(
-              groupId: testGroupId,
-              year: testYear,
-              onBackPressed: null,
-              tripEntryRepository: mockTripEntryRepository,
-              isTestEnvironment: true,
+        ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(
+              body: TripManagement(
+                groupId: testGroupId,
+                year: testYear,
+                onBackPressed: null,
+                tripEntryRepository: mockTripEntryRepository,
+                isTestEnvironment: true,
+              ),
             ),
           ),
         ),
@@ -273,13 +284,15 @@ void main() {
       ).thenAnswer((_) async => detailedTripEntry);
       // Act
       await tester.pumpWidget(
-        MaterialApp(
-          home: TripManagement(
-            groupId: testGroupId,
-            year: testYear,
-            onBackPressed: null,
-            tripEntryRepository: mockTripEntryRepository,
-            isTestEnvironment: true,
+        ProviderScope(
+          child: MaterialApp(
+            home: TripManagement(
+              groupId: testGroupId,
+              year: testYear,
+              onBackPressed: null,
+              tripEntryRepository: mockTripEntryRepository,
+              isTestEnvironment: true,
+            ),
           ),
         ),
       );
@@ -316,14 +329,16 @@ void main() {
 
       // Act
       await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: TripManagement(
-              groupId: testGroupId,
-              year: testYear,
-              onBackPressed: null,
-              tripEntryRepository: mockTripEntryRepository,
-              isTestEnvironment: true,
+        ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(
+              body: TripManagement(
+                groupId: testGroupId,
+                year: testYear,
+                onBackPressed: null,
+                tripEntryRepository: mockTripEntryRepository,
+                isTestEnvironment: true,
+              ),
             ),
           ),
         ),
@@ -358,14 +373,16 @@ void main() {
 
       // Act
       await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: TripManagement(
-              groupId: testGroupId,
-              year: testYear,
-              onBackPressed: null,
-              tripEntryRepository: mockTripEntryRepository,
-              isTestEnvironment: true,
+        ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(
+              body: TripManagement(
+                groupId: testGroupId,
+                year: testYear,
+                onBackPressed: null,
+                tripEntryRepository: mockTripEntryRepository,
+                isTestEnvironment: true,
+              ),
             ),
           ),
         ),
@@ -404,13 +421,15 @@ void main() {
 
       // Act
       await tester.pumpWidget(
-        MaterialApp(
-          home: TripManagement(
-            groupId: testGroupId,
-            year: testYear,
-            onBackPressed: null,
-            tripEntryRepository: mockTripEntryRepository,
-            isTestEnvironment: true,
+        ProviderScope(
+          child: MaterialApp(
+            home: TripManagement(
+              groupId: testGroupId,
+              year: testYear,
+              onBackPressed: null,
+              tripEntryRepository: mockTripEntryRepository,
+              isTestEnvironment: true,
+            ),
           ),
         ),
       );
@@ -443,14 +462,16 @@ void main() {
 
       // Act
       await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: TripManagement(
-              groupId: testGroupId,
-              year: testYear,
-              onBackPressed: null,
-              tripEntryRepository: mockTripEntryRepository,
-              isTestEnvironment: true,
+        ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(
+              body: TripManagement(
+                groupId: testGroupId,
+                year: testYear,
+                onBackPressed: null,
+                tripEntryRepository: mockTripEntryRepository,
+                isTestEnvironment: true,
+              ),
             ),
           ),
         ),
@@ -484,14 +505,16 @@ void main() {
 
       // Act
       await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: TripManagement(
-              groupId: testGroupId,
-              year: testYear,
-              onBackPressed: null,
-              tripEntryRepository: mockTripEntryRepository,
-              isTestEnvironment: true,
+        ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(
+              body: TripManagement(
+                groupId: testGroupId,
+                year: testYear,
+                onBackPressed: null,
+                tripEntryRepository: mockTripEntryRepository,
+                isTestEnvironment: true,
+              ),
             ),
           ),
         ),
@@ -528,16 +551,18 @@ void main() {
 
       // Act
       await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: TripManagement(
-              groupId: testGroupId,
-              year: testYear,
-              onBackPressed: () {
-                backPressed = true;
-              },
-              tripEntryRepository: mockTripEntryRepository,
-              isTestEnvironment: true,
+        ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(
+              body: TripManagement(
+                groupId: testGroupId,
+                year: testYear,
+                onBackPressed: () {
+                  backPressed = true;
+                },
+                tripEntryRepository: mockTripEntryRepository,
+                isTestEnvironment: true,
+              ),
             ),
           ),
         ),
@@ -568,13 +593,15 @@ void main() {
 
       // Act
       await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: TripManagement(
-              groupId: testGroupId,
-              year: testYear,
-              tripEntryRepository: mockTripEntryRepository,
-              isTestEnvironment: true,
+        ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(
+              body: TripManagement(
+                groupId: testGroupId,
+                year: testYear,
+                tripEntryRepository: mockTripEntryRepository,
+                isTestEnvironment: true,
+              ),
             ),
           ),
         ),


### PR DESCRIPTION
## Summary
- add RepositoryFactory helpers for both provider and widget contexts to enable runtime database switching
- refactor member, group, trip, and timeline screens plus auth notifier to resolve repositories via the factory and wrap related widget tests in ProviderScope
- mark the repository factory todo as complete

## Testing
- flutter test test/unit/presentation/features/group/group_management_test.dart test/unit/presentation/features/trip/trip_management_test.dart test/unit/presentation/features/timeline/group_timeline_test.dart

------
https://chatgpt.com/codex/tasks/task_e_68e3ddcab65c8332bbd1e197e5ccb12f