### PR TITLE
refactor(timeline): 遷移先定義名からgroupを削除

### DIFF
--- a/lib/presentation/features/timeline/dvc_row.dart
+++ b/lib/presentation/features/timeline/dvc_row.dart
@@ -6,7 +6,7 @@ import 'package:memora/core/app_logger.dart';
 import 'package:memora/presentation/features/dvc/dvc_point_usage_detail_modal.dart';
 import 'package:memora/presentation/features/dvc/dvc_point_calculation_screen.dart';
 import 'package:memora/presentation/features/dvc/dvc_point_calculation_date_utils.dart';
-import 'package:memora/presentation/features/timeline/group_timeline_destination_page_definition.dart';
+import 'package:memora/presentation/features/timeline/timeline_destination_page_definition.dart';
 import 'package:memora/presentation/features/timeline/timeline_row_definition.dart';
 import 'package:memora/presentation/features/timeline/timeline_overflow_cell.dart';
 import 'package:memora/presentation/notifiers/group_timeline_destination.dart';
@@ -34,10 +34,8 @@ class DvcRow extends TimelineRowDefinition {
   Key yearCellKey(int year) => Key('dvc_point_usage_cell_$year');
 
   @override
-  Iterable<GroupTimelineDestinationPageDefinition>
-  get destinationPageDefinitions => const [
-    _DvcPointCalculationDestinationPageDefinition(),
-  ];
+  Iterable<TimelineDestinationPageDefinition> get destinationPageDefinitions =>
+      const [_DvcPointCalculationDestinationPageDefinition()];
 
   @override
   Widget buildFixedColumn(BuildContext context, TimelineRowContext rowContext) {
@@ -100,7 +98,7 @@ class DvcRow extends TimelineRowDefinition {
 }
 
 class _DvcPointCalculationDestinationPageDefinition
-    extends GroupTimelineDestinationPageDefinition {
+    extends TimelineDestinationPageDefinition {
   const _DvcPointCalculationDestinationPageDefinition();
 
   @override

--- a/lib/presentation/features/timeline/timeline_destination_page_definition.dart
+++ b/lib/presentation/features/timeline/timeline_destination_page_definition.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:memora/presentation/notifiers/group_timeline_destination.dart';
 
-abstract class GroupTimelineDestinationPageDefinition {
-  const GroupTimelineDestinationPageDefinition();
+abstract class TimelineDestinationPageDefinition {
+  const TimelineDestinationPageDefinition();
 
   bool matches(GroupTimelineDestination destination);
 

--- a/lib/presentation/features/timeline/timeline_row_definition.dart
+++ b/lib/presentation/features/timeline/timeline_row_definition.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:memora/presentation/features/timeline/group_timeline_destination_page_definition.dart';
+import 'package:memora/presentation/features/timeline/timeline_destination_page_definition.dart';
 import 'package:memora/presentation/features/timeline/timeline_controller.dart';
 import 'package:memora/presentation/features/timeline/timeline_layout_config.dart';
 
@@ -23,8 +23,8 @@ abstract class TimelineRowDefinition {
   String get fixedColumnLabel;
   double get initialHeight;
   Color? get backgroundColor;
-  Iterable<GroupTimelineDestinationPageDefinition>
-  get destinationPageDefinitions => const [];
+  Iterable<TimelineDestinationPageDefinition> get destinationPageDefinitions =>
+      const [];
 
   Key? yearCellKey(int year) => null;
 

--- a/lib/presentation/features/timeline/trip_row.dart
+++ b/lib/presentation/features/timeline/trip_row.dart
@@ -3,7 +3,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:memora/application/dtos/trip/trip_entry_dto.dart';
 import 'package:memora/application/usecases/trip/get_trip_entries_usecase.dart';
 import 'package:memora/core/app_logger.dart';
-import 'package:memora/presentation/features/timeline/group_timeline_destination_page_definition.dart';
+import 'package:memora/presentation/features/timeline/timeline_destination_page_definition.dart';
 import 'package:memora/presentation/features/timeline/timeline_row_definition.dart';
 import 'package:memora/presentation/features/timeline/timeline_overflow_cell.dart';
 import 'package:memora/presentation/features/trip/trip_management.dart';
@@ -29,10 +29,8 @@ class TripRow extends TimelineRowDefinition {
   Color get backgroundColor => Colors.lightBlue.shade50;
 
   @override
-  Iterable<GroupTimelineDestinationPageDefinition>
-  get destinationPageDefinitions => const [
-    _TripManagementDestinationPageDefinition(),
-  ];
+  Iterable<TimelineDestinationPageDefinition> get destinationPageDefinitions =>
+      const [_TripManagementDestinationPageDefinition()];
 
   @override
   Widget buildYearCell(
@@ -67,7 +65,7 @@ class TripRow extends TimelineRowDefinition {
 }
 
 class _TripManagementDestinationPageDefinition
-    extends GroupTimelineDestinationPageDefinition {
+    extends TimelineDestinationPageDefinition {
   const _TripManagementDestinationPageDefinition();
 
   @override

--- a/lib/presentation/notifiers/group_timeline_navigation_notifier.dart
+++ b/lib/presentation/notifiers/group_timeline_navigation_notifier.dart
@@ -3,8 +3,8 @@ import 'dart:async';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:memora/application/dtos/group/group_dto.dart';
 import 'package:memora/presentation/features/timeline/default_timeline_rows.dart';
-import 'package:memora/presentation/features/timeline/group_timeline_destination_page_definition.dart';
 import 'package:memora/presentation/features/timeline/timeline.dart';
+import 'package:memora/presentation/features/timeline/timeline_destination_page_definition.dart';
 import 'package:memora/presentation/features/timeline/timeline_row_definition.dart';
 import 'package:memora/presentation/features/timeline/refresh_timeline_callback.dart';
 import 'package:memora/presentation/notifiers/group_timeline_destination.dart';
@@ -36,7 +36,7 @@ class GroupTimelineNavigationState {
 
   int? get selectedYear => destination.year;
 
-  List<GroupTimelineDestinationPageDefinition> get destinationPageDefinitions {
+  List<TimelineDestinationPageDefinition> get destinationPageDefinitions {
     return timelineRowDefinitions
         .expand((rowDefinition) => rowDefinition.destinationPageDefinitions)
         .toList(growable: false);


### PR DESCRIPTION
## 概要
- `GroupTimelineDestinationPageDefinition` を `TimelineDestinationPageDefinition` にリネーム
- 定義ファイル名を `timeline_destination_page_definition.dart` に変更
- 年表関連の参照先 import と型注釈を新名称へ追従

## 背景
- 年表の遷移先定義はグループ年表専用の文脈で使われており、クラス名とファイル名の `group` が冗長だったため

## 影響
- 挙動変更はなく、命名整理のみ
- 参照箇所は年表行定義、旅行行、DVC行、ナビゲーション notifier に限定

## 検証
- `./check.sh`