### PR TITLE
refactor: UseCase provider経由のDIに統一

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -351,6 +351,8 @@
   - [x] AuthServiceFactoryを実装
 - [x] UseCaseをProviderに依存する形に変更する
   - [x] GroupManagementで実装
+- [x] UseCase Providerを利用するようにリポジトリDIをリファクタリングする
+  - [x] コミット52d2e1361ea105de003ce15d5b078f92dab45ad1の対応を全機能に展開する
 
 ## 全体
 

--- a/lib/application/usecases/account/delete_user_usecase.dart
+++ b/lib/application/usecases/account/delete_user_usecase.dart
@@ -1,4 +1,10 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:memora/application/interfaces/auth_service.dart';
+import 'package:memora/infrastructure/factories/auth_service_factory.dart';
+
+final deleteUserUseCaseProvider = Provider<DeleteUserUseCase>((ref) {
+  return DeleteUserUseCase(authService: ref.watch(authServiceProvider));
+});
 
 class DeleteUserUseCase {
   const DeleteUserUseCase({required this.authService});

--- a/lib/application/usecases/account/reauthenticate_usecase.dart
+++ b/lib/application/usecases/account/reauthenticate_usecase.dart
@@ -1,4 +1,10 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:memora/application/interfaces/auth_service.dart';
+import 'package:memora/infrastructure/factories/auth_service_factory.dart';
+
+final reauthenticateUseCaseProvider = Provider<ReauthenticateUseCase>((ref) {
+  return ReauthenticateUseCase(authService: ref.watch(authServiceProvider));
+});
 
 class ReauthenticateUseCase {
   ReauthenticateUseCase({required this.authService});

--- a/lib/application/usecases/account/update_email_usecase.dart
+++ b/lib/application/usecases/account/update_email_usecase.dart
@@ -1,4 +1,10 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:memora/application/interfaces/auth_service.dart';
+import 'package:memora/infrastructure/factories/auth_service_factory.dart';
+
+final updateEmailUseCaseProvider = Provider<UpdateEmailUseCase>((ref) {
+  return UpdateEmailUseCase(authService: ref.watch(authServiceProvider));
+});
 
 class UpdateEmailUseCase {
   const UpdateEmailUseCase({required this.authService});

--- a/lib/application/usecases/account/update_password_usecase.dart
+++ b/lib/application/usecases/account/update_password_usecase.dart
@@ -1,4 +1,10 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:memora/application/interfaces/auth_service.dart';
+import 'package:memora/infrastructure/factories/auth_service_factory.dart';
+
+final updatePasswordUseCaseProvider = Provider<UpdatePasswordUseCase>((ref) {
+  return UpdatePasswordUseCase(authService: ref.watch(authServiceProvider));
+});
 
 class UpdatePasswordUseCase {
   const UpdatePasswordUseCase({required this.authService});

--- a/lib/application/usecases/group/get_groups_with_members_usecase.dart
+++ b/lib/application/usecases/group/get_groups_with_members_usecase.dart
@@ -1,6 +1,13 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:memora/domain/entities/member.dart';
 import 'package:memora/application/interfaces/group_query_service.dart';
 import 'package:memora/application/dtos/group/group_with_members_dto.dart';
+import 'package:memora/infrastructure/factories/query_service_factory.dart';
+
+final getGroupsWithMembersUsecaseProvider =
+    Provider<GetGroupsWithMembersUsecase>((ref) {
+      return GetGroupsWithMembersUsecase(ref.watch(groupQueryServiceProvider));
+    });
 
 class GetGroupsWithMembersUsecase {
   final GroupQueryService _groupQueryService;

--- a/lib/application/usecases/member/accept_invitation_usecase.dart
+++ b/lib/application/usecases/member/accept_invitation_usecase.dart
@@ -1,6 +1,17 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:memora/domain/repositories/member_invitation_repository.dart';
 import 'package:memora/domain/repositories/member_repository.dart';
+import 'package:memora/infrastructure/factories/repository_factory.dart';
 import 'package:memora/core/app_logger.dart';
+
+final acceptInvitationUseCaseProvider = Provider<AcceptInvitationUseCase>((
+  ref,
+) {
+  return AcceptInvitationUseCase(
+    ref.watch(memberInvitationRepositoryProvider),
+    ref.watch(memberRepositoryProvider),
+  );
+});
 
 class AcceptInvitationUseCase {
   final MemberInvitationRepository _memberInvitationRepository;

--- a/lib/application/usecases/member/check_member_exists_usecase.dart
+++ b/lib/application/usecases/member/check_member_exists_usecase.dart
@@ -1,5 +1,13 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:memora/domain/entities/user.dart';
 import 'package:memora/domain/repositories/member_repository.dart';
+import 'package:memora/infrastructure/factories/repository_factory.dart';
+
+final checkMemberExistsUseCaseProvider = Provider<CheckMemberExistsUseCase>((
+  ref,
+) {
+  return CheckMemberExistsUseCase(ref.watch(memberRepositoryProvider));
+});
 
 class CheckMemberExistsUseCase {
   final MemberRepository _memberRepository;

--- a/lib/application/usecases/member/create_member_from_user_usecase.dart
+++ b/lib/application/usecases/member/create_member_from_user_usecase.dart
@@ -1,7 +1,14 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:memora/domain/entities/member.dart';
 import 'package:memora/domain/entities/user.dart';
 import 'package:memora/domain/repositories/member_repository.dart';
+import 'package:memora/infrastructure/factories/repository_factory.dart';
 import 'package:memora/core/app_logger.dart';
+
+final createMemberFromUserUseCaseProvider =
+    Provider<CreateMemberFromUserUseCase>((ref) {
+      return CreateMemberFromUserUseCase(ref.watch(memberRepositoryProvider));
+    });
 
 class CreateMemberFromUserUseCase {
   final MemberRepository _memberRepository;

--- a/lib/application/usecases/member/create_member_usecase.dart
+++ b/lib/application/usecases/member/create_member_usecase.dart
@@ -1,6 +1,12 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:uuid/uuid.dart';
 import 'package:memora/domain/entities/member.dart';
 import 'package:memora/domain/repositories/member_repository.dart';
+import 'package:memora/infrastructure/factories/repository_factory.dart';
+
+final createMemberUsecaseProvider = Provider<CreateMemberUsecase>((ref) {
+  return CreateMemberUsecase(ref.watch(memberRepositoryProvider));
+});
 
 class CreateMemberUsecase {
   final MemberRepository _memberRepository;

--- a/lib/application/usecases/member/create_or_update_member_invitation_usecase.dart
+++ b/lib/application/usecases/member/create_or_update_member_invitation_usecase.dart
@@ -1,6 +1,15 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:uuid/uuid.dart';
 import 'package:memora/domain/entities/member_invitation.dart';
 import 'package:memora/domain/repositories/member_invitation_repository.dart';
+import 'package:memora/infrastructure/factories/repository_factory.dart';
+
+final createOrUpdateMemberInvitationUsecaseProvider =
+    Provider<CreateOrUpdateMemberInvitationUsecase>((ref) {
+      return CreateOrUpdateMemberInvitationUsecase(
+        ref.watch(memberInvitationRepositoryProvider),
+      );
+    });
 
 class CreateOrUpdateMemberInvitationUsecase {
   final MemberInvitationRepository _memberInvitationRepository;

--- a/lib/application/usecases/member/delete_member_usecase.dart
+++ b/lib/application/usecases/member/delete_member_usecase.dart
@@ -1,6 +1,16 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:memora/domain/repositories/member_repository.dart';
 import 'package:memora/domain/repositories/group_repository.dart';
 import 'package:memora/domain/repositories/member_event_repository.dart';
+import 'package:memora/infrastructure/factories/repository_factory.dart';
+
+final deleteMemberUsecaseProvider = Provider<DeleteMemberUsecase>((ref) {
+  return DeleteMemberUsecase(
+    ref.watch(memberRepositoryProvider),
+    ref.watch(groupRepositoryProvider),
+    ref.watch(memberEventRepositoryProvider),
+  );
+});
 
 class DeleteMemberUsecase {
   final MemberRepository _memberRepository;

--- a/lib/application/usecases/member/get_current_member_usecase.dart
+++ b/lib/application/usecases/member/get_current_member_usecase.dart
@@ -1,6 +1,18 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:memora/domain/entities/member.dart';
 import 'package:memora/domain/repositories/member_repository.dart';
 import 'package:memora/application/interfaces/auth_service.dart';
+import 'package:memora/infrastructure/factories/auth_service_factory.dart';
+import 'package:memora/infrastructure/factories/repository_factory.dart';
+
+final getCurrentMemberUsecaseProvider = Provider<GetCurrentMemberUseCase>((
+  ref,
+) {
+  return GetCurrentMemberUseCase(
+    ref.watch(memberRepositoryProvider),
+    ref.watch(authServiceProvider),
+  );
+});
 
 class GetCurrentMemberUseCase {
   final MemberRepository _memberRepository;

--- a/lib/application/usecases/member/get_member_by_id_usecase.dart
+++ b/lib/application/usecases/member/get_member_by_id_usecase.dart
@@ -1,5 +1,11 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:memora/domain/entities/member.dart';
 import 'package:memora/domain/repositories/member_repository.dart';
+import 'package:memora/infrastructure/factories/repository_factory.dart';
+
+final getMemberByIdUsecaseProvider = Provider<GetMemberByIdUseCase>((ref) {
+  return GetMemberByIdUseCase(ref.watch(memberRepositoryProvider));
+});
 
 class GetMemberByIdUseCase {
   final MemberRepository _memberRepository;

--- a/lib/application/usecases/member/update_member_usecase.dart
+++ b/lib/application/usecases/member/update_member_usecase.dart
@@ -1,5 +1,11 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:memora/domain/entities/member.dart';
 import 'package:memora/domain/repositories/member_repository.dart';
+import 'package:memora/infrastructure/factories/repository_factory.dart';
+
+final updateMemberUsecaseProvider = Provider<UpdateMemberUsecase>((ref) {
+  return UpdateMemberUsecase(ref.watch(memberRepositoryProvider));
+});
 
 class UpdateMemberUsecase {
   final MemberRepository _memberRepository;

--- a/lib/application/usecases/pin/get_pins_by_member_id_usecase.dart
+++ b/lib/application/usecases/pin/get_pins_by_member_id_usecase.dart
@@ -1,5 +1,13 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:memora/application/dtos/pin/pin_dto.dart';
 import 'package:memora/application/interfaces/pin_query_service.dart';
+import 'package:memora/infrastructure/factories/query_service_factory.dart';
+
+final getPinsByMemberIdUsecaseProvider = Provider<GetPinsByMemberIdUsecase>((
+  ref,
+) {
+  return GetPinsByMemberIdUsecase(ref.watch(pinQueryServiceProvider));
+});
 
 class GetPinsByMemberIdUsecase {
   final PinQueryService _pinQueryService;

--- a/lib/application/usecases/trip/create_trip_entry_usecase.dart
+++ b/lib/application/usecases/trip/create_trip_entry_usecase.dart
@@ -1,5 +1,11 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:memora/domain/entities/trip_entry.dart';
 import 'package:memora/domain/repositories/trip_entry_repository.dart';
+import 'package:memora/infrastructure/factories/repository_factory.dart';
+
+final createTripEntryUsecaseProvider = Provider<CreateTripEntryUsecase>((ref) {
+  return CreateTripEntryUsecase(ref.watch(tripEntryRepositoryProvider));
+});
 
 class CreateTripEntryUsecase {
   final TripEntryRepository _tripEntryRepository;

--- a/lib/application/usecases/trip/delete_trip_entry_usecase.dart
+++ b/lib/application/usecases/trip/delete_trip_entry_usecase.dart
@@ -1,4 +1,10 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:memora/domain/repositories/trip_entry_repository.dart';
+import 'package:memora/infrastructure/factories/repository_factory.dart';
+
+final deleteTripEntryUsecaseProvider = Provider<DeleteTripEntryUsecase>((ref) {
+  return DeleteTripEntryUsecase(ref.watch(tripEntryRepositoryProvider));
+});
 
 class DeleteTripEntryUsecase {
   final TripEntryRepository _tripEntryRepository;

--- a/lib/application/usecases/trip/get_trip_entries_usecase.dart
+++ b/lib/application/usecases/trip/get_trip_entries_usecase.dart
@@ -1,6 +1,12 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:memora/domain/entities/trip_entry.dart';
 import 'package:memora/domain/repositories/trip_entry_repository.dart';
 import 'package:memora/domain/value_objects/order_by.dart';
+import 'package:memora/infrastructure/factories/repository_factory.dart';
+
+final getTripEntriesUsecaseProvider = Provider<GetTripEntriesUsecase>((ref) {
+  return GetTripEntriesUsecase(ref.watch(tripEntryRepositoryProvider));
+});
 
 class GetTripEntriesUsecase {
   final TripEntryRepository _tripEntryRepository;

--- a/lib/application/usecases/trip/get_trip_entry_by_id_usecase.dart
+++ b/lib/application/usecases/trip/get_trip_entry_by_id_usecase.dart
@@ -1,5 +1,13 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:memora/domain/entities/trip_entry.dart';
 import 'package:memora/domain/repositories/trip_entry_repository.dart';
+import 'package:memora/infrastructure/factories/repository_factory.dart';
+
+final getTripEntryByIdUsecaseProvider = Provider<GetTripEntryByIdUsecase>((
+  ref,
+) {
+  return GetTripEntryByIdUsecase(ref.watch(tripEntryRepositoryProvider));
+});
 
 class GetTripEntryByIdUsecase {
   final TripEntryRepository _tripEntryRepository;

--- a/lib/application/usecases/trip/update_trip_entry_usecase.dart
+++ b/lib/application/usecases/trip/update_trip_entry_usecase.dart
@@ -1,5 +1,11 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:memora/domain/entities/trip_entry.dart';
 import 'package:memora/domain/repositories/trip_entry_repository.dart';
+import 'package:memora/infrastructure/factories/repository_factory.dart';
+
+final updateTripEntryUsecaseProvider = Provider<UpdateTripEntryUsecase>((ref) {
+  return UpdateTripEntryUsecase(ref.watch(tripEntryRepositoryProvider));
+});
 
 class UpdateTripEntryUsecase {
   final TripEntryRepository _tripEntryRepository;

--- a/lib/presentation/app/top_page.dart
+++ b/lib/presentation/app/top_page.dart
@@ -1,11 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:memora/application/interfaces/auth_service.dart';
-import 'package:memora/application/interfaces/group_query_service.dart';
-import 'package:memora/application/interfaces/pin_query_service.dart';
-import 'package:memora/domain/repositories/member_repository.dart';
-import 'package:memora/infrastructure/factories/auth_service_factory.dart';
-import 'package:memora/infrastructure/factories/repository_factory.dart';
 import 'package:memora/presentation/notifiers/auth_notifier.dart';
 import 'package:memora/presentation/notifiers/navigation_notifier.dart';
 import 'package:memora/presentation/notifiers/group_timeline_navigation_notifier.dart';
@@ -25,19 +19,8 @@ import 'package:memora/core/app_logger.dart';
 
 class TopPage extends ConsumerStatefulWidget {
   final bool isTestEnvironment;
-  final MemberRepository? memberRepository;
-  final AuthService? authService;
-  final GroupQueryService? groupQueryService;
-  final PinQueryService? pinQueryService;
 
-  const TopPage({
-    super.key,
-    this.isTestEnvironment = false,
-    this.memberRepository,
-    this.authService,
-    this.groupQueryService,
-    this.pinQueryService,
-  });
+  const TopPage({super.key, this.isTestEnvironment = false});
 
   @override
   ConsumerState<TopPage> createState() => _TopPageState();
@@ -51,15 +34,7 @@ class _TopPageState extends ConsumerState<TopPage> {
   void initState() {
     super.initState();
 
-    final MemberRepository memberRepository =
-        widget.memberRepository ?? ref.read(memberRepositoryProvider);
-    final AuthService authService =
-        widget.authService ?? ref.read(authServiceProvider);
-
-    _getCurrentMemberUseCase = GetCurrentMemberUseCase(
-      memberRepository,
-      authService,
-    );
+    _getCurrentMemberUseCase = ref.read(getCurrentMemberUsecaseProvider);
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) {
@@ -130,7 +105,6 @@ class _TopPageState extends ConsumerState<TopPage> {
         GroupList(
           member: _currentMember!,
           onGroupSelected: (group) => _onGroupSelected(group),
-          groupQueryService: widget.groupQueryService,
         ),
         widget.isTestEnvironment
             ? _buildTestGroupTimeline()
@@ -192,7 +166,6 @@ class _TopPageState extends ConsumerState<TopPage> {
         return MapScreen(
           member: _currentMember!,
           isTestEnvironment: widget.isTestEnvironment,
-          pinQueryService: widget.pinQueryService,
         );
       case NavigationItem.groupManagement:
         if (_currentMember == null) {

--- a/lib/presentation/features/account_setting/account_settings.dart
+++ b/lib/presentation/features/account_setting/account_settings.dart
@@ -4,7 +4,6 @@ import 'package:memora/application/usecases/account/update_email_usecase.dart';
 import 'package:memora/application/usecases/account/update_password_usecase.dart';
 import 'package:memora/application/usecases/account/delete_user_usecase.dart';
 import 'package:memora/application/usecases/account/reauthenticate_usecase.dart';
-import 'package:memora/infrastructure/factories/auth_service_factory.dart';
 import 'email_change_modal.dart';
 import 'password_change_modal.dart';
 import 'account_delete_modal.dart';
@@ -18,11 +17,8 @@ class AccountSettings extends ConsumerWidget {
     BuildContext context,
     WidgetRef ref,
   ) async {
-    final authService = ref.read(authServiceProvider);
-    final updateEmailUseCase = UpdateEmailUseCase(authService: authService);
-    final reauthenticateUseCase = ReauthenticateUseCase(
-      authService: authService,
-    );
+    final updateEmailUseCase = ref.read(updateEmailUseCaseProvider);
+    final reauthenticateUseCase = ref.read(reauthenticateUseCaseProvider);
 
     await showDialog(
       context: context,
@@ -82,13 +78,8 @@ class AccountSettings extends ConsumerWidget {
     BuildContext context,
     WidgetRef ref,
   ) async {
-    final authService = ref.read(authServiceProvider);
-    final updatePasswordUseCase = UpdatePasswordUseCase(
-      authService: authService,
-    );
-    final reauthenticateUseCase = ReauthenticateUseCase(
-      authService: authService,
-    );
+    final updatePasswordUseCase = ref.read(updatePasswordUseCaseProvider);
+    final reauthenticateUseCase = ref.read(reauthenticateUseCaseProvider);
 
     await showDialog(
       context: context,
@@ -142,11 +133,8 @@ class AccountSettings extends ConsumerWidget {
     BuildContext context,
     WidgetRef ref,
   ) async {
-    final authService = ref.read(authServiceProvider);
-    final deleteUserUseCase = DeleteUserUseCase(authService: authService);
-    final reauthenticateUseCase = ReauthenticateUseCase(
-      authService: authService,
-    );
+    final deleteUserUseCase = ref.read(deleteUserUseCaseProvider);
+    final reauthenticateUseCase = ref.read(reauthenticateUseCaseProvider);
 
     await showDialog(
       context: context,

--- a/lib/presentation/features/map/map_screen.dart
+++ b/lib/presentation/features/map/map_screen.dart
@@ -1,22 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:memora/application/dtos/pin/pin_dto.dart';
-import 'package:memora/application/interfaces/pin_query_service.dart';
 import 'package:memora/application/usecases/pin/get_pins_by_member_id_usecase.dart';
 import 'package:memora/domain/entities/member.dart';
-import 'package:memora/infrastructure/factories/query_service_factory.dart';
 import 'package:memora/presentation/shared/map_views/map_view_factory.dart';
 
 class MapScreen extends ConsumerStatefulWidget {
   final Member member;
   final bool isTestEnvironment;
-  final PinQueryService? pinQueryService;
 
   const MapScreen({
     super.key,
     required this.member,
     this.isTestEnvironment = false,
-    this.pinQueryService,
   });
 
   @override
@@ -32,10 +28,7 @@ class _MapScreenState extends ConsumerState<MapScreen> {
   void initState() {
     super.initState();
 
-    final PinQueryService pinQueryService =
-        widget.pinQueryService ?? ref.read(pinQueryServiceProvider);
-
-    _getPinsByMemberIdUsecase = GetPinsByMemberIdUsecase(pinQueryService);
+    _getPinsByMemberIdUsecase = ref.read(getPinsByMemberIdUsecaseProvider);
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _loadPins();

--- a/lib/presentation/features/member/member_management.dart
+++ b/lib/presentation/features/member/member_management.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:memora/domain/repositories/group_repository.dart';
-import 'package:memora/infrastructure/factories/repository_factory.dart';
 import 'package:memora/presentation/shared/dialogs/delete_confirm_dialog.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:memora/application/usecases/member/get_managed_members_usecase.dart';
@@ -11,27 +9,13 @@ import 'package:memora/application/usecases/member/update_member_usecase.dart';
 import 'package:memora/application/usecases/member/delete_member_usecase.dart';
 import 'package:memora/application/usecases/member/get_member_by_id_usecase.dart';
 import 'package:memora/domain/entities/member.dart';
-import 'package:memora/domain/repositories/member_repository.dart';
-import 'package:memora/domain/repositories/member_event_repository.dart';
-import 'package:memora/domain/repositories/member_invitation_repository.dart';
 import 'member_edit_modal.dart';
 import 'package:memora/core/app_logger.dart';
 
 class MemberManagement extends ConsumerStatefulWidget {
   final Member member;
-  final MemberRepository? memberRepository;
-  final GroupRepository? groupRepository;
-  final MemberEventRepository? memberEventRepository;
-  final MemberInvitationRepository? memberInvitationRepository;
 
-  const MemberManagement({
-    super.key,
-    required this.member,
-    this.memberRepository,
-    this.groupRepository,
-    this.memberEventRepository,
-    this.memberInvitationRepository,
-  });
+  const MemberManagement({super.key, required this.member});
 
   @override
   ConsumerState<MemberManagement> createState() => _MemberManagementState();
@@ -53,27 +37,14 @@ class _MemberManagementState extends ConsumerState<MemberManagement> {
   void initState() {
     super.initState();
 
-    final MemberRepository memberRepository =
-        widget.memberRepository ?? ref.read(memberRepositoryProvider);
-    final GroupRepository groupRepository =
-        widget.groupRepository ?? ref.read(groupRepositoryProvider);
-    final MemberEventRepository memberEventRepository =
-        widget.memberEventRepository ?? ref.read(memberEventRepositoryProvider);
-    final MemberInvitationRepository memberInvitationRepository =
-        widget.memberInvitationRepository ??
-        ref.read(memberInvitationRepositoryProvider);
-
-    _getManagedMembersUsecase = GetManagedMembersUsecase(memberRepository);
-    _createMemberUsecase = CreateMemberUsecase(memberRepository);
-    _updateMemberUsecase = UpdateMemberUsecase(memberRepository);
-    _deleteMemberUsecase = DeleteMemberUsecase(
-      memberRepository,
-      groupRepository,
-      memberEventRepository,
+    _getManagedMembersUsecase = ref.read(getManagedMembersUsecaseProvider);
+    _createMemberUsecase = ref.read(createMemberUsecaseProvider);
+    _updateMemberUsecase = ref.read(updateMemberUsecaseProvider);
+    _deleteMemberUsecase = ref.read(deleteMemberUsecaseProvider);
+    _getMemberByIdUseCase = ref.read(getMemberByIdUsecaseProvider);
+    _createOrUpdateMemberInvitationUsecase = ref.read(
+      createOrUpdateMemberInvitationUsecaseProvider,
     );
-    _getMemberByIdUseCase = GetMemberByIdUseCase(memberRepository);
-    _createOrUpdateMemberInvitationUsecase =
-        CreateOrUpdateMemberInvitationUsecase(memberInvitationRepository);
 
     _loadData();
   }

--- a/lib/presentation/features/timeline/group_list.dart
+++ b/lib/presentation/features/timeline/group_list.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:memora/application/interfaces/group_query_service.dart';
 import 'package:memora/application/usecases/group/get_groups_with_members_usecase.dart';
-import 'package:memora/infrastructure/factories/query_service_factory.dart';
 import 'package:memora/domain/entities/member.dart';
 import 'package:memora/application/dtos/group/group_with_members_dto.dart';
 import 'package:memora/core/app_logger.dart';
@@ -12,14 +10,8 @@ enum GroupListState { loading, groupList, empty, error }
 class GroupList extends ConsumerStatefulWidget {
   final Member member;
   final void Function(GroupWithMembersDto)? onGroupSelected;
-  final GroupQueryService? groupQueryService;
 
-  const GroupList({
-    super.key,
-    required this.member,
-    this.onGroupSelected,
-    this.groupQueryService,
-  });
+  const GroupList({super.key, required this.member, this.onGroupSelected});
 
   @override
   ConsumerState<GroupList> createState() => _GroupListState();
@@ -35,11 +27,8 @@ class _GroupListState extends ConsumerState<GroupList> {
   void initState() {
     super.initState();
 
-    final GroupQueryService groupQueryService =
-        widget.groupQueryService ?? ref.read(groupQueryServiceProvider);
-
-    _getGroupsWithMembersUsecase = GetGroupsWithMembersUsecase(
-      groupQueryService,
+    _getGroupsWithMembersUsecase = ref.read(
+      getGroupsWithMembersUsecaseProvider,
     );
 
     _loadData();

--- a/lib/presentation/features/timeline/group_timeline.dart
+++ b/lib/presentation/features/timeline/group_timeline.dart
@@ -3,9 +3,7 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:memora/application/usecases/trip/get_trip_entries_usecase.dart';
-import 'package:memora/domain/repositories/trip_entry_repository.dart';
 import 'package:memora/application/dtos/group/group_with_members_dto.dart';
-import 'package:memora/infrastructure/factories/repository_factory.dart';
 import 'package:memora/core/formatters/japanese_era_formatter.dart';
 import 'package:memora/domain/entities/trip_entry.dart';
 import 'package:memora/presentation/shared/displays/trip_cell.dart';
@@ -22,13 +20,11 @@ class GroupTimeline extends ConsumerStatefulWidget {
   final GroupWithMembersDto groupWithMembers;
   final VoidCallback? onBackPressed;
   final Function(String groupId, int year)? onTripManagementSelected;
-  final TripEntryRepository? tripEntryRepository;
   final Function(VoidCallback)? onSetRefreshCallback;
 
   const GroupTimeline({
     super.key,
     required this.groupWithMembers,
-    this.tripEntryRepository,
     this.onBackPressed,
     this.onTripManagementSelected,
     this.onSetRefreshCallback,
@@ -77,10 +73,7 @@ class _GroupTimelineState extends ConsumerState<GroupTimeline> {
   void initState() {
     super.initState();
 
-    final TripEntryRepository tripEntryRepository =
-        widget.tripEntryRepository ?? ref.read(tripEntryRepositoryProvider);
-
-    _getTripEntriesUsecase = GetTripEntriesUsecase(tripEntryRepository);
+    _getTripEntriesUsecase = ref.read(getTripEntriesUsecaseProvider);
     final totalDataRows = 2 + widget.groupWithMembers.members.length;
     _rowHeights = List.filled(totalDataRows, _dataRowHeight);
 

--- a/lib/presentation/features/trip/trip_management.dart
+++ b/lib/presentation/features/trip/trip_management.dart
@@ -7,8 +7,6 @@ import 'package:memora/application/usecases/trip/update_trip_entry_usecase.dart'
 import 'package:memora/application/usecases/trip/get_trip_entry_by_id_usecase.dart';
 import 'package:memora/application/usecases/trip/delete_trip_entry_usecase.dart';
 import 'package:memora/domain/entities/trip_entry.dart';
-import 'package:memora/domain/repositories/trip_entry_repository.dart';
-import 'package:memora/infrastructure/factories/repository_factory.dart';
 import 'package:memora/presentation/shared/dialogs/delete_confirm_dialog.dart';
 import 'trip_edit_modal.dart';
 import 'package:memora/core/app_logger.dart';
@@ -17,7 +15,6 @@ class TripManagement extends ConsumerStatefulWidget {
   final String groupId;
   final int year;
   final VoidCallback? onBackPressed;
-  final TripEntryRepository? tripEntryRepository;
   final bool isTestEnvironment;
 
   const TripManagement({
@@ -25,7 +22,6 @@ class TripManagement extends ConsumerStatefulWidget {
     required this.groupId,
     required this.year,
     this.onBackPressed,
-    this.tripEntryRepository,
     this.isTestEnvironment = false,
   });
 
@@ -47,14 +43,11 @@ class _TripManagementState extends ConsumerState<TripManagement> {
   void initState() {
     super.initState();
 
-    final TripEntryRepository tripEntryRepository =
-        widget.tripEntryRepository ?? ref.read(tripEntryRepositoryProvider);
-
-    _getTripEntriesUsecase = GetTripEntriesUsecase(tripEntryRepository);
-    _createTripEntryUsecase = CreateTripEntryUsecase(tripEntryRepository);
-    _updateTripEntryUsecase = UpdateTripEntryUsecase(tripEntryRepository);
-    _deleteTripEntryUsecase = DeleteTripEntryUsecase(tripEntryRepository);
-    _getTripEntryByIdUsecase = GetTripEntryByIdUsecase(tripEntryRepository);
+    _getTripEntriesUsecase = ref.read(getTripEntriesUsecaseProvider);
+    _createTripEntryUsecase = ref.read(createTripEntryUsecaseProvider);
+    _updateTripEntryUsecase = ref.read(updateTripEntryUsecaseProvider);
+    _deleteTripEntryUsecase = ref.read(deleteTripEntryUsecaseProvider);
+    _getTripEntryByIdUsecase = ref.read(getTripEntryByIdUsecaseProvider);
 
     _loadTripEntries();
   }

--- a/lib/presentation/notifiers/auth_notifier.dart
+++ b/lib/presentation/notifiers/auth_notifier.dart
@@ -4,34 +4,10 @@ import 'package:memora/domain/value_objects/auth_state.dart';
 import 'package:memora/domain/entities/user.dart';
 import 'package:memora/application/interfaces/auth_service.dart';
 import 'package:memora/infrastructure/factories/auth_service_factory.dart';
-import 'package:memora/infrastructure/factories/repository_factory.dart';
 import 'package:memora/application/usecases/member/check_member_exists_usecase.dart';
 import 'package:memora/application/usecases/member/create_member_from_user_usecase.dart';
 import 'package:memora/application/usecases/member/accept_invitation_usecase.dart';
 import 'package:memora/core/app_logger.dart';
-
-final checkMemberExistsUseCaseProvider = Provider<CheckMemberExistsUseCase>((
-  ref,
-) {
-  final memberRepository = ref.watch(memberRepositoryProvider);
-  return CheckMemberExistsUseCase(memberRepository);
-});
-
-final createMemberFromUserUseCaseProvider =
-    Provider<CreateMemberFromUserUseCase>((ref) {
-      final memberRepository = ref.watch(memberRepositoryProvider);
-      return CreateMemberFromUserUseCase(memberRepository);
-    });
-
-final acceptInvitationUseCaseProvider = Provider<AcceptInvitationUseCase>((
-  ref,
-) {
-  final memberInvitationRepository = ref.watch(
-    memberInvitationRepositoryProvider,
-  );
-  final memberRepository = ref.watch(memberRepositoryProvider);
-  return AcceptInvitationUseCase(memberInvitationRepository, memberRepository);
-});
 
 final authNotifierProvider = StateNotifierProvider<AuthNotifier, AuthState>((
   ref,

--- a/test/unit/main_test.dart
+++ b/test/unit/main_test.dart
@@ -10,6 +10,9 @@ import 'package:memora/domain/entities/user.dart';
 import 'package:memora/domain/repositories/member_repository.dart';
 import 'package:memora/presentation/notifiers/auth_notifier.dart';
 import 'package:memora/presentation/app/top_page.dart';
+import 'package:memora/infrastructure/factories/auth_service_factory.dart';
+import 'package:memora/infrastructure/factories/query_service_factory.dart';
+import 'package:memora/infrastructure/factories/repository_factory.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 
@@ -65,17 +68,15 @@ void main() {
         authNotifierProvider.overrideWith((ref) {
           return FakeAuthNotifier.authenticated();
         }),
+        memberRepositoryProvider.overrideWithValue(mockMemberRepository),
+        authServiceProvider.overrideWithValue(mockAuthService),
+        groupQueryServiceProvider.overrideWithValue(mockGroupQueryService),
+        pinQueryServiceProvider.overrideWithValue(mockPinQueryService),
       ],
       child: MaterialApp(
         title: 'memora',
         locale: const Locale('ja'),
-        home: TopPage(
-          isTestEnvironment: true,
-          memberRepository: mockMemberRepository,
-          authService: mockAuthService,
-          groupQueryService: mockGroupQueryService,
-          pinQueryService: mockPinQueryService,
-        ),
+        home: TopPage(isTestEnvironment: true),
       ),
     );
   }

--- a/test/unit/presentation/app/top_page_test.dart
+++ b/test/unit/presentation/app/top_page_test.dart
@@ -11,6 +11,9 @@ import 'package:memora/presentation/notifiers/navigation_notifier.dart';
 import 'package:memora/domain/entities/member.dart';
 import 'package:memora/domain/entities/user.dart';
 import 'package:memora/domain/repositories/member_repository.dart';
+import 'package:memora/infrastructure/factories/auth_service_factory.dart';
+import 'package:memora/infrastructure/factories/query_service_factory.dart';
+import 'package:memora/infrastructure/factories/repository_factory.dart';
 import 'package:memora/application/dtos/group/group_with_members_dto.dart';
 import 'package:memora/application/dtos/member/member_dto.dart';
 import 'package:memora/presentation/app/top_page.dart';
@@ -132,16 +135,12 @@ void main() {
         authNotifierProvider.overrideWith((ref) {
           return FakeAuthNotifier.authenticated();
         }),
+        memberRepositoryProvider.overrideWithValue(testMemberRepository),
+        authServiceProvider.overrideWithValue(testAuthService),
+        groupQueryServiceProvider.overrideWithValue(mockGroupQueryService),
+        pinQueryServiceProvider.overrideWithValue(mockPinQueryService),
       ],
-      child: MaterialApp(
-        home: TopPage(
-          isTestEnvironment: true,
-          memberRepository: testMemberRepository,
-          authService: testAuthService,
-          groupQueryService: mockGroupQueryService,
-          pinQueryService: mockPinQueryService,
-        ),
-      ),
+      child: MaterialApp(home: TopPage(isTestEnvironment: true)),
     );
   }
 
@@ -549,16 +548,12 @@ void main() {
           groupTimelineNavigationNotifierProvider.overrideWith((ref) {
             return _TestGroupTimelineNavigationNotifier();
           }),
+          memberRepositoryProvider.overrideWithValue(mockMemberRepository),
+          authServiceProvider.overrideWithValue(mockAuthService),
+          groupQueryServiceProvider.overrideWithValue(mockGroupQueryService),
+          pinQueryServiceProvider.overrideWithValue(mockPinQueryService),
         ],
-        child: MaterialApp(
-          home: TopPage(
-            isTestEnvironment: true,
-            memberRepository: mockMemberRepository,
-            authService: mockAuthService,
-            groupQueryService: mockGroupQueryService,
-            pinQueryService: mockPinQueryService,
-          ),
-        ),
+        child: MaterialApp(home: TopPage(isTestEnvironment: true)),
       );
 
       // Act
@@ -608,16 +603,12 @@ void main() {
       final widget = ProviderScope(
         overrides: [
           authNotifierProvider.overrideWith((ref) => fakeAuthNotifier),
+          memberRepositoryProvider.overrideWithValue(testMemberRepository),
+          authServiceProvider.overrideWithValue(testAuthService),
+          groupQueryServiceProvider.overrideWithValue(mockGroupQueryService),
+          pinQueryServiceProvider.overrideWithValue(mockPinQueryService),
         ],
-        child: MaterialApp(
-          home: TopPage(
-            isTestEnvironment: true,
-            memberRepository: testMemberRepository,
-            authService: testAuthService,
-            groupQueryService: mockGroupQueryService,
-            pinQueryService: mockPinQueryService,
-          ),
-        ),
+        child: MaterialApp(home: TopPage(isTestEnvironment: true)),
       );
 
       // Act

--- a/test/unit/presentation/features/account_setting/account_settings_test.dart
+++ b/test/unit/presentation/features/account_setting/account_settings_test.dart
@@ -1,29 +1,81 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:memora/application/interfaces/auth_service.dart';
+import 'package:memora/domain/entities/user.dart';
+import 'package:memora/infrastructure/factories/auth_service_factory.dart';
 import 'package:memora/presentation/features/account_setting/account_settings.dart';
+
+class _FakeAuthService implements AuthService {
+  @override
+  Future<void> createUserWithEmailAndPassword({
+    required String email,
+    required String password,
+  }) async {}
+
+  @override
+  Stream<User?> get authStateChanges => Stream<User?>.empty();
+
+  @override
+  Future<User?> getCurrentUser() async => null;
+
+  @override
+  Future<void> deleteUser() async {}
+
+  @override
+  Future<void> reauthenticate({required String password}) async {}
+
+  @override
+  Future<void> sendEmailVerification() async {}
+
+  @override
+  Future<void> signInWithEmailAndPassword({
+    required String email,
+    required String password,
+  }) async {}
+
+  @override
+  Future<void> signOut() async {}
+
+  @override
+  Future<void> updateEmail({required String newEmail}) async {}
+
+  @override
+  Future<void> updatePassword({required String newPassword}) async {}
+
+  @override
+  Future<void> validateCurrentUserToken() async {}
+}
+
+Widget _buildTestApp(Widget child) {
+  return ProviderScope(
+    overrides: [authServiceProvider.overrideWithValue(_FakeAuthService())],
+    child: MaterialApp(home: child),
+  );
+}
 
 void main() {
   group('AccountSettings', () {
     testWidgets('アカウント設定画面が表示される', (WidgetTester tester) async {
-      await tester.pumpWidget(const MaterialApp(home: AccountSettings()));
+      await tester.pumpWidget(_buildTestApp(const AccountSettings()));
 
       expect(find.text('アカウント設定'), findsOneWidget);
     });
 
     testWidgets('メールアドレス変更セクションが表示される', (WidgetTester tester) async {
-      await tester.pumpWidget(const MaterialApp(home: AccountSettings()));
+      await tester.pumpWidget(_buildTestApp(const AccountSettings()));
 
       expect(find.text('メールアドレス変更'), findsOneWidget);
     });
 
     testWidgets('パスワード変更セクションが表示される', (WidgetTester tester) async {
-      await tester.pumpWidget(const MaterialApp(home: AccountSettings()));
+      await tester.pumpWidget(_buildTestApp(const AccountSettings()));
 
       expect(find.text('パスワード変更'), findsOneWidget);
     });
 
     testWidgets('アカウント削除セクションが表示される', (WidgetTester tester) async {
-      await tester.pumpWidget(const MaterialApp(home: AccountSettings()));
+      await tester.pumpWidget(_buildTestApp(const AccountSettings()));
 
       expect(find.text('アカウント削除'), findsOneWidget);
     });

--- a/test/unit/presentation/features/map/map_screen_test.dart
+++ b/test/unit/presentation/features/map/map_screen_test.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:memora/application/dtos/pin/pin_dto.dart';
 import 'package:memora/application/interfaces/pin_query_service.dart';
 import 'package:memora/domain/entities/member.dart';
+import 'package:memora/infrastructure/factories/query_service_factory.dart';
 import 'package:memora/presentation/features/map/map_screen.dart';
 import 'package:memora/presentation/shared/map_views/placeholder_map_view.dart';
 import 'package:mockito/annotations.dart';
@@ -22,12 +24,13 @@ void main() {
       ).thenAnswer((_) async => []);
 
       await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: MapScreen(
-              member: testMember,
-              isTestEnvironment: true,
-              pinQueryService: mockPinQueryService,
+        ProviderScope(
+          overrides: [
+            pinQueryServiceProvider.overrideWithValue(mockPinQueryService),
+          ],
+          child: MaterialApp(
+            home: Scaffold(
+              body: MapScreen(member: testMember, isTestEnvironment: true),
             ),
           ),
         ),
@@ -61,12 +64,13 @@ void main() {
       ).thenAnswer((_) async => testPins);
 
       await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: MapScreen(
-              member: testMember,
-              isTestEnvironment: true,
-              pinQueryService: mockPinQueryService,
+        ProviderScope(
+          overrides: [
+            pinQueryServiceProvider.overrideWithValue(mockPinQueryService),
+          ],
+          child: MaterialApp(
+            home: Scaffold(
+              body: MapScreen(member: testMember, isTestEnvironment: true),
             ),
           ),
         ),

--- a/test/unit/presentation/features/member/member_management_test.dart
+++ b/test/unit/presentation/features/member/member_management_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:memora/core/app_logger.dart';
 import 'package:mockito/annotations.dart';
@@ -8,6 +9,7 @@ import 'package:memora/domain/repositories/member_repository.dart';
 import 'package:memora/domain/repositories/group_repository.dart';
 import 'package:memora/domain/repositories/member_event_repository.dart';
 import 'package:memora/domain/repositories/member_invitation_repository.dart';
+import 'package:memora/infrastructure/factories/repository_factory.dart';
 import 'package:memora/presentation/features/member/member_management.dart';
 import '../../../../helpers/test_exception.dart';
 
@@ -25,6 +27,7 @@ void main() {
   late MockMemberEventRepository mockMemberEventRepository;
   late MockMemberInvitationRepository mockMemberInvitationRepository;
   late Member testMember;
+  late List<Override> providerOverrides;
 
   setUp(() {
     mockMemberRepository = MockMemberRepository();
@@ -55,7 +58,29 @@ void main() {
     when(
       mockMemberRepository.getMemberById(testMember.id),
     ).thenAnswer((_) async => testMember);
+
+    providerOverrides = [
+      memberRepositoryProvider.overrideWithValue(mockMemberRepository),
+      groupRepositoryProvider.overrideWithValue(mockGroupRepository),
+      memberEventRepositoryProvider.overrideWithValue(
+        mockMemberEventRepository,
+      ),
+      memberInvitationRepositoryProvider.overrideWithValue(
+        mockMemberInvitationRepository,
+      ),
+    ];
   });
+
+  Widget createApp({Member? member, Widget? home}) {
+    final defaultHome = Scaffold(
+      body: MemberManagement(member: member ?? testMember),
+    );
+
+    return ProviderScope(
+      overrides: providerOverrides,
+      child: MaterialApp(home: home ?? defaultHome),
+    );
+  }
 
   group('MemberManagement', () {
     testWidgets('初期化時にメンバーリストが読み込まれること', (WidgetTester tester) async {
@@ -87,17 +112,7 @@ void main() {
       ).thenAnswer((_) async => managedMembers);
 
       // Act
-      await tester.pumpWidget(
-        MaterialApp(
-          home: MemberManagement(
-            member: testMember,
-            memberRepository: mockMemberRepository,
-            groupRepository: mockGroupRepository,
-            memberEventRepository: mockMemberEventRepository,
-            memberInvitationRepository: mockMemberInvitationRepository,
-          ),
-        ),
-      );
+      await tester.pumpWidget(createApp());
 
       // 初期ローディング状態を確認
       expect(find.byType(CircularProgressIndicator), findsOneWidget);
@@ -156,17 +171,7 @@ void main() {
       ).thenAnswer((_) async => []);
 
       // Act
-      await tester.pumpWidget(
-        MaterialApp(
-          home: MemberManagement(
-            member: testMember,
-            memberRepository: mockMemberRepository,
-            groupRepository: mockGroupRepository,
-            memberEventRepository: mockMemberEventRepository,
-            memberInvitationRepository: mockMemberInvitationRepository,
-          ),
-        ),
-      );
+      await tester.pumpWidget(createApp());
 
       await tester.pumpAndSettle();
 
@@ -183,17 +188,7 @@ void main() {
       ).thenAnswer((_) async => []);
 
       // Act
-      await tester.pumpWidget(
-        MaterialApp(
-          home: MemberManagement(
-            member: testMember,
-            memberRepository: mockMemberRepository,
-            groupRepository: mockGroupRepository,
-            memberEventRepository: mockMemberEventRepository,
-            memberInvitationRepository: mockMemberInvitationRepository,
-          ),
-        ),
-      );
+      await tester.pumpWidget(createApp());
 
       await tester.pumpAndSettle();
 
@@ -209,19 +204,7 @@ void main() {
       ).thenThrow(TestException('Network error'));
 
       // Act
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: MemberManagement(
-              member: testMember,
-              memberRepository: mockMemberRepository,
-              groupRepository: mockGroupRepository,
-              memberEventRepository: mockMemberEventRepository,
-              memberInvitationRepository: mockMemberInvitationRepository,
-            ),
-          ),
-        ),
-      );
+      await tester.pumpWidget(createApp());
 
       await tester.pumpAndSettle();
 
@@ -261,17 +244,7 @@ void main() {
       ).thenAnswer((_) async => managedMembers);
 
       // Act
-      await tester.pumpWidget(
-        MaterialApp(
-          home: MemberManagement(
-            member: testMember,
-            memberRepository: mockMemberRepository,
-            groupRepository: mockGroupRepository,
-            memberEventRepository: mockMemberEventRepository,
-            memberInvitationRepository: mockMemberInvitationRepository,
-          ),
-        ),
-      );
+      await tester.pumpWidget(createApp());
 
       await tester.pumpAndSettle();
 
@@ -316,17 +289,7 @@ void main() {
       ).thenAnswer((_) async => managedMembers);
 
       // Act
-      await tester.pumpWidget(
-        MaterialApp(
-          home: MemberManagement(
-            member: testMember,
-            memberRepository: mockMemberRepository,
-            groupRepository: mockGroupRepository,
-            memberEventRepository: mockMemberEventRepository,
-            memberInvitationRepository: mockMemberInvitationRepository,
-          ),
-        ),
-      );
+      await tester.pumpWidget(createApp());
 
       await tester.pumpAndSettle();
 
@@ -372,17 +335,7 @@ void main() {
       when(mockMemberRepository.updateMember(any)).thenAnswer((_) async {});
 
       // Act
-      await tester.pumpWidget(
-        MaterialApp(
-          home: MemberManagement(
-            member: testMember,
-            memberRepository: mockMemberRepository,
-            groupRepository: mockGroupRepository,
-            memberEventRepository: mockMemberEventRepository,
-            memberInvitationRepository: mockMemberInvitationRepository,
-          ),
-        ),
-      );
+      await tester.pumpWidget(createApp());
 
       await tester.pumpAndSettle();
 
@@ -419,19 +372,7 @@ void main() {
       ).thenAnswer((_) async => null); // nullを返すように設定
 
       // Act
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: MemberManagement(
-              member: testMember,
-              memberRepository: mockMemberRepository,
-              groupRepository: mockGroupRepository,
-              memberEventRepository: mockMemberEventRepository,
-              memberInvitationRepository: mockMemberInvitationRepository,
-            ),
-          ),
-        ),
-      );
+      await tester.pumpWidget(createApp());
 
       await tester.pumpAndSettle();
 
@@ -466,17 +407,7 @@ void main() {
       ).thenAnswer((_) async => managedMembers);
 
       // Act
-      await tester.pumpWidget(
-        MaterialApp(
-          home: MemberManagement(
-            member: testMember,
-            memberRepository: mockMemberRepository,
-            groupRepository: mockGroupRepository,
-            memberEventRepository: mockMemberEventRepository,
-            memberInvitationRepository: mockMemberInvitationRepository,
-          ),
-        ),
-      );
+      await tester.pumpWidget(createApp());
 
       await tester.pumpAndSettle();
 
@@ -584,17 +515,7 @@ void main() {
       });
 
       // Act
-      await tester.pumpWidget(
-        MaterialApp(
-          home: MemberManagement(
-            member: testMember,
-            memberRepository: mockMemberRepository,
-            groupRepository: mockGroupRepository,
-            memberEventRepository: mockMemberEventRepository,
-            memberInvitationRepository: mockMemberInvitationRepository,
-          ),
-        ),
-      );
+      await tester.pumpWidget(createApp());
 
       await tester.pumpAndSettle();
 
@@ -643,17 +564,7 @@ void main() {
       ).thenAnswer((_) async => managedMembers);
 
       // Act
-      await tester.pumpWidget(
-        MaterialApp(
-          home: MemberManagement(
-            member: testMember,
-            memberRepository: mockMemberRepository,
-            groupRepository: mockGroupRepository,
-            memberEventRepository: mockMemberEventRepository,
-            memberInvitationRepository: mockMemberInvitationRepository,
-          ),
-        ),
-      );
+      await tester.pumpWidget(createApp());
 
       await tester.pumpAndSettle();
 
@@ -692,17 +603,7 @@ void main() {
       ).thenAnswer((_) async {});
 
       // Act
-      await tester.pumpWidget(
-        MaterialApp(
-          home: MemberManagement(
-            member: testMember,
-            memberRepository: mockMemberRepository,
-            groupRepository: mockGroupRepository,
-            memberEventRepository: mockMemberEventRepository,
-            memberInvitationRepository: mockMemberInvitationRepository,
-          ),
-        ),
-      );
+      await tester.pumpWidget(createApp());
 
       await tester.pumpAndSettle();
 
@@ -733,17 +634,7 @@ void main() {
       ).thenAnswer((_) async => []);
 
       // Act
-      await tester.pumpWidget(
-        MaterialApp(
-          home: MemberManagement(
-            member: testMember,
-            memberRepository: mockMemberRepository,
-            groupRepository: mockGroupRepository,
-            memberEventRepository: mockMemberEventRepository,
-            memberInvitationRepository: mockMemberInvitationRepository,
-          ),
-        ),
-      );
+      await tester.pumpWidget(createApp());
 
       await tester.pumpAndSettle();
 

--- a/test/unit/presentation/features/timeline/group_list_test.dart
+++ b/test/unit/presentation/features/timeline/group_list_test.dart
@@ -6,6 +6,7 @@ import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:memora/application/interfaces/group_query_service.dart';
 import 'package:memora/domain/entities/member.dart';
+import 'package:memora/infrastructure/factories/query_service_factory.dart';
 import 'package:memora/presentation/features/timeline/group_list.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../../helpers/test_exception.dart';
@@ -42,13 +43,11 @@ void main() {
 
   Widget createTestWidget({Member? member}) {
     return ProviderScope(
+      overrides: [
+        groupQueryServiceProvider.overrideWithValue(mockGroupQueryService),
+      ],
       child: MaterialApp(
-        home: Scaffold(
-          body: GroupList(
-            groupQueryService: mockGroupQueryService,
-            member: member ?? testMember,
-          ),
-        ),
+        home: Scaffold(body: GroupList(member: member ?? testMember)),
       ),
     );
   }
@@ -179,10 +178,12 @@ void main() {
       // Act
       await tester.pumpWidget(
         ProviderScope(
+          overrides: [
+            groupQueryServiceProvider.overrideWithValue(mockGroupQueryService),
+          ],
           child: MaterialApp(
             home: Scaffold(
               body: GroupList(
-                groupQueryService: mockGroupQueryService,
                 member: testMember,
                 onGroupSelected: (groupWithMembers) {
                   selectedGroup = groupWithMembers;

--- a/test/unit/presentation/features/timeline/group_timeline_test.dart
+++ b/test/unit/presentation/features/timeline/group_timeline_test.dart
@@ -8,6 +8,7 @@ import 'package:mockito/annotations.dart';
 import 'package:memora/domain/repositories/trip_entry_repository.dart';
 import 'package:memora/domain/entities/trip_entry.dart';
 import 'package:memora/domain/value_objects/order_by.dart';
+import 'package:memora/infrastructure/factories/repository_factory.dart';
 import 'package:memora/presentation/features/timeline/group_timeline.dart';
 
 import 'group_timeline_test.mocks.dart';
@@ -44,16 +45,17 @@ void main() {
 
   Widget createTestWidget({TripEntryRepository? tripEntryRepository}) {
     return ProviderScope(
+      overrides: [
+        tripEntryRepositoryProvider.overrideWithValue(
+          tripEntryRepository ?? mockTripEntryRepository,
+        ),
+      ],
       child: MaterialApp(
         home: Scaffold(
           body: SizedBox(
             width: 1200, // より広い画面サイズを設定
             height: 800,
-            child: GroupTimeline(
-              groupWithMembers: testGroupWithMembers,
-              tripEntryRepository:
-                  tripEntryRepository ?? mockTripEntryRepository,
-            ),
+            child: GroupTimeline(groupWithMembers: testGroupWithMembers),
           ),
         ),
       ),
@@ -303,15 +305,21 @@ void main() {
       WidgetTester tester,
     ) async {
       // Arrange
-      final widget = MaterialApp(
-        home: Scaffold(
-          body: SizedBox(
-            width: 1200,
-            height: 800,
-            child: GroupTimeline(
-              groupWithMembers: testGroupWithMembers,
-              tripEntryRepository: mockTripEntryRepository,
-              onBackPressed: () {},
+      final widget = ProviderScope(
+        overrides: [
+          tripEntryRepositoryProvider.overrideWithValue(
+            mockTripEntryRepository,
+          ),
+        ],
+        child: MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 1200,
+              height: 800,
+              child: GroupTimeline(
+                groupWithMembers: testGroupWithMembers,
+                onBackPressed: () {},
+              ),
             ),
           ),
         ),
@@ -342,17 +350,23 @@ void main() {
       // Arrange
       bool callbackCalled = false;
 
-      final widget = MaterialApp(
-        home: Scaffold(
-          body: SizedBox(
-            width: 1200,
-            height: 800,
-            child: GroupTimeline(
-              groupWithMembers: testGroupWithMembers,
-              tripEntryRepository: mockTripEntryRepository,
-              onBackPressed: () {
-                callbackCalled = true;
-              },
+      final widget = ProviderScope(
+        overrides: [
+          tripEntryRepositoryProvider.overrideWithValue(
+            mockTripEntryRepository,
+          ),
+        ],
+        child: MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 1200,
+              height: 800,
+              child: GroupTimeline(
+                groupWithMembers: testGroupWithMembers,
+                onBackPressed: () {
+                  callbackCalled = true;
+                },
+              ),
             ),
           ),
         ),
@@ -376,18 +390,24 @@ void main() {
       String? selectedGroupId;
       int? selectedYear;
 
-      final widget = MaterialApp(
-        home: Scaffold(
-          body: SizedBox(
-            width: 1200,
-            height: 800,
-            child: GroupTimeline(
-              groupWithMembers: testGroupWithMembers,
-              tripEntryRepository: mockTripEntryRepository,
-              onTripManagementSelected: (groupId, year) {
-                selectedGroupId = groupId;
-                selectedYear = year;
-              },
+      final widget = ProviderScope(
+        overrides: [
+          tripEntryRepositoryProvider.overrideWithValue(
+            mockTripEntryRepository,
+          ),
+        ],
+        child: MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 1200,
+              height: 800,
+              child: GroupTimeline(
+                groupWithMembers: testGroupWithMembers,
+                onTripManagementSelected: (groupId, year) {
+                  selectedGroupId = groupId;
+                  selectedYear = year;
+                },
+              ),
             ),
           ),
         ),
@@ -454,14 +474,20 @@ void main() {
       // Arrange
       VoidCallback? capturedCallback;
 
-      Widget widget = MaterialApp(
-        home: Scaffold(
-          body: GroupTimeline(
-            groupWithMembers: testGroupWithMembers,
-            tripEntryRepository: mockTripEntryRepository,
-            onSetRefreshCallback: (callback) {
-              capturedCallback = callback;
-            },
+      Widget widget = ProviderScope(
+        overrides: [
+          tripEntryRepositoryProvider.overrideWithValue(
+            mockTripEntryRepository,
+          ),
+        ],
+        child: MaterialApp(
+          home: Scaffold(
+            body: GroupTimeline(
+              groupWithMembers: testGroupWithMembers,
+              onSetRefreshCallback: (callback) {
+                capturedCallback = callback;
+              },
+            ),
           ),
         ),
       );

--- a/test/unit/presentation/features/trip/trip_management_test.dart
+++ b/test/unit/presentation/features/trip/trip_management_test.dart
@@ -7,6 +7,7 @@ import 'package:memora/domain/entities/pin.dart';
 import 'package:memora/domain/entities/trip_entry.dart';
 import 'package:memora/domain/repositories/trip_entry_repository.dart';
 import 'package:memora/domain/value_objects/order_by.dart';
+import 'package:memora/infrastructure/factories/repository_factory.dart';
 import 'package:memora/presentation/features/trip/trip_management.dart';
 import '../../../../helpers/test_exception.dart';
 
@@ -55,6 +56,20 @@ void main() {
     detailedTripEntry = testTripEntries.first.copyWith(pins: [testPin]);
   });
 
+  Widget createApp({
+    required Widget home,
+    TripEntryRepository? tripEntryRepository,
+  }) {
+    return ProviderScope(
+      overrides: [
+        tripEntryRepositoryProvider.overrideWithValue(
+          tripEntryRepository ?? mockTripEntryRepository,
+        ),
+      ],
+      child: MaterialApp(home: home),
+    );
+  }
+
   group('TripManagement', () {
     const testGroupId = 'test-group-id';
     const testYear = 2025;
@@ -71,16 +86,13 @@ void main() {
 
       // Act
       await tester.pumpWidget(
-        ProviderScope(
-          child: MaterialApp(
-            home: Scaffold(
-              body: TripManagement(
-                groupId: testGroupId,
-                year: testYear,
-                onBackPressed: null,
-                tripEntryRepository: mockTripEntryRepository,
-                isTestEnvironment: true,
-              ),
+        createApp(
+          home: Scaffold(
+            body: TripManagement(
+              groupId: testGroupId,
+              year: testYear,
+              onBackPressed: null,
+              isTestEnvironment: true,
             ),
           ),
         ),
@@ -126,16 +138,13 @@ void main() {
 
       // Act
       await tester.pumpWidget(
-        ProviderScope(
-          child: MaterialApp(
-            home: Scaffold(
-              body: TripManagement(
-                groupId: testGroupId,
-                year: testYear,
-                onBackPressed: null,
-                tripEntryRepository: mockTripEntryRepository,
-                isTestEnvironment: true,
-              ),
+        createApp(
+          home: Scaffold(
+            body: TripManagement(
+              groupId: testGroupId,
+              year: testYear,
+              onBackPressed: null,
+              isTestEnvironment: true,
             ),
           ),
         ),
@@ -165,16 +174,13 @@ void main() {
 
       // Act
       await tester.pumpWidget(
-        ProviderScope(
-          child: MaterialApp(
-            home: Scaffold(
-              body: TripManagement(
-                groupId: testGroupId,
-                year: testYear,
-                onBackPressed: null,
-                tripEntryRepository: mockTripEntryRepository,
-                isTestEnvironment: true,
-              ),
+        createApp(
+          home: Scaffold(
+            body: TripManagement(
+              groupId: testGroupId,
+              year: testYear,
+              onBackPressed: null,
+              isTestEnvironment: true,
             ),
           ),
         ),
@@ -199,16 +205,13 @@ void main() {
 
       // Act
       await tester.pumpWidget(
-        ProviderScope(
-          child: MaterialApp(
-            home: Scaffold(
-              body: TripManagement(
-                groupId: testGroupId,
-                year: testYear,
-                onBackPressed: null,
-                tripEntryRepository: mockTripEntryRepository,
-                isTestEnvironment: true,
-              ),
+        createApp(
+          home: Scaffold(
+            body: TripManagement(
+              groupId: testGroupId,
+              year: testYear,
+              onBackPressed: null,
+              isTestEnvironment: true,
             ),
           ),
         ),
@@ -235,16 +238,13 @@ void main() {
 
       // Act
       await tester.pumpWidget(
-        ProviderScope(
-          child: MaterialApp(
-            home: Scaffold(
-              body: TripManagement(
-                groupId: testGroupId,
-                year: testYear,
-                onBackPressed: null,
-                tripEntryRepository: mockTripEntryRepository,
-                isTestEnvironment: true,
-              ),
+        createApp(
+          home: Scaffold(
+            body: TripManagement(
+              groupId: testGroupId,
+              year: testYear,
+              onBackPressed: null,
+              isTestEnvironment: true,
             ),
           ),
         ),
@@ -284,15 +284,12 @@ void main() {
       ).thenAnswer((_) async => detailedTripEntry);
       // Act
       await tester.pumpWidget(
-        ProviderScope(
-          child: MaterialApp(
-            home: TripManagement(
-              groupId: testGroupId,
-              year: testYear,
-              onBackPressed: null,
-              tripEntryRepository: mockTripEntryRepository,
-              isTestEnvironment: true,
-            ),
+        createApp(
+          home: TripManagement(
+            groupId: testGroupId,
+            year: testYear,
+            onBackPressed: null,
+            isTestEnvironment: true,
           ),
         ),
       );
@@ -329,16 +326,13 @@ void main() {
 
       // Act
       await tester.pumpWidget(
-        ProviderScope(
-          child: MaterialApp(
-            home: Scaffold(
-              body: TripManagement(
-                groupId: testGroupId,
-                year: testYear,
-                onBackPressed: null,
-                tripEntryRepository: mockTripEntryRepository,
-                isTestEnvironment: true,
-              ),
+        createApp(
+          home: Scaffold(
+            body: TripManagement(
+              groupId: testGroupId,
+              year: testYear,
+              onBackPressed: null,
+              isTestEnvironment: true,
             ),
           ),
         ),
@@ -373,16 +367,13 @@ void main() {
 
       // Act
       await tester.pumpWidget(
-        ProviderScope(
-          child: MaterialApp(
-            home: Scaffold(
-              body: TripManagement(
-                groupId: testGroupId,
-                year: testYear,
-                onBackPressed: null,
-                tripEntryRepository: mockTripEntryRepository,
-                isTestEnvironment: true,
-              ),
+        createApp(
+          home: Scaffold(
+            body: TripManagement(
+              groupId: testGroupId,
+              year: testYear,
+              onBackPressed: null,
+              isTestEnvironment: true,
             ),
           ),
         ),
@@ -421,15 +412,12 @@ void main() {
 
       // Act
       await tester.pumpWidget(
-        ProviderScope(
-          child: MaterialApp(
-            home: TripManagement(
-              groupId: testGroupId,
-              year: testYear,
-              onBackPressed: null,
-              tripEntryRepository: mockTripEntryRepository,
-              isTestEnvironment: true,
-            ),
+        createApp(
+          home: TripManagement(
+            groupId: testGroupId,
+            year: testYear,
+            onBackPressed: null,
+            isTestEnvironment: true,
           ),
         ),
       );
@@ -462,16 +450,13 @@ void main() {
 
       // Act
       await tester.pumpWidget(
-        ProviderScope(
-          child: MaterialApp(
-            home: Scaffold(
-              body: TripManagement(
-                groupId: testGroupId,
-                year: testYear,
-                onBackPressed: null,
-                tripEntryRepository: mockTripEntryRepository,
-                isTestEnvironment: true,
-              ),
+        createApp(
+          home: Scaffold(
+            body: TripManagement(
+              groupId: testGroupId,
+              year: testYear,
+              onBackPressed: null,
+              isTestEnvironment: true,
             ),
           ),
         ),
@@ -505,16 +490,13 @@ void main() {
 
       // Act
       await tester.pumpWidget(
-        ProviderScope(
-          child: MaterialApp(
-            home: Scaffold(
-              body: TripManagement(
-                groupId: testGroupId,
-                year: testYear,
-                onBackPressed: null,
-                tripEntryRepository: mockTripEntryRepository,
-                isTestEnvironment: true,
-              ),
+        createApp(
+          home: Scaffold(
+            body: TripManagement(
+              groupId: testGroupId,
+              year: testYear,
+              onBackPressed: null,
+              isTestEnvironment: true,
             ),
           ),
         ),
@@ -551,18 +533,15 @@ void main() {
 
       // Act
       await tester.pumpWidget(
-        ProviderScope(
-          child: MaterialApp(
-            home: Scaffold(
-              body: TripManagement(
-                groupId: testGroupId,
-                year: testYear,
-                onBackPressed: () {
-                  backPressed = true;
-                },
-                tripEntryRepository: mockTripEntryRepository,
-                isTestEnvironment: true,
-              ),
+        createApp(
+          home: Scaffold(
+            body: TripManagement(
+              groupId: testGroupId,
+              year: testYear,
+              onBackPressed: () {
+                backPressed = true;
+              },
+              isTestEnvironment: true,
             ),
           ),
         ),
@@ -593,15 +572,12 @@ void main() {
 
       // Act
       await tester.pumpWidget(
-        ProviderScope(
-          child: MaterialApp(
-            home: Scaffold(
-              body: TripManagement(
-                groupId: testGroupId,
-                year: testYear,
-                tripEntryRepository: mockTripEntryRepository,
-                isTestEnvironment: true,
-              ),
+        createApp(
+          home: Scaffold(
+            body: TripManagement(
+              groupId: testGroupId,
+              year: testYear,
+              isTestEnvironment: true,
             ),
           ),
         ),


### PR DESCRIPTION
## Summary
- UseCaseを直接生成していた箇所をusecaseのProvider経由のDIに置き換え
- AccountSettingsなどのUIはProviderからUseCaseを取得するよう更新
- テストではProviderScopeのオーバーライドに対応するよう修正

## Related TODO
- docs/todo.md: UseCase Providerを利用するようにリポジトリDIをリファクタリングする

------
https://chatgpt.com/codex/tasks/task_e_68e66fa01e348332a3ff17419ff06cac