### PR TITLE
fix: ProviderScopeの二重作成によるDB切替不具合を修正

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -84,28 +84,26 @@ class _MyAppState extends ConsumerState<MyApp> {
 
   @override
   Widget build(BuildContext context) {
-    return ProviderScope(
-      child: MaterialApp(
-        title: 'memora',
-        theme: ThemeData(
-          colorScheme: ColorScheme.fromSeed(seedColor: Colors.lightBlue),
-          appBarTheme: const AppBarTheme(
-            backgroundColor: Colors.lightBlue,
-            foregroundColor: Colors.white,
-          ),
+    return MaterialApp(
+      title: 'memora',
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.lightBlue),
+        appBarTheme: const AppBarTheme(
+          backgroundColor: Colors.lightBlue,
+          foregroundColor: Colors.white,
         ),
-        locale: const Locale('ja'),
-        supportedLocales: const [Locale('ja'), Locale('en')],
-        localizationsDelegates: const [
-          GlobalMaterialLocalizations.delegate,
-          GlobalWidgetsLocalizations.delegate,
-          GlobalCupertinoLocalizations.delegate,
-        ],
-        home: AuthGuard(
-          child: TopPage(
-            getGroupsWithMembersUsecase: getGroupsWithMembersUsecase,
-            getCurrentMemberUseCase: getCurrentMemberUseCase,
-          ),
+      ),
+      locale: const Locale('ja'),
+      supportedLocales: const [Locale('ja'), Locale('en')],
+      localizationsDelegates: const [
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      home: AuthGuard(
+        child: TopPage(
+          getGroupsWithMembersUsecase: getGroupsWithMembersUsecase,
+          getCurrentMemberUseCase: getCurrentMemberUseCase,
         ),
       ),
     );


### PR DESCRIPTION
## 概要

`main.dart`でrunAppの時点ですでに`ProviderScope(child: MyApp())`を構築しているのに、`_MyAppState.build`でも新たに`ProviderScope`を返すようになっていました。

この結果、`initState`でRepositoryFactory.createに渡した`ref`は外側のスコープの`databaseTypeProvider`を参照し続ける一方、画面側は内側スコープの`databaseTypeProvider`を操作します。

実行中にデータベース種別を切り替えても`MyApp`生成時に作られたリポジトリやユースケースは外側スコープの値から更新されず、切替が一貫して反映されませんでした。

## 変更内容

- `_MyAppState.build`の内側`ProviderScope`を削除
- 外側のスコープに統一することで、DB切り替えが正常に同期するようになった

## テスト

- `./check.sh`ですべてのテストが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)