### PR TITLE
docs(todo): 年表行順変更タスクを追加

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -28,6 +28,15 @@
 
 ## グループ年表画面
 
+- グループ年表の行順を将来外から指定できる形にする
+  - `lib/presentation/features/timeline/default_timeline_rows.dart` で、現在固定の `旅行 -> イベント -> DVC -> groupWithMembers.members順` をそのまま並べる実装をやめ、任意の行順リストを受け取れる形に変更する
+  - 今回の対応では行順リストはどこからも渡さず、未指定時のデフォルト値として現在と同じ `旅行 -> イベント -> DVC -> groupWithMembers.members順` を使う
+  - 行順リストには `旅行` `イベント` `DVC` と、各メンバーを区別できる値を含められるようにして、将来指定された順序で `TimelineRowDefinition` を生成できる状態にする
+- グループ年表表示の入口は「受け取れる状態」までを整える
+  - `lib/presentation/notifiers/group_timeline_navigation_notifier.dart` の `showGroupTimeline` に行順リストの引数を追加し、省略時は現在のデフォルト順が使われるようにする
+  - 既存呼び出し元 (`lib/presentation/app/top_page.dart`) は今回変更せず、引数省略のまま現行挙動を維持する
+  - `Timeline` にはこれまでどおり生成済みの `rowDefinitions` を渡す構成のままにして、行順の切り替え責務は行生成側に閉じ込める
+
 ## 旅行管理画面
 
 ## 地図画面

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -29,9 +29,9 @@
 ## グループ年表画面
 
 - グループ年表の行順を将来外から指定できる形にする
-  - `lib/presentation/features/timeline/default_timeline_rows.dart` で、現在固定の `旅行 -> イベント -> DVC -> groupWithMembers.members順` をそのまま並べる実装をやめ、任意の行順リストを受け取れる形に変更する
-  - 今回の対応では行順リストはどこからも渡さず、未指定時のデフォルト値として現在と同じ `旅行 -> イベント -> DVC -> groupWithMembers.members順` を使う
-  - 行順リストには `旅行` `イベント` `DVC` と、各メンバーを区別できる値を含められるようにして、将来指定された順序で `TimelineRowDefinition` を生成できる状態にする
+  - `lib/presentation/features/timeline/default_timeline_rows.dart` で、現在固定の `旅行 -> イベント -> DVC -> メンバー順` をそのまま並べる実装をやめ、任意の行順リストを受け取れる形に変更する
+  - 今回の対応では行順リストはどこからも渡さず、未指定時のデフォルト値として現在と同じ `旅行 -> イベント -> DVC -> メンバー順` を使う
+  - 行順リストには `旅行` `イベント` `DVC` `メンバー` を含められるようにして、将来指定された順序で `TimelineRowDefinition` を生成できる状態にする
 - グループ年表表示の入口は「受け取れる状態」までを整える
   - `lib/presentation/notifiers/group_timeline_navigation_notifier.dart` の `showGroupTimeline` に行順リストの引数を追加し、省略時は現在のデフォルト順が使われるようにする
   - 既存呼び出し元 (`lib/presentation/app/top_page.dart`) は今回変更せず、引数省略のまま現行挙動を維持する


### PR DESCRIPTION
## 概要
- グループ年表の行順を将来外から指定できるようにするためのtodoを追加
- 今回の対応では行順リストは渡さず、未指定時は現行のデフォルト順を維持する前提を明記
- `showGroupTimeline` 側は受け口だけ整える方針をタスク化

## 背景
現在の年表行は `旅行 -> イベント -> DVC -> groupWithMembers.members順` で固定生成されています。今回の整理では、この並びを将来任意指定できるようにするための実装タスクを、過剰な設計に寄らず最小限の範囲で `docs/todo.md` に追加しました。

## 影響
- アプリ挙動への影響はありません
- 変更は `docs/todo.md` のみです

## 確認
- `./check.sh`