### PR TITLE
docs: グループ年表遷移共通化のtodoを追加

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -51,7 +51,7 @@
 ## リファクタリング
 
 - グループ年表の次画面遷移を、遷移先を表す共通表現（新規型。仮称: `GroupTimelineDestination`）に整理し、行クラスごとの個別コールバック依存をなくす
-- `TripRow` と `DvcRow` の遷移要求を共通の遷移先表現へ揃え、`buildDefaultTimelineRows()` の個別引数依存を解消する
+- `TripRow` と `DvcRow` の行実装を共通化するのではなく、遷移要求を受け渡す引数インタフェースのみを共通化し、`buildDefaultTimelineRows()` の個別引数依存を解消する
 - `group_timeline_navigation_notifier.dart` の `selectedGroupId` / `selectedYear` / 個別画面遷移管理を共通の遷移先管理へ整理する
 - `_buildGroupTimelineStack` の個別画面分岐を共通の遷移先に基づく描画へ整理する
 - グループ年表遷移まわりの notifier / widget テストを共通化後の設計に合わせて更新する

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -50,7 +50,7 @@
 
 ## リファクタリング
 
-- グループ年表の次画面遷移を `GroupTimelineDestination` などの共通表現に整理し、行クラスごとの個別コールバック依存をなくす
+- グループ年表の次画面遷移を、遷移先を表す共通表現（新規型。仮称: `GroupTimelineDestination`）に整理し、行クラスごとの個別コールバック依存をなくす
 - `TripRow` と `DvcRow` の遷移要求を共通の遷移先表現へ揃え、`buildDefaultTimelineRows()` の個別引数依存を解消する
 - `group_timeline_navigation_notifier.dart` の `selectedGroupId` / `selectedYear` / 個別画面遷移管理を共通の遷移先管理へ整理する
 - `_buildGroupTimelineStack` の個別画面分岐を共通の遷移先に基づく描画へ整理する

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -50,4 +50,10 @@
 
 ## リファクタリング
 
+- グループ年表の次画面遷移を `GroupTimelineDestination` などの共通表現に整理し、行クラスごとの個別コールバック依存をなくす
+- `TripRow` と `DvcRow` の遷移要求を共通の遷移先表現へ揃え、`buildDefaultTimelineRows()` の個別引数依存を解消する
+- `group_timeline_navigation_notifier.dart` の `selectedGroupId` / `selectedYear` / 個別画面遷移管理を共通の遷移先管理へ整理する
+- `_buildGroupTimelineStack` の個別画面分岐を共通の遷移先に基づく描画へ整理する
+- グループ年表遷移まわりの notifier / widget テストを共通化後の設計に合わせて更新する
+
 ## 不具合修正


### PR DESCRIPTION
## 概要
- グループ年表の次画面遷移共通化に向けた todo を `docs/todo.md` に追加
- 実装対象がぶれないよう、作業を明確なサブタスクに分解

## 変更内容
- `GroupTimelineDestination` などの共通表現への整理
- `TripRow` / `DvcRow` の個別引数依存解消
- `group_timeline_navigation_notifier.dart` の個別画面遷移管理整理
- `_buildGroupTimelineStack` の個別画面分岐整理
- 関連 notifier / widget テスト更新

## 影響
- ドキュメントのみの更新
- 実装コードの変更はなし

## 検証
- 差分確認のみ
- テスト未実行（ドキュメント変更のみのため）