### PR TITLE
refactor(db): Firestore更新方針を統一

### DIFF
--- a/docs/done.md
+++ b/docs/done.md
@@ -2,6 +2,12 @@
 
 ## DB設計・リポジトリ・ユースケース・DTO・マッパー関連
 
+- FirestoreのMapperは新規作成用と更新用で出し分ける方針に統一する
+  - 新規作成時は`createdAt`と`updatedAt`の両方に`FieldValue.serverTimestamp()`を設定する
+  - 更新時は`createdAt`を更新データに含めず、`updatedAt`のみ更新する
+- FirestoreのRepositoryは既存ドキュメント更新時に全置換の`set`を使わず、`update`で差分更新する方針に統一する
+  - 新規作成時のみ`add`または新規`doc`への`set`を使用する
+  - 既存フィールドを保持したいが`update`を使えないケースがある場合のみ、理由を明記したうえで`set(..., SetOptions(merge: true))`を許容する
 - pinsテーブルにlocationNameカラムを追加する
 - group_membersにisAdministratorを追加する
 - group_membersにorderIndexを追加する

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -2,13 +2,6 @@
 
 ## DB設計・リポジトリ・ユースケース・DTO・マッパー関連
 
-- FirestoreのMapperは新規作成用と更新用で出し分ける方針に統一する
-  - 新規作成時は`createdAt`と`updatedAt`の両方に`FieldValue.serverTimestamp()`を設定する
-  - 更新時は`createdAt`を更新データに含めず、`updatedAt`のみ更新する
-- FirestoreのRepositoryは既存ドキュメント更新時に全置換の`set`を使わず、`update`で差分更新する方針に統一する
-  - 新規作成時のみ`add`または新規`doc`への`set`を使用する
-  - 既存フィールドを保持したいが`update`を使えないケースがある場合のみ、理由を明記したうえで`set(..., SetOptions(merge: true))`を許容する
-
 ## マップの表示
 
 

--- a/lib/infrastructure/mappers/dvc/firestore_dvc_limited_point_mapper.dart
+++ b/lib/infrastructure/mappers/dvc/firestore_dvc_limited_point_mapper.dart
@@ -2,6 +2,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:memora/application/dtos/dvc/dvc_limited_point_dto.dart';
 import 'package:memora/domain/entities/dvc/dvc_limited_point.dart';
 import 'package:memora/infrastructure/mappers/firestore_mapper_value_parser.dart';
+import 'package:memora/infrastructure/mappers/firestore_write_metadata.dart';
 
 class FirestoreDvcLimitedPointMapper {
   static final _defaultDate = DateTime.fromMillisecondsSinceEpoch(0);
@@ -24,14 +25,14 @@ class FirestoreDvcLimitedPointMapper {
     );
   }
 
-  static Map<String, dynamic> toFirestore(DvcLimitedPoint limitedPoint) {
+  static Map<String, dynamic> toCreateFirestore(DvcLimitedPoint limitedPoint) {
     return {
       'groupId': limitedPoint.groupId,
       'startYearMonth': Timestamp.fromDate(limitedPoint.startYearMonth),
       'endYearMonth': Timestamp.fromDate(limitedPoint.endYearMonth),
       'point': limitedPoint.point,
       'memo': limitedPoint.memo,
-      'createdAt': FieldValue.serverTimestamp(),
+      ...FirestoreWriteMetadata.forCreate(),
     };
   }
 }

--- a/lib/infrastructure/mappers/dvc/firestore_dvc_point_contract_mapper.dart
+++ b/lib/infrastructure/mappers/dvc/firestore_dvc_point_contract_mapper.dart
@@ -2,6 +2,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:memora/application/dtos/dvc/dvc_point_contract_dto.dart';
 import 'package:memora/domain/entities/dvc/dvc_point_contract.dart';
 import 'package:memora/infrastructure/mappers/firestore_mapper_value_parser.dart';
+import 'package:memora/infrastructure/mappers/firestore_write_metadata.dart';
 
 class FirestoreDvcPointContractMapper {
   static final _defaultDate = DateTime.fromMillisecondsSinceEpoch(0);
@@ -29,7 +30,7 @@ class FirestoreDvcPointContractMapper {
     );
   }
 
-  static Map<String, dynamic> toFirestore(DvcPointContract contract) {
+  static Map<String, dynamic> toCreateFirestore(DvcPointContract contract) {
     return {
       'groupId': contract.groupId,
       'contractName': contract.contractName,
@@ -39,7 +40,7 @@ class FirestoreDvcPointContractMapper {
       'contractEndYearMonth': Timestamp.fromDate(contract.contractEndYearMonth),
       'useYearStartMonth': contract.useYearStartMonth,
       'annualPoint': contract.annualPoint,
-      'createdAt': FieldValue.serverTimestamp(),
+      ...FirestoreWriteMetadata.forCreate(),
     };
   }
 }

--- a/lib/infrastructure/mappers/dvc/firestore_dvc_point_usage_mapper.dart
+++ b/lib/infrastructure/mappers/dvc/firestore_dvc_point_usage_mapper.dart
@@ -2,6 +2,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:memora/application/dtos/dvc/dvc_point_usage_dto.dart';
 import 'package:memora/domain/entities/dvc/dvc_point_usage.dart';
 import 'package:memora/infrastructure/mappers/firestore_mapper_value_parser.dart';
+import 'package:memora/infrastructure/mappers/firestore_write_metadata.dart';
 
 class FirestoreDvcPointUsageMapper {
   static final _defaultDate = DateTime.fromMillisecondsSinceEpoch(0);
@@ -21,13 +22,13 @@ class FirestoreDvcPointUsageMapper {
     );
   }
 
-  static Map<String, dynamic> toFirestore(DvcPointUsage pointUsage) {
+  static Map<String, dynamic> toCreateFirestore(DvcPointUsage pointUsage) {
     return {
       'groupId': pointUsage.groupId,
       'usageYearMonth': Timestamp.fromDate(pointUsage.usageYearMonth),
       'usedPoint': pointUsage.usedPoint,
       'memo': pointUsage.memo,
-      'createdAt': FieldValue.serverTimestamp(),
+      ...FirestoreWriteMetadata.forCreate(),
     };
   }
 }

--- a/lib/infrastructure/mappers/firestore_write_metadata.dart
+++ b/lib/infrastructure/mappers/firestore_write_metadata.dart
@@ -1,0 +1,14 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class FirestoreWriteMetadata {
+  static Map<String, dynamic> forCreate() {
+    return {
+      'createdAt': FieldValue.serverTimestamp(),
+      'updatedAt': FieldValue.serverTimestamp(),
+    };
+  }
+
+  static Map<String, dynamic> forUpdate() {
+    return {'updatedAt': FieldValue.serverTimestamp()};
+  }
+}

--- a/lib/infrastructure/mappers/group/firestore_group_event_mapper.dart
+++ b/lib/infrastructure/mappers/group/firestore_group_event_mapper.dart
@@ -1,6 +1,7 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:memora/application/dtos/group/group_event_dto.dart';
 import 'package:memora/domain/entities/group/group_event.dart';
+import 'package:memora/infrastructure/mappers/firestore_write_metadata.dart';
 
 class FirestoreGroupEventMapper {
   static GroupEventDto fromFirestore(
@@ -15,12 +16,21 @@ class FirestoreGroupEventMapper {
     );
   }
 
-  static Map<String, dynamic> toFirestore(GroupEvent groupEvent) {
+  static Map<String, dynamic> toCreateFirestore(GroupEvent groupEvent) {
     return {
       'groupId': groupEvent.groupId,
       'year': groupEvent.year,
       'memo': groupEvent.memo,
-      'updatedAt': FieldValue.serverTimestamp(),
+      ...FirestoreWriteMetadata.forCreate(),
+    };
+  }
+
+  static Map<String, dynamic> toUpdateFirestore(GroupEvent groupEvent) {
+    return {
+      'groupId': groupEvent.groupId,
+      'year': groupEvent.year,
+      'memo': groupEvent.memo,
+      ...FirestoreWriteMetadata.forUpdate(),
     };
   }
 }

--- a/lib/infrastructure/mappers/group/firestore_group_mapper.dart
+++ b/lib/infrastructure/mappers/group/firestore_group_mapper.dart
@@ -2,6 +2,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:memora/application/dtos/group/group_dto.dart';
 import 'package:memora/application/dtos/group/group_member_dto.dart';
 import 'package:memora/domain/entities/group/group.dart';
+import 'package:memora/infrastructure/mappers/firestore_write_metadata.dart';
 
 class FirestoreGroupMapper {
   static GroupDto fromFirestore(
@@ -18,12 +19,21 @@ class FirestoreGroupMapper {
     );
   }
 
-  static Map<String, dynamic> toFirestore(Group group) {
+  static Map<String, dynamic> toCreateFirestore(Group group) {
     return {
       'ownerId': group.ownerId,
       'name': group.name,
       'memo': group.memo,
-      'createdAt': FieldValue.serverTimestamp(),
+      ...FirestoreWriteMetadata.forCreate(),
+    };
+  }
+
+  static Map<String, dynamic> toUpdateFirestore(Group group) {
+    return {
+      'ownerId': group.ownerId,
+      'name': group.name,
+      'memo': group.memo,
+      ...FirestoreWriteMetadata.forUpdate(),
     };
   }
 }

--- a/lib/infrastructure/mappers/group/firestore_group_member_mapper.dart
+++ b/lib/infrastructure/mappers/group/firestore_group_member_mapper.dart
@@ -2,6 +2,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:memora/application/dtos/group/group_member_dto.dart';
 import 'package:memora/domain/entities/group/group_member.dart';
 import 'package:memora/infrastructure/mappers/firestore_mapper_value_parser.dart';
+import 'package:memora/infrastructure/mappers/firestore_write_metadata.dart';
 
 class FirestoreGroupMemberMapper {
   static GroupMemberDto fromFirestore(
@@ -36,13 +37,13 @@ class FirestoreGroupMemberMapper {
     );
   }
 
-  static Map<String, dynamic> toFirestore(GroupMember groupMember) {
+  static Map<String, dynamic> toCreateFirestore(GroupMember groupMember) {
     return {
       'groupId': groupMember.groupId,
       'memberId': groupMember.memberId,
       'isAdministrator': groupMember.isAdministrator,
       'orderIndex': groupMember.orderIndex,
-      'createdAt': FieldValue.serverTimestamp(),
+      ...FirestoreWriteMetadata.forCreate(),
     };
   }
 }

--- a/lib/infrastructure/mappers/member/firestore_member_event_mapper.dart
+++ b/lib/infrastructure/mappers/member/firestore_member_event_mapper.dart
@@ -2,6 +2,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:memora/application/dtos/member/member_event_dto.dart';
 import 'package:memora/domain/entities/member/member_event.dart';
 import 'package:memora/infrastructure/mappers/firestore_mapper_value_parser.dart';
+import 'package:memora/infrastructure/mappers/firestore_write_metadata.dart';
 
 class FirestoreMemberEventMapper {
   static final _defaultDate = DateTime.fromMillisecondsSinceEpoch(0);
@@ -25,7 +26,7 @@ class FirestoreMemberEventMapper {
     );
   }
 
-  static Map<String, dynamic> toFirestore(MemberEvent memberEvent) {
+  static Map<String, dynamic> toCreateFirestore(MemberEvent memberEvent) {
     return {
       'memberId': memberEvent.memberId,
       'type': memberEvent.type,
@@ -33,7 +34,7 @@ class FirestoreMemberEventMapper {
       'startDate': Timestamp.fromDate(memberEvent.startDate),
       'endDate': Timestamp.fromDate(memberEvent.endDate),
       'memo': memberEvent.memo,
-      'createdAt': FieldValue.serverTimestamp(),
+      ...FirestoreWriteMetadata.forCreate(),
     };
   }
 }

--- a/lib/infrastructure/mappers/member/firestore_member_invitation_mapper.dart
+++ b/lib/infrastructure/mappers/member/firestore_member_invitation_mapper.dart
@@ -1,6 +1,7 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:memora/application/dtos/member/member_invitation_dto.dart';
 import 'package:memora/domain/entities/member/member_invitation.dart';
+import 'package:memora/infrastructure/mappers/firestore_write_metadata.dart';
 
 class FirestoreMemberInvitationMapper {
   static MemberInvitationDto fromFirestore(
@@ -15,12 +16,25 @@ class FirestoreMemberInvitationMapper {
     );
   }
 
-  static Map<String, dynamic> toFirestore(MemberInvitation memberInvitation) {
+  static Map<String, dynamic> toCreateFirestore(
+    MemberInvitation memberInvitation,
+  ) {
     return {
       'inviteeId': memberInvitation.inviteeId,
       'inviterId': memberInvitation.inviterId,
       'invitationCode': memberInvitation.invitationCode,
-      'createdAt': FieldValue.serverTimestamp(),
+      ...FirestoreWriteMetadata.forCreate(),
+    };
+  }
+
+  static Map<String, dynamic> toUpdateFirestore(
+    MemberInvitation memberInvitation,
+  ) {
+    return {
+      'inviteeId': memberInvitation.inviteeId,
+      'inviterId': memberInvitation.inviterId,
+      'invitationCode': memberInvitation.invitationCode,
+      ...FirestoreWriteMetadata.forUpdate(),
     };
   }
 }

--- a/lib/infrastructure/mappers/member/firestore_member_mapper.dart
+++ b/lib/infrastructure/mappers/member/firestore_member_mapper.dart
@@ -2,6 +2,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:memora/application/dtos/member/member_dto.dart';
 import 'package:memora/domain/entities/member/member.dart';
 import 'package:memora/infrastructure/mappers/firestore_mapper_value_parser.dart';
+import 'package:memora/infrastructure/mappers/firestore_write_metadata.dart';
 
 class FirestoreMemberMapper {
   static MemberDto fromFirestore(DocumentSnapshot<Map<String, dynamic>> doc) {
@@ -27,7 +28,7 @@ class FirestoreMemberMapper {
     );
   }
 
-  static Map<String, dynamic> toFirestore(Member member) {
+  static Map<String, dynamic> toCreateFirestore(Member member) {
     return {
       'accountId': member.accountId,
       'ownerId': member.ownerId,
@@ -47,7 +48,31 @@ class FirestoreMemberMapper {
       'phoneNumber': member.phoneNumber,
       'passportNumber': member.passportNumber,
       'passportExpiration': member.passportExpiration,
-      'createdAt': FieldValue.serverTimestamp(),
+      ...FirestoreWriteMetadata.forCreate(),
+    };
+  }
+
+  static Map<String, dynamic> toUpdateFirestore(Member member) {
+    return {
+      'accountId': member.accountId,
+      'ownerId': member.ownerId,
+      'hiraganaFirstName': member.hiraganaFirstName,
+      'hiraganaLastName': member.hiraganaLastName,
+      'kanjiFirstName': member.kanjiFirstName,
+      'kanjiLastName': member.kanjiLastName,
+      'firstName': member.firstName,
+      'lastName': member.lastName,
+      'displayName': member.displayName,
+      'type': member.type,
+      'birthday': member.birthday != null
+          ? Timestamp.fromDate(member.birthday!)
+          : null,
+      'gender': member.gender,
+      'email': member.email,
+      'phoneNumber': member.phoneNumber,
+      'passportNumber': member.passportNumber,
+      'passportExpiration': member.passportExpiration,
+      ...FirestoreWriteMetadata.forUpdate(),
     };
   }
 }

--- a/lib/infrastructure/mappers/trip/firestore_pin_mapper.dart
+++ b/lib/infrastructure/mappers/trip/firestore_pin_mapper.dart
@@ -2,6 +2,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:memora/application/dtos/trip/pin_dto.dart';
 import 'package:memora/domain/entities/trip/pin.dart';
 import 'package:memora/infrastructure/mappers/firestore_mapper_value_parser.dart';
+import 'package:memora/infrastructure/mappers/firestore_write_metadata.dart';
 
 class FirestorePinMapper {
   static PinDto fromFirestore(DocumentSnapshot<Map<String, dynamic>> doc) {
@@ -21,7 +22,7 @@ class FirestorePinMapper {
     );
   }
 
-  static Map<String, dynamic> toFirestore(Pin pin) {
+  static Map<String, dynamic> toCreateFirestore(Pin pin) {
     return {
       'pinId': pin.pinId,
       'tripId': pin.tripId,
@@ -36,7 +37,7 @@ class FirestorePinMapper {
           ? Timestamp.fromDate(pin.visitEndDate!)
           : null,
       'visitMemo': pin.visitMemo,
-      'createdAt': FieldValue.serverTimestamp(),
+      ...FirestoreWriteMetadata.forCreate(),
     };
   }
 }

--- a/lib/infrastructure/mappers/trip/firestore_task_mapper.dart
+++ b/lib/infrastructure/mappers/trip/firestore_task_mapper.dart
@@ -38,23 +38,4 @@ class FirestoreTaskMapper {
 
     return data;
   }
-
-  static Map<String, dynamic> toUpdateFirestore(Task task) {
-    final data = <String, dynamic>{
-      'tripId': task.tripId,
-      'orderIndex': task.orderIndex,
-      'parentTaskId': task.parentTaskId,
-      'name': task.name,
-      'isCompleted': task.isCompleted,
-      'memo': task.memo,
-      'assignedMemberId': task.assignedMemberId,
-      ...FirestoreWriteMetadata.forUpdate(),
-    };
-
-    data['dueDate'] = task.dueDate != null
-        ? Timestamp.fromDate(task.dueDate!)
-        : null;
-
-    return data;
-  }
 }

--- a/lib/infrastructure/mappers/trip/firestore_task_mapper.dart
+++ b/lib/infrastructure/mappers/trip/firestore_task_mapper.dart
@@ -38,4 +38,23 @@ class FirestoreTaskMapper {
 
     return data;
   }
+
+  static Map<String, dynamic> toUpdateFirestore(Task task) {
+    final data = <String, dynamic>{
+      'tripId': task.tripId,
+      'orderIndex': task.orderIndex,
+      'parentTaskId': task.parentTaskId,
+      'name': task.name,
+      'isCompleted': task.isCompleted,
+      'memo': task.memo,
+      'assignedMemberId': task.assignedMemberId,
+      ...FirestoreWriteMetadata.forUpdate(),
+    };
+
+    data['dueDate'] = task.dueDate != null
+        ? Timestamp.fromDate(task.dueDate!)
+        : null;
+
+    return data;
+  }
 }

--- a/lib/infrastructure/mappers/trip/firestore_task_mapper.dart
+++ b/lib/infrastructure/mappers/trip/firestore_task_mapper.dart
@@ -2,6 +2,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:memora/application/dtos/trip/task_dto.dart';
 import 'package:memora/domain/entities/trip/task.dart';
 import 'package:memora/infrastructure/mappers/firestore_mapper_value_parser.dart';
+import 'package:memora/infrastructure/mappers/firestore_write_metadata.dart';
 
 class FirestoreTaskMapper {
   static TaskDto fromFirestore(DocumentSnapshot<Map<String, dynamic>> doc) {
@@ -19,7 +20,7 @@ class FirestoreTaskMapper {
     );
   }
 
-  static Map<String, dynamic> toFirestore(Task task) {
+  static Map<String, dynamic> toCreateFirestore(Task task) {
     final data = <String, dynamic>{
       'tripId': task.tripId,
       'orderIndex': task.orderIndex,
@@ -28,7 +29,7 @@ class FirestoreTaskMapper {
       'isCompleted': task.isCompleted,
       'memo': task.memo,
       'assignedMemberId': task.assignedMemberId,
-      'createdAt': FieldValue.serverTimestamp(),
+      ...FirestoreWriteMetadata.forCreate(),
     };
 
     data['dueDate'] = task.dueDate != null

--- a/lib/infrastructure/mappers/trip/firestore_trip_entry_mapper.dart
+++ b/lib/infrastructure/mappers/trip/firestore_trip_entry_mapper.dart
@@ -4,6 +4,7 @@ import 'package:memora/application/dtos/trip/task_dto.dart';
 import 'package:memora/application/dtos/trip/trip_entry_dto.dart';
 import 'package:memora/domain/entities/trip/trip_entry.dart';
 import 'package:memora/infrastructure/mappers/firestore_mapper_value_parser.dart';
+import 'package:memora/infrastructure/mappers/firestore_write_metadata.dart';
 
 class FirestoreTripEntryMapper {
   static TripEntryDto fromFirestore(
@@ -32,13 +33,32 @@ class FirestoreTripEntryMapper {
     );
   }
 
-  static Map<String, dynamic> toFirestore(TripEntry tripEntry) {
+  static Map<String, dynamic> toCreateFirestore(TripEntry tripEntry) {
     final data = <String, dynamic>{
       'groupId': tripEntry.groupId,
       'tripYear': tripEntry.tripYear,
       'tripName': tripEntry.tripName,
       'tripMemo': tripEntry.tripMemo,
-      'createdAt': FieldValue.serverTimestamp(),
+      ...FirestoreWriteMetadata.forCreate(),
+    };
+
+    data['tripStartDate'] = tripEntry.tripStartDate != null
+        ? Timestamp.fromDate(tripEntry.tripStartDate!)
+        : null;
+    data['tripEndDate'] = tripEntry.tripEndDate != null
+        ? Timestamp.fromDate(tripEntry.tripEndDate!)
+        : null;
+
+    return data;
+  }
+
+  static Map<String, dynamic> toUpdateFirestore(TripEntry tripEntry) {
+    final data = <String, dynamic>{
+      'groupId': tripEntry.groupId,
+      'tripYear': tripEntry.tripYear,
+      'tripName': tripEntry.tripName,
+      'tripMemo': tripEntry.tripMemo,
+      ...FirestoreWriteMetadata.forUpdate(),
     };
 
     data['tripStartDate'] = tripEntry.tripStartDate != null

--- a/lib/infrastructure/repositories/dvc/firestore_dvc_limited_point_repository.dart
+++ b/lib/infrastructure/repositories/dvc/firestore_dvc_limited_point_repository.dart
@@ -13,7 +13,7 @@ class FirestoreDvcLimitedPointRepository implements DvcLimitedPointRepository {
   Future<void> saveDvcLimitedPoint(DvcLimitedPoint limitedPoint) async {
     await _firestore
         .collection('dvc_limited_points')
-        .add(FirestoreDvcLimitedPointMapper.toFirestore(limitedPoint));
+        .add(FirestoreDvcLimitedPointMapper.toCreateFirestore(limitedPoint));
   }
 
   @override

--- a/lib/infrastructure/repositories/dvc/firestore_dvc_point_contract_repository.dart
+++ b/lib/infrastructure/repositories/dvc/firestore_dvc_point_contract_repository.dart
@@ -14,7 +14,7 @@ class FirestoreDvcPointContractRepository
   Future<void> saveDvcPointContract(DvcPointContract contract) async {
     await _firestore
         .collection('dvc_point_contracts')
-        .add(FirestoreDvcPointContractMapper.toFirestore(contract));
+        .add(FirestoreDvcPointContractMapper.toCreateFirestore(contract));
   }
 
   @override

--- a/lib/infrastructure/repositories/dvc/firestore_dvc_point_usage_repository.dart
+++ b/lib/infrastructure/repositories/dvc/firestore_dvc_point_usage_repository.dart
@@ -13,7 +13,7 @@ class FirestoreDvcPointUsageRepository implements DvcPointUsageRepository {
   Future<void> saveDvcPointUsage(DvcPointUsage pointUsage) async {
     await _firestore
         .collection('dvc_point_usages')
-        .add(FirestoreDvcPointUsageMapper.toFirestore(pointUsage));
+        .add(FirestoreDvcPointUsageMapper.toCreateFirestore(pointUsage));
   }
 
   @override

--- a/lib/infrastructure/repositories/group/firestore_group_event_repository.dart
+++ b/lib/infrastructure/repositories/group/firestore_group_event_repository.dart
@@ -11,13 +11,14 @@ class FirestoreGroupEventRepository implements GroupEventRepository {
 
   @override
   Future<String> saveGroupEvent(GroupEvent groupEvent) async {
-    final data = FirestoreGroupEventMapper.toFirestore(groupEvent);
     if (groupEvent.id.isEmpty) {
+      final data = FirestoreGroupEventMapper.toCreateFirestore(groupEvent);
       final docRef = await _firestore.collection('group_events').add(data);
       return docRef.id;
     }
 
-    await _firestore.collection('group_events').doc(groupEvent.id).set(data);
+    final data = FirestoreGroupEventMapper.toUpdateFirestore(groupEvent);
+    await _firestore.collection('group_events').doc(groupEvent.id).update(data);
     return groupEvent.id;
   }
 

--- a/lib/infrastructure/repositories/group/firestore_group_repository.dart
+++ b/lib/infrastructure/repositories/group/firestore_group_repository.dart
@@ -16,13 +16,13 @@ class FirestoreGroupRepository implements GroupRepository {
     final batch = _firestore.batch();
 
     final groupDocRef = _firestore.collection('groups').doc();
-    batch.set(groupDocRef, FirestoreGroupMapper.toFirestore(group));
+    batch.set(groupDocRef, FirestoreGroupMapper.toCreateFirestore(group));
 
     for (final GroupMember member in group.members) {
       final memberDocRef = _firestore.collection('group_members').doc();
       batch.set(
         memberDocRef,
-        FirestoreGroupMemberMapper.toFirestore(
+        FirestoreGroupMemberMapper.toCreateFirestore(
           member.copyWith(groupId: groupDocRef.id),
         ),
       );
@@ -38,7 +38,7 @@ class FirestoreGroupRepository implements GroupRepository {
 
     batch.update(
       _firestore.collection('groups').doc(group.id),
-      FirestoreGroupMapper.toFirestore(group),
+      FirestoreGroupMapper.toUpdateFirestore(group),
     );
 
     final memberSnapshot = await _firestore
@@ -53,7 +53,7 @@ class FirestoreGroupRepository implements GroupRepository {
       final memberDocRef = _firestore.collection('group_members').doc();
       batch.set(
         memberDocRef,
-        FirestoreGroupMemberMapper.toFirestore(
+        FirestoreGroupMemberMapper.toCreateFirestore(
           member.copyWith(groupId: group.id),
         ),
       );

--- a/lib/infrastructure/repositories/member/firestore_member_event_repository.dart
+++ b/lib/infrastructure/repositories/member/firestore_member_event_repository.dart
@@ -13,7 +13,7 @@ class FirestoreMemberEventRepository implements MemberEventRepository {
   Future<void> saveMemberEvent(MemberEvent memberEvent) async {
     await _firestore
         .collection('member_events')
-        .add(FirestoreMemberEventMapper.toFirestore(memberEvent));
+        .add(FirestoreMemberEventMapper.toCreateFirestore(memberEvent));
   }
 
   @override

--- a/lib/infrastructure/repositories/member/firestore_member_invitation_repository.dart
+++ b/lib/infrastructure/repositories/member/firestore_member_invitation_repository.dart
@@ -12,13 +12,17 @@ class FirestoreMemberInvitationRepository
 
   @override
   Future<void> saveMemberInvitation(MemberInvitation memberInvitation) async {
-    final data = FirestoreMemberInvitationMapper.toFirestore(memberInvitation);
+    final data = FirestoreMemberInvitationMapper.toCreateFirestore(
+      memberInvitation,
+    );
     await _firestore.collection('member_invitations').add(data);
   }
 
   @override
   Future<void> updateMemberInvitation(MemberInvitation memberInvitation) async {
-    final data = FirestoreMemberInvitationMapper.toFirestore(memberInvitation);
+    final data = FirestoreMemberInvitationMapper.toUpdateFirestore(
+      memberInvitation,
+    );
     await _firestore
         .collection('member_invitations')
         .doc(memberInvitation.id)

--- a/lib/infrastructure/repositories/member/firestore_member_repository.dart
+++ b/lib/infrastructure/repositories/member/firestore_member_repository.dart
@@ -13,7 +13,7 @@ class FirestoreMemberRepository implements MemberRepository {
   Future<void> saveMember(Member member) async {
     await _firestore
         .collection('members')
-        .add(FirestoreMemberMapper.toFirestore(member));
+        .add(FirestoreMemberMapper.toCreateFirestore(member));
   }
 
   @override
@@ -21,7 +21,7 @@ class FirestoreMemberRepository implements MemberRepository {
     await _firestore
         .collection('members')
         .doc(member.id)
-        .update(FirestoreMemberMapper.toFirestore(member));
+        .update(FirestoreMemberMapper.toUpdateFirestore(member));
   }
 
   @override

--- a/lib/infrastructure/repositories/trip/firestore_trip_entry_repository.dart
+++ b/lib/infrastructure/repositories/trip/firestore_trip_entry_repository.dart
@@ -69,8 +69,14 @@ class FirestoreTripEntryRepository implements TripEntryRepository {
     final tasksSnapshot = await tasksCollection
         .where('tripId', isEqualTo: tripEntry.id)
         .get();
+    final existingTaskDocsById = {
+      for (final taskDoc in tasksSnapshot.docs) taskDoc.id: taskDoc,
+    };
+    final nextTaskIds = tripEntry.tasks.map((task) => task.id).toSet();
     for (final taskDoc in tasksSnapshot.docs) {
-      batch.delete(taskDoc.reference);
+      if (!nextTaskIds.contains(taskDoc.id)) {
+        batch.delete(taskDoc.reference);
+      }
     }
 
     for (final Pin pin in tripEntry.pins) {
@@ -84,13 +90,19 @@ class FirestoreTripEntryRepository implements TripEntryRepository {
     }
 
     for (final Task task in tripEntry.tasks) {
+      final updatedTask = task.copyWith(tripId: tripEntry.id);
+      final existingTaskDoc = existingTaskDocsById[task.id];
+
+      if (existingTaskDoc != null) {
+        batch.update(
+          existingTaskDoc.reference,
+          FirestoreTaskMapper.toUpdateFirestore(updatedTask),
+        );
+        continue;
+      }
+
       final taskDocRef = tasksCollection.doc(task.id);
-      batch.set(
-        taskDocRef,
-        FirestoreTaskMapper.toCreateFirestore(
-          task.copyWith(tripId: tripEntry.id),
-        ),
-      );
+      batch.set(taskDocRef, FirestoreTaskMapper.toCreateFirestore(updatedTask));
     }
 
     await batch.commit();

--- a/lib/infrastructure/repositories/trip/firestore_trip_entry_repository.dart
+++ b/lib/infrastructure/repositories/trip/firestore_trip_entry_repository.dart
@@ -69,14 +69,8 @@ class FirestoreTripEntryRepository implements TripEntryRepository {
     final tasksSnapshot = await tasksCollection
         .where('tripId', isEqualTo: tripEntry.id)
         .get();
-    final existingTaskDocsById = {
-      for (final taskDoc in tasksSnapshot.docs) taskDoc.id: taskDoc,
-    };
-    final nextTaskIds = tripEntry.tasks.map((task) => task.id).toSet();
     for (final taskDoc in tasksSnapshot.docs) {
-      if (!nextTaskIds.contains(taskDoc.id)) {
-        batch.delete(taskDoc.reference);
-      }
+      batch.delete(taskDoc.reference);
     }
 
     for (final Pin pin in tripEntry.pins) {
@@ -90,19 +84,13 @@ class FirestoreTripEntryRepository implements TripEntryRepository {
     }
 
     for (final Task task in tripEntry.tasks) {
-      final updatedTask = task.copyWith(tripId: tripEntry.id);
-      final existingTaskDoc = existingTaskDocsById[task.id];
-
-      if (existingTaskDoc != null) {
-        batch.update(
-          existingTaskDoc.reference,
-          FirestoreTaskMapper.toUpdateFirestore(updatedTask),
-        );
-        continue;
-      }
-
       final taskDocRef = tasksCollection.doc(task.id);
-      batch.set(taskDocRef, FirestoreTaskMapper.toCreateFirestore(updatedTask));
+      batch.set(
+        taskDocRef,
+        FirestoreTaskMapper.toCreateFirestore(
+          task.copyWith(tripId: tripEntry.id),
+        ),
+      );
     }
 
     await batch.commit();

--- a/lib/infrastructure/repositories/trip/firestore_trip_entry_repository.dart
+++ b/lib/infrastructure/repositories/trip/firestore_trip_entry_repository.dart
@@ -18,14 +18,19 @@ class FirestoreTripEntryRepository implements TripEntryRepository {
     final batch = _firestore.batch();
 
     final tripDocRef = _firestore.collection('trip_entries').doc();
-    batch.set(tripDocRef, FirestoreTripEntryMapper.toFirestore(tripEntry));
+    batch.set(
+      tripDocRef,
+      FirestoreTripEntryMapper.toCreateFirestore(tripEntry),
+    );
     final tasksCollection = _firestore.collection('tasks');
 
     for (final Pin pin in tripEntry.pins) {
       final pinDocRef = _firestore.collection('pins').doc();
       batch.set(
         pinDocRef,
-        FirestorePinMapper.toFirestore(pin.copyWith(tripId: tripDocRef.id)),
+        FirestorePinMapper.toCreateFirestore(
+          pin.copyWith(tripId: tripDocRef.id),
+        ),
       );
     }
 
@@ -33,7 +38,9 @@ class FirestoreTripEntryRepository implements TripEntryRepository {
       final taskDocRef = tasksCollection.doc(task.id);
       batch.set(
         taskDocRef,
-        FirestoreTaskMapper.toFirestore(task.copyWith(tripId: tripDocRef.id)),
+        FirestoreTaskMapper.toCreateFirestore(
+          task.copyWith(tripId: tripDocRef.id),
+        ),
       );
     }
 
@@ -48,7 +55,7 @@ class FirestoreTripEntryRepository implements TripEntryRepository {
 
     batch.update(
       _firestore.collection('trip_entries').doc(tripEntry.id),
-      FirestoreTripEntryMapper.toFirestore(tripEntry),
+      FirestoreTripEntryMapper.toUpdateFirestore(tripEntry),
     );
 
     final pinsSnapshot = await _firestore
@@ -70,7 +77,7 @@ class FirestoreTripEntryRepository implements TripEntryRepository {
       final pinDocRef = _firestore.collection('pins').doc();
       batch.set(
         pinDocRef,
-        FirestorePinMapper.toFirestore(
+        FirestorePinMapper.toCreateFirestore(
           pin.copyWith(tripId: tripEntry.id, groupId: tripEntry.groupId),
         ),
       );
@@ -80,7 +87,9 @@ class FirestoreTripEntryRepository implements TripEntryRepository {
       final taskDocRef = tasksCollection.doc(task.id);
       batch.set(
         taskDocRef,
-        FirestoreTaskMapper.toFirestore(task.copyWith(tripId: tripEntry.id)),
+        FirestoreTaskMapper.toCreateFirestore(
+          task.copyWith(tripId: tripEntry.id),
+        ),
       );
     }
 

--- a/test/unit/infrastructure/mappers/dvc/firestore_dvc_limited_point_mapper_test.dart
+++ b/test/unit/infrastructure/mappers/dvc/firestore_dvc_limited_point_mapper_test.dart
@@ -68,7 +68,7 @@ void main() {
         memo: '追加分',
       );
 
-      final map = FirestoreDvcLimitedPointMapper.toFirestore(point);
+      final map = FirestoreDvcLimitedPointMapper.toCreateFirestore(point);
 
       expect(map['groupId'], 'group001');
       expect(map['startYearMonth'], isA<Timestamp>());
@@ -76,6 +76,7 @@ void main() {
       expect(map['point'], 30);
       expect(map['memo'], '追加分');
       expect(map['createdAt'], isA<FieldValue>());
+      expect(map['updatedAt'], isA<FieldValue>());
     });
   });
 }

--- a/test/unit/infrastructure/mappers/dvc/firestore_dvc_point_contract_mapper_test.dart
+++ b/test/unit/infrastructure/mappers/dvc/firestore_dvc_point_contract_mapper_test.dart
@@ -66,7 +66,7 @@ void main() {
         annualPoint: 200,
       );
 
-      final map = FirestoreDvcPointContractMapper.toFirestore(contract);
+      final map = FirestoreDvcPointContractMapper.toCreateFirestore(contract);
 
       expect(map['groupId'], 'group001');
       expect(map['contractName'], '契約A');
@@ -75,6 +75,7 @@ void main() {
       expect(map['useYearStartMonth'], 10);
       expect(map['annualPoint'], 200);
       expect(map['createdAt'], isA<FieldValue>());
+      expect(map['updatedAt'], isA<FieldValue>());
     });
   });
 }

--- a/test/unit/infrastructure/mappers/dvc/firestore_dvc_point_usage_mapper_test.dart
+++ b/test/unit/infrastructure/mappers/dvc/firestore_dvc_point_usage_mapper_test.dart
@@ -52,13 +52,14 @@ void main() {
         memo: 'ホテル',
       );
 
-      final map = FirestoreDvcPointUsageMapper.toFirestore(usage);
+      final map = FirestoreDvcPointUsageMapper.toCreateFirestore(usage);
 
       expect(map['groupId'], 'group001');
       expect(map['usageYearMonth'], isA<Timestamp>());
       expect(map['usedPoint'], 60);
       expect(map['memo'], 'ホテル');
       expect(map['createdAt'], isA<FieldValue>());
+      expect(map['updatedAt'], isA<FieldValue>());
     });
   });
 }

--- a/test/unit/infrastructure/mappers/group/firestore_group_event_mapper_test.dart
+++ b/test/unit/infrastructure/mappers/group/firestore_group_event_mapper_test.dart
@@ -38,7 +38,7 @@ void main() {
       expect(result.memo, '');
     });
 
-    test('GroupEventからFirestoreのMapへ変換できる', () {
+    test('GroupEventを新規作成用FirestoreのMapへ変換できる', () {
       const groupEvent = GroupEvent(
         id: 'groupevent001',
         groupId: 'group001',
@@ -46,11 +46,29 @@ void main() {
         memo: 'テストメモ',
       );
 
-      final data = FirestoreGroupEventMapper.toFirestore(groupEvent);
+      final data = FirestoreGroupEventMapper.toCreateFirestore(groupEvent);
 
       expect(data['groupId'], 'group001');
       expect(data['year'], 2025);
       expect(data['memo'], 'テストメモ');
+      expect(data['createdAt'], isA<FieldValue>());
+      expect(data['updatedAt'], isA<FieldValue>());
+    });
+
+    test('GroupEventを更新用FirestoreのMapへ変換できる', () {
+      const groupEvent = GroupEvent(
+        id: 'groupevent001',
+        groupId: 'group001',
+        year: 2025,
+        memo: '更新後メモ',
+      );
+
+      final data = FirestoreGroupEventMapper.toUpdateFirestore(groupEvent);
+
+      expect(data['groupId'], 'group001');
+      expect(data['year'], 2025);
+      expect(data['memo'], '更新後メモ');
+      expect(data.containsKey('createdAt'), isFalse);
       expect(data['updatedAt'], isA<FieldValue>());
     });
   });

--- a/test/unit/infrastructure/mappers/group/firestore_group_mapper_test.dart
+++ b/test/unit/infrastructure/mappers/group/firestore_group_mapper_test.dart
@@ -48,7 +48,7 @@ void main() {
       expect(result.members, isEmpty);
     });
 
-    test('GroupからFirestoreのMapへ変換できる', () {
+    test('Groupを新規作成用FirestoreのMapへ変換できる', () {
       final group = Group(
         id: 'group001',
         ownerId: 'admin001',
@@ -56,38 +56,41 @@ void main() {
         memo: 'テストメモ',
       );
 
-      final data = FirestoreGroupMapper.toFirestore(group);
+      final data = FirestoreGroupMapper.toCreateFirestore(group);
 
       expect(data['ownerId'], 'admin001');
       expect(data['name'], 'テストグループ');
       expect(data['memo'], 'テストメモ');
       expect(data['createdAt'], isA<FieldValue>());
+      expect(data['updatedAt'], isA<FieldValue>());
     });
 
-    test('nullableなフィールドがnullでもFirestoreのMapへ変換できる', () {
+    test('Groupを更新用FirestoreのMapへ変換できる', () {
       final group = Group(
         id: 'group002',
         ownerId: 'admin002',
         name: 'テストグループ2',
       );
 
-      final data = FirestoreGroupMapper.toFirestore(group);
+      final data = FirestoreGroupMapper.toUpdateFirestore(group);
 
       expect(data['ownerId'], 'admin002');
       expect(data['name'], 'テストグループ2');
       expect(data['memo'], null);
-      expect(data['createdAt'], isA<FieldValue>());
+      expect(data.containsKey('createdAt'), isFalse);
+      expect(data['updatedAt'], isA<FieldValue>());
     });
 
-    test('空文字を含むGroupからFirestoreのMapへ変換できる', () {
+    test('空文字を含むGroupでも更新用FirestoreのMapへ変換できる', () {
       final group = Group(id: 'group004', ownerId: '', name: '');
 
-      final data = FirestoreGroupMapper.toFirestore(group);
+      final data = FirestoreGroupMapper.toUpdateFirestore(group);
 
       expect(data['ownerId'], '');
       expect(data['name'], '');
       expect(data['memo'], null);
-      expect(data['createdAt'], isA<FieldValue>());
+      expect(data.containsKey('createdAt'), isFalse);
+      expect(data['updatedAt'], isA<FieldValue>());
     });
   });
 }

--- a/test/unit/infrastructure/mappers/group/firestore_group_member_mapper_test.dart
+++ b/test/unit/infrastructure/mappers/group/firestore_group_member_mapper_test.dart
@@ -62,7 +62,7 @@ void main() {
       expect(result.email, isNull);
     });
 
-    test('GroupMemberからFirestoreのMapへ変換できる', () {
+    test('GroupMemberを新規作成用FirestoreのMapへ変換できる', () {
       final groupMember = GroupMember(
         groupId: 'group001',
         memberId: 'member001',
@@ -70,25 +70,27 @@ void main() {
         orderIndex: 2,
       );
 
-      final data = FirestoreGroupMemberMapper.toFirestore(groupMember);
+      final data = FirestoreGroupMemberMapper.toCreateFirestore(groupMember);
 
       expect(data['groupId'], 'group001');
       expect(data['memberId'], 'member001');
       expect(data['isAdministrator'], true);
       expect(data['orderIndex'], 2);
       expect(data['createdAt'], isA<FieldValue>());
+      expect(data['updatedAt'], isA<FieldValue>());
     });
 
-    test('空文字を含むGroupMemberからFirestoreのMapへ変換できる', () {
+    test('空文字を含むGroupMemberでも新規作成用FirestoreのMapへ変換できる', () {
       final groupMember = GroupMember(groupId: '', memberId: '');
 
-      final data = FirestoreGroupMemberMapper.toFirestore(groupMember);
+      final data = FirestoreGroupMemberMapper.toCreateFirestore(groupMember);
 
       expect(data['groupId'], '');
       expect(data['memberId'], '');
       expect(data['isAdministrator'], false);
       expect(data['orderIndex'], 0);
       expect(data['createdAt'], isA<FieldValue>());
+      expect(data['updatedAt'], isA<FieldValue>());
     });
   });
 }

--- a/test/unit/infrastructure/mappers/member/firestore_member_event_mapper_test.dart
+++ b/test/unit/infrastructure/mappers/member/firestore_member_event_mapper_test.dart
@@ -49,7 +49,7 @@ void main() {
       expect(result.memo, isNull);
     });
 
-    test('MemberEventからFirestoreのMapへ変換できる', () {
+    test('MemberEventを新規作成用FirestoreのMapへ変換できる', () {
       final memberEvent = MemberEvent(
         id: 'memberevent001',
         memberId: 'member001',
@@ -60,7 +60,7 @@ void main() {
         memo: 'テストメモ',
       );
 
-      final data = FirestoreMemberEventMapper.toFirestore(memberEvent);
+      final data = FirestoreMemberEventMapper.toCreateFirestore(memberEvent);
 
       expect(data['memberId'], 'member001');
       expect(data['type'], 'birthday');
@@ -69,9 +69,10 @@ void main() {
       expect(data['endDate'], isA<Timestamp>());
       expect(data['memo'], 'テストメモ');
       expect(data['createdAt'], isA<FieldValue>());
+      expect(data['updatedAt'], isA<FieldValue>());
     });
 
-    test('nullableなフィールドがnullでもFirestoreのMapへ変換できる', () {
+    test('nullableなフィールドがnullでも新規作成用FirestoreのMapへ変換できる', () {
       final memberEvent = MemberEvent(
         id: 'memberevent004',
         memberId: 'member002',
@@ -80,7 +81,7 @@ void main() {
         endDate: DateTime(2025, 8, 2),
       );
 
-      final data = FirestoreMemberEventMapper.toFirestore(memberEvent);
+      final data = FirestoreMemberEventMapper.toCreateFirestore(memberEvent);
 
       expect(data['memberId'], 'member002');
       expect(data['type'], 'anniversary');
@@ -89,6 +90,7 @@ void main() {
       expect(data['endDate'], isA<Timestamp>());
       expect(data['memo'], isNull);
       expect(data['createdAt'], isA<FieldValue>());
+      expect(data['updatedAt'], isA<FieldValue>());
     });
   });
 }

--- a/test/unit/infrastructure/mappers/member/firestore_member_invitation_mapper_test.dart
+++ b/test/unit/infrastructure/mappers/member/firestore_member_invitation_mapper_test.dart
@@ -40,7 +40,7 @@ void main() {
       expect(result.invitationCode, '');
     });
 
-    test('MemberInvitationからFirestoreのMapへ変換できる', () {
+    test('MemberInvitationを新規作成用FirestoreのMapへ変換できる', () {
       const memberInvitation = MemberInvitation(
         id: 'invitation001',
         inviteeId: 'invitee001',
@@ -48,7 +48,7 @@ void main() {
         invitationCode: 'code001',
       );
 
-      final data = FirestoreMemberInvitationMapper.toFirestore(
+      final data = FirestoreMemberInvitationMapper.toCreateFirestore(
         memberInvitation,
       );
 
@@ -56,9 +56,10 @@ void main() {
       expect(data['inviterId'], 'inviter001');
       expect(data['invitationCode'], 'code001');
       expect(data['createdAt'], isA<FieldValue>());
+      expect(data['updatedAt'], isA<FieldValue>());
     });
 
-    test('空文字を含むMemberInvitationからFirestoreのMapへ変換できる', () {
+    test('空文字を含むMemberInvitationでも更新用FirestoreのMapへ変換できる', () {
       const memberInvitation = MemberInvitation(
         id: 'invitation003',
         inviteeId: '',
@@ -66,14 +67,15 @@ void main() {
         invitationCode: '',
       );
 
-      final data = FirestoreMemberInvitationMapper.toFirestore(
+      final data = FirestoreMemberInvitationMapper.toUpdateFirestore(
         memberInvitation,
       );
 
       expect(data['inviteeId'], '');
       expect(data['inviterId'], '');
       expect(data['invitationCode'], '');
-      expect(data['createdAt'], isA<FieldValue>());
+      expect(data.containsKey('createdAt'), isFalse);
+      expect(data['updatedAt'], isA<FieldValue>());
     });
   });
 }

--- a/test/unit/infrastructure/mappers/member/firestore_member_mapper_test.dart
+++ b/test/unit/infrastructure/mappers/member/firestore_member_mapper_test.dart
@@ -45,7 +45,7 @@ void main() {
       expect(result.ownerId, isNull);
     });
 
-    test('MemberからFirestoreのMapへ変換できる', () {
+    test('Memberを新規作成用FirestoreのMapへ変換できる', () {
       final member = Member(
         id: 'member001',
         accountId: 'account001',
@@ -63,7 +63,7 @@ void main() {
         email: 'taro@example.com',
       );
 
-      final data = FirestoreMemberMapper.toFirestore(member);
+      final data = FirestoreMemberMapper.toCreateFirestore(member);
 
       expect(data['accountId'], 'account001');
       expect(data['ownerId'], 'admin001');
@@ -79,12 +79,13 @@ void main() {
       expect(data['gender'], 'male');
       expect(data['email'], 'taro@example.com');
       expect(data['createdAt'], isA<FieldValue>());
+      expect(data['updatedAt'], isA<FieldValue>());
     });
 
-    test('nullフィールドを含むMemberからFirestoreのMapへ変換できる', () {
+    test('nullフィールドを含むMemberでも更新用FirestoreのMapへ変換できる', () {
       final member = Member(id: 'member003', displayName: 'たろちゃん');
 
-      final data = FirestoreMemberMapper.toFirestore(member);
+      final data = FirestoreMemberMapper.toUpdateFirestore(member);
 
       expect(data['accountId'], null);
       expect(data['ownerId'], null);
@@ -102,7 +103,8 @@ void main() {
       expect(data['phoneNumber'], null);
       expect(data['passportNumber'], null);
       expect(data['passportExpiration'], null);
-      expect(data['createdAt'], isA<FieldValue>());
+      expect(data.containsKey('createdAt'), isFalse);
+      expect(data['updatedAt'], isA<FieldValue>());
     });
   });
 }

--- a/test/unit/infrastructure/mappers/trip/firestore_pin_mapper_test.dart
+++ b/test/unit/infrastructure/mappers/trip/firestore_pin_mapper_test.dart
@@ -67,7 +67,7 @@ void main() {
         visitMemo: '観光開始',
       );
 
-      final map = FirestorePinMapper.toFirestore(pin);
+      final map = FirestorePinMapper.toCreateFirestore(pin);
 
       expect(map['pinId'], 'pin-entity-001');
       expect(map['tripId'], 'trip-entity-001');
@@ -79,6 +79,7 @@ void main() {
       expect(map['visitEndDate'], isA<Timestamp>());
       expect(map['visitMemo'], '観光開始');
       expect(map['createdAt'], isA<FieldValue>());
+      expect(map['updatedAt'], isA<FieldValue>());
     });
 
     test('オプショナルプロパティがnullでもFirestoreのMapへ変換できる', () {
@@ -90,7 +91,7 @@ void main() {
         longitude: 127.6811,
       );
 
-      final map = FirestorePinMapper.toFirestore(pin);
+      final map = FirestorePinMapper.toCreateFirestore(pin);
 
       expect(map['pinId'], 'pin-entity-002');
       expect(map['tripId'], 'trip-entity-002');
@@ -102,6 +103,7 @@ void main() {
       expect(map['visitEndDate'], isNull);
       expect(map['visitMemo'], isNull);
       expect(map['createdAt'], isA<FieldValue>());
+      expect(map['updatedAt'], isA<FieldValue>());
     });
 
     test('空文字列を含むPinからFirestoreのMapへ変換できる', () {
@@ -113,7 +115,7 @@ void main() {
         longitude: 0.0,
       );
 
-      final map = FirestorePinMapper.toFirestore(pin);
+      final map = FirestorePinMapper.toCreateFirestore(pin);
 
       expect(map['pinId'], '');
       expect(map['tripId'], '');
@@ -125,6 +127,7 @@ void main() {
       expect(map['visitEndDate'], isNull);
       expect(map['visitMemo'], isNull);
       expect(map['createdAt'], isA<FieldValue>());
+      expect(map['updatedAt'], isA<FieldValue>());
     });
   });
 }

--- a/test/unit/infrastructure/mappers/trip/firestore_task_mapper_test.dart
+++ b/test/unit/infrastructure/mappers/trip/firestore_task_mapper_test.dart
@@ -69,7 +69,7 @@ void main() {
         assignedMemberId: 'member001',
       );
 
-      final map = firestore_mapper.FirestoreTaskMapper.toFirestore(task);
+      final map = firestore_mapper.FirestoreTaskMapper.toCreateFirestore(task);
 
       expect(map['tripId'], 'trip001');
       expect(map['orderIndex'], 0);
@@ -80,6 +80,7 @@ void main() {
       expect(map['assignedMemberId'], 'member001');
       expect(map['dueDate'], isNotNull);
       expect(map['createdAt'], isNotNull);
+      expect(map['updatedAt'], isNotNull);
     });
   });
 }

--- a/test/unit/infrastructure/mappers/trip/firestore_task_mapper_test.dart
+++ b/test/unit/infrastructure/mappers/trip/firestore_task_mapper_test.dart
@@ -82,24 +82,5 @@ void main() {
       expect(map['createdAt'], isNotNull);
       expect(map['updatedAt'], isNotNull);
     });
-
-    test('Taskエンティティを更新用Firestoreマップへ変換できる', () {
-      final task = Task(
-        id: 'task001',
-        tripId: 'trip001',
-        orderIndex: 1,
-        name: '更新準備',
-        isCompleted: false,
-      );
-
-      final map = firestore_mapper.FirestoreTaskMapper.toUpdateFirestore(task);
-
-      expect(map['tripId'], 'trip001');
-      expect(map['orderIndex'], 1);
-      expect(map['name'], '更新準備');
-      expect(map['isCompleted'], false);
-      expect(map.containsKey('createdAt'), isFalse);
-      expect(map['updatedAt'], isNotNull);
-    });
   });
 }

--- a/test/unit/infrastructure/mappers/trip/firestore_task_mapper_test.dart
+++ b/test/unit/infrastructure/mappers/trip/firestore_task_mapper_test.dart
@@ -82,5 +82,24 @@ void main() {
       expect(map['createdAt'], isNotNull);
       expect(map['updatedAt'], isNotNull);
     });
+
+    test('Taskエンティティを更新用Firestoreマップへ変換できる', () {
+      final task = Task(
+        id: 'task001',
+        tripId: 'trip001',
+        orderIndex: 1,
+        name: '更新準備',
+        isCompleted: false,
+      );
+
+      final map = firestore_mapper.FirestoreTaskMapper.toUpdateFirestore(task);
+
+      expect(map['tripId'], 'trip001');
+      expect(map['orderIndex'], 1);
+      expect(map['name'], '更新準備');
+      expect(map['isCompleted'], false);
+      expect(map.containsKey('createdAt'), isFalse);
+      expect(map['updatedAt'], isNotNull);
+    });
   });
 }

--- a/test/unit/infrastructure/mappers/trip/firestore_trip_entry_mapper_test.dart
+++ b/test/unit/infrastructure/mappers/trip/firestore_trip_entry_mapper_test.dart
@@ -67,7 +67,7 @@ void main() {
       expect(result.tripEndDate, isNull);
     });
 
-    test('TripEntryからFirestoreのMapへ変換できる', () {
+    test('TripEntryを新規作成用FirestoreのMapへ変換できる', () {
       final tripEntry = TripEntry(
         id: 'trip001',
         groupId: 'group001',
@@ -78,7 +78,7 @@ void main() {
         tripMemo: 'テストメモ',
       );
 
-      final data = FirestoreTripEntryMapper.toFirestore(tripEntry);
+      final data = FirestoreTripEntryMapper.toCreateFirestore(tripEntry);
 
       expect(data['groupId'], 'group001');
       expect(data['tripYear'], 2025);
@@ -87,16 +87,17 @@ void main() {
       expect(data['tripEndDate'], isA<Timestamp>());
       expect(data['tripMemo'], 'テストメモ');
       expect(data['createdAt'], isA<FieldValue>());
+      expect(data['updatedAt'], isA<FieldValue>());
     });
 
-    test('旅行期間が未設定の場合はtripYearのみで保存できる', () {
+    test('旅行期間が未設定でも更新用FirestoreのMapへ変換できる', () {
       final tripEntry = TripEntry(
         id: 'trip002',
         groupId: 'group002',
         tripYear: 2025,
       );
 
-      final data = FirestoreTripEntryMapper.toFirestore(tripEntry);
+      final data = FirestoreTripEntryMapper.toUpdateFirestore(tripEntry);
 
       expect(data['groupId'], 'group002');
       expect(data['tripYear'], 2025);
@@ -104,7 +105,8 @@ void main() {
       expect(data['tripStartDate'], isNull);
       expect(data['tripEndDate'], isNull);
       expect(data['tripMemo'], null);
-      expect(data['createdAt'], isA<FieldValue>());
+      expect(data.containsKey('createdAt'), isFalse);
+      expect(data['updatedAt'], isA<FieldValue>());
     });
   });
 }

--- a/test/unit/infrastructure/repositories/group/firestore_group_event_repository_test.dart
+++ b/test/unit/infrastructure/repositories/group/firestore_group_event_repository_test.dart
@@ -56,6 +56,7 @@ void main() {
               containsPair('groupId', 'group001'),
               containsPair('year', 2025),
               containsPair('memo', 'テストメモ'),
+              contains('createdAt'),
               contains('updatedAt'),
             ]),
           ),
@@ -63,7 +64,7 @@ void main() {
       ).called(1);
     });
 
-    test('idがある場合は該当ドキュメントをsetする', () async {
+    test('idがある場合は該当ドキュメントをupdateする', () async {
       const groupEvent = GroupEvent(
         id: 'groupevent001',
         groupId: 'group001',
@@ -73,19 +74,23 @@ void main() {
       final mockDocRef = MockDocumentReference<Map<String, dynamic>>();
 
       when(mockCollection.doc(groupEvent.id)).thenReturn(mockDocRef);
-      when(mockDocRef.set(any)).thenAnswer((_) async {});
+      when(mockDocRef.update(any)).thenAnswer((_) async {});
 
       await repository.saveGroupEvent(groupEvent);
 
       verify(mockCollection.doc(groupEvent.id)).called(1);
       verify(
-        mockDocRef.set(
+        mockDocRef.update(
           argThat(
             allOf([
               containsPair('groupId', 'group001'),
               containsPair('year', 2025),
               containsPair('memo', '更新後メモ'),
               contains('updatedAt'),
+              predicate<Map<String, dynamic>>(
+                (data) => !data.containsKey('createdAt'),
+                'createdAtを含まない',
+              ),
             ]),
           ),
         ),

--- a/test/unit/infrastructure/repositories/group/firestore_group_repository_test.dart
+++ b/test/unit/infrastructure/repositories/group/firestore_group_repository_test.dart
@@ -112,6 +112,7 @@ void main() {
           ),
         ),
       ).called(1);
+      verify(mockBatch.commit()).called(1);
     });
 
     test('deleteGroupがgroups collectionの該当ドキュメントを削除する', () async {

--- a/test/unit/infrastructure/repositories/group/firestore_group_repository_test.dart
+++ b/test/unit/infrastructure/repositories/group/firestore_group_repository_test.dart
@@ -53,8 +53,65 @@ void main() {
       expect(result, 'auto_generated_id');
       verify(mockFirestore.batch()).called(1);
       verify(mockCollection.doc()).called(1);
-      verify(mockBatch.set(mockDocRef, any)).called(1);
+      verify(
+        mockBatch.set(
+          mockDocRef,
+          argThat(
+            allOf([
+              containsPair('ownerId', 'admin001'),
+              containsPair('name', 'テストグループ'),
+              containsPair('memo', 'テストメモ'),
+              contains('createdAt'),
+              contains('updatedAt'),
+            ]),
+          ),
+        ),
+      ).called(1);
       verify(mockBatch.commit()).called(1);
+    });
+
+    test('updateGroupがgroups collectionの該当ドキュメントを差分更新する', () async {
+      final group = Group(id: 'group001', ownerId: 'admin001', name: '更新後グループ');
+      final mockDocRef = MockDocumentReference<Map<String, dynamic>>();
+      final mockBatch = MockWriteBatch();
+      final mockGroupMembersCollection =
+          MockCollectionReference<Map<String, dynamic>>();
+      final mockGroupMembersQuery = MockQuery<Map<String, dynamic>>();
+      final mockGroupMembersSnapshot =
+          MockQuerySnapshot<Map<String, dynamic>>();
+
+      when(mockFirestore.batch()).thenReturn(mockBatch);
+      when(mockCollection.doc('group001')).thenReturn(mockDocRef);
+      when(
+        mockFirestore.collection('group_members'),
+      ).thenReturn(mockGroupMembersCollection);
+      when(
+        mockGroupMembersCollection.where('groupId', isEqualTo: 'group001'),
+      ).thenReturn(mockGroupMembersQuery);
+      when(
+        mockGroupMembersQuery.get(),
+      ).thenAnswer((_) async => mockGroupMembersSnapshot);
+      when(mockGroupMembersSnapshot.docs).thenReturn([]);
+      when(mockBatch.commit()).thenAnswer((_) async {});
+
+      await repository.updateGroup(group);
+
+      verify(
+        mockBatch.update(
+          mockDocRef,
+          argThat(
+            allOf([
+              containsPair('ownerId', 'admin001'),
+              containsPair('name', '更新後グループ'),
+              contains('updatedAt'),
+              predicate<Map<String, dynamic>>(
+                (data) => !data.containsKey('createdAt'),
+                'createdAtを含まない',
+              ),
+            ]),
+          ),
+        ),
+      ).called(1);
     });
 
     test('deleteGroupがgroups collectionの該当ドキュメントを削除する', () async {

--- a/test/unit/infrastructure/repositories/group/firestore_group_repository_test.dart
+++ b/test/unit/infrastructure/repositories/group/firestore_group_repository_test.dart
@@ -112,7 +112,6 @@ void main() {
           ),
         ),
       ).called(1);
-      verify(mockBatch.commit()).called(1);
     });
 
     test('deleteGroupがgroups collectionの該当ドキュメントを削除する', () async {

--- a/test/unit/infrastructure/repositories/member/firestore_member_invitation_repository_test.dart
+++ b/test/unit/infrastructure/repositories/member/firestore_member_invitation_repository_test.dart
@@ -55,6 +55,8 @@ void main() {
                 containsPair('inviterId', 'inviter001'),
                 containsPair('inviteeId', 'invitee001'),
                 containsPair('invitationCode', 'CODE123'),
+                contains('createdAt'),
+                contains('updatedAt'),
               ]),
             ),
           ),
@@ -74,7 +76,7 @@ void main() {
 
         final mockDocRef = MockDocumentReference<Map<String, dynamic>>();
         when(mockCollection.doc('invitation001')).thenReturn(mockDocRef);
-        when(mockDocRef.set(any)).thenAnswer((_) async {});
+        when(mockDocRef.update(any)).thenAnswer((_) async {});
 
         await repository.updateMemberInvitation(memberInvitation);
 
@@ -86,6 +88,11 @@ void main() {
                 containsPair('inviterId', 'inviter001'),
                 containsPair('inviteeId', 'invitee001'),
                 containsPair('invitationCode', 'CODE123'),
+                contains('updatedAt'),
+                predicate<Map<String, dynamic>>(
+                  (data) => !data.containsKey('createdAt'),
+                  'createdAtを含まない',
+                ),
               ]),
             ),
           ),

--- a/test/unit/infrastructure/repositories/member/firestore_member_repository_test.dart
+++ b/test/unit/infrastructure/repositories/member/firestore_member_repository_test.dart
@@ -66,6 +66,38 @@ void main() {
               containsPair('email', 'taro@example.com'),
               contains('birthday'),
               contains('createdAt'),
+              contains('updatedAt'),
+            ]),
+          ),
+        ),
+      ).called(1);
+    });
+
+    test('updateMemberがmembers collectionの該当ドキュメントを差分更新する', () async {
+      final member = Member(
+        id: 'member001',
+        ownerId: 'admin001',
+        displayName: '更新後表示名',
+      );
+      final mockDocRef = MockDocumentReference<Map<String, dynamic>>();
+
+      when(mockCollection.doc('member001')).thenReturn(mockDocRef);
+      when(mockDocRef.update(any)).thenAnswer((_) async {});
+
+      await repository.updateMember(member);
+
+      verify(mockCollection.doc('member001')).called(1);
+      verify(
+        mockDocRef.update(
+          argThat(
+            allOf([
+              containsPair('ownerId', 'admin001'),
+              containsPair('displayName', '更新後表示名'),
+              contains('updatedAt'),
+              predicate<Map<String, dynamic>>(
+                (data) => !data.containsKey('createdAt'),
+                'createdAtを含まない',
+              ),
             ]),
           ),
         ),

--- a/test/unit/infrastructure/repositories/trip/firestore_trip_entry_repository_test.dart
+++ b/test/unit/infrastructure/repositories/trip/firestore_trip_entry_repository_test.dart
@@ -122,7 +122,13 @@ void main() {
       final mockPinsSnapshot = MockQuerySnapshot<Map<String, dynamic>>();
       final mockTasksQuery = MockQuery<Map<String, dynamic>>();
       final mockTasksSnapshot = MockQuerySnapshot<Map<String, dynamic>>();
-      final mockTaskDocRefWithId =
+      final mockExistingTaskDoc =
+          MockQueryDocumentSnapshot<Map<String, dynamic>>();
+      final mockExistingTaskDocRef =
+          MockDocumentReference<Map<String, dynamic>>();
+      final mockDeletedTaskDoc =
+          MockQueryDocumentSnapshot<Map<String, dynamic>>();
+      final mockDeletedTaskDocRef =
           MockDocumentReference<Map<String, dynamic>>();
 
       when(mockCollection.doc('trip001')).thenReturn(mockTripDocRef);
@@ -138,11 +144,13 @@ void main() {
         mockTasksCollection.where('tripId', isEqualTo: 'trip001'),
       ).thenReturn(mockTasksQuery);
       when(mockTasksQuery.get()).thenAnswer((_) async => mockTasksSnapshot);
-      when(mockTasksSnapshot.docs).thenReturn([]);
-
       when(
-        mockTasksCollection.doc('task-uuid'),
-      ).thenReturn(mockTaskDocRefWithId);
+        mockTasksSnapshot.docs,
+      ).thenReturn([mockExistingTaskDoc, mockDeletedTaskDoc]);
+      when(mockExistingTaskDoc.id).thenReturn('task-uuid');
+      when(mockExistingTaskDoc.reference).thenReturn(mockExistingTaskDocRef);
+      when(mockDeletedTaskDoc.id).thenReturn('task-deleted');
+      when(mockDeletedTaskDoc.reference).thenReturn(mockDeletedTaskDocRef);
       when(mockBatch.commit()).thenAnswer((_) async {});
 
       await repository.updateTripEntry(tripEntry);
@@ -163,7 +171,24 @@ void main() {
           ),
         ),
       ).called(1);
-      verify(mockTasksCollection.doc('task-uuid')).called(1);
+      verifyNever(mockBatch.delete(mockExistingTaskDocRef));
+      verify(
+        mockBatch.update(
+          mockExistingTaskDocRef,
+          argThat(
+            allOf([
+              containsPair('tripId', 'trip001'),
+              containsPair('name', '準備'),
+              contains('updatedAt'),
+              predicate<Map<String, dynamic>>(
+                (data) => !data.containsKey('createdAt'),
+                'createdAtを含まない',
+              ),
+            ]),
+          ),
+        ),
+      ).called(1);
+      verify(mockBatch.delete(mockDeletedTaskDocRef)).called(1);
     });
 
     test(

--- a/test/unit/infrastructure/repositories/trip/firestore_trip_entry_repository_test.dart
+++ b/test/unit/infrastructure/repositories/trip/firestore_trip_entry_repository_test.dart
@@ -98,7 +98,7 @@ void main() {
       },
     );
 
-    test('updateTripEntryが既存タスクのidを保持したまま更新する', () async {
+    test('updateTripEntryが既存タスクを削除して再作成する', () async {
       final tripEntry = TripEntry(
         id: 'trip001',
         groupId: 'group001',
@@ -126,9 +126,7 @@ void main() {
           MockQueryDocumentSnapshot<Map<String, dynamic>>();
       final mockExistingTaskDocRef =
           MockDocumentReference<Map<String, dynamic>>();
-      final mockDeletedTaskDoc =
-          MockQueryDocumentSnapshot<Map<String, dynamic>>();
-      final mockDeletedTaskDocRef =
+      final mockTaskDocRefWithId =
           MockDocumentReference<Map<String, dynamic>>();
 
       when(mockCollection.doc('trip001')).thenReturn(mockTripDocRef);
@@ -144,13 +142,12 @@ void main() {
         mockTasksCollection.where('tripId', isEqualTo: 'trip001'),
       ).thenReturn(mockTasksQuery);
       when(mockTasksQuery.get()).thenAnswer((_) async => mockTasksSnapshot);
-      when(
-        mockTasksSnapshot.docs,
-      ).thenReturn([mockExistingTaskDoc, mockDeletedTaskDoc]);
+      when(mockTasksSnapshot.docs).thenReturn([mockExistingTaskDoc]);
       when(mockExistingTaskDoc.id).thenReturn('task-uuid');
       when(mockExistingTaskDoc.reference).thenReturn(mockExistingTaskDocRef);
-      when(mockDeletedTaskDoc.id).thenReturn('task-deleted');
-      when(mockDeletedTaskDoc.reference).thenReturn(mockDeletedTaskDocRef);
+      when(
+        mockTasksCollection.doc('task-uuid'),
+      ).thenReturn(mockTaskDocRefWithId);
       when(mockBatch.commit()).thenAnswer((_) async {});
 
       await repository.updateTripEntry(tripEntry);
@@ -171,24 +168,23 @@ void main() {
           ),
         ),
       ).called(1);
-      verifyNever(mockBatch.delete(mockExistingTaskDocRef));
       verify(
-        mockBatch.update(
-          mockExistingTaskDocRef,
+        mockBatch.delete(mockExistingTaskDocRef),
+      ).called(1);
+      verify(mockTasksCollection.doc('task-uuid')).called(1);
+      verify(
+        mockBatch.set(
+          mockTaskDocRefWithId,
           argThat(
             allOf([
               containsPair('tripId', 'trip001'),
               containsPair('name', '準備'),
+              contains('createdAt'),
               contains('updatedAt'),
-              predicate<Map<String, dynamic>>(
-                (data) => !data.containsKey('createdAt'),
-                'createdAtを含まない',
-              ),
             ]),
           ),
         ),
       ).called(1);
-      verify(mockBatch.delete(mockDeletedTaskDocRef)).called(1);
     });
 
     test(

--- a/test/unit/infrastructure/repositories/trip/firestore_trip_entry_repository_test.dart
+++ b/test/unit/infrastructure/repositories/trip/firestore_trip_entry_repository_test.dart
@@ -78,6 +78,20 @@ void main() {
         expect(result, equals('generated-doc-id'));
         verify(mockFirestore.batch()).called(1);
         verify(mockCollection.doc()).called(1);
+        verify(
+          mockBatch.set(
+            mockDocRef,
+            argThat(
+              allOf([
+                containsPair('groupId', 'group001'),
+                containsPair('tripYear', 2025),
+                containsPair('tripName', 'テスト旅行'),
+                contains('createdAt'),
+                contains('updatedAt'),
+              ]),
+            ),
+          ),
+        ).called(1);
         verify(mockTasksCollection.doc('task-001')).called(1);
         verify(mockBatch.set(mockTaskDocRef, any)).called(1);
         verify(mockBatch.commit()).called(1);
@@ -133,6 +147,22 @@ void main() {
 
       await repository.updateTripEntry(tripEntry);
 
+      verify(
+        mockBatch.update(
+          mockTripDocRef,
+          argThat(
+            allOf([
+              containsPair('groupId', 'group001'),
+              containsPair('tripYear', 2025),
+              contains('updatedAt'),
+              predicate<Map<String, dynamic>>(
+                (data) => !data.containsKey('createdAt'),
+                'createdAtを含まない',
+              ),
+            ]),
+          ),
+        ),
+      ).called(1);
       verify(mockTasksCollection.doc('task-uuid')).called(1);
     });
 

--- a/test/unit/infrastructure/repositories/trip/firestore_trip_entry_repository_test.dart
+++ b/test/unit/infrastructure/repositories/trip/firestore_trip_entry_repository_test.dart
@@ -168,9 +168,7 @@ void main() {
           ),
         ),
       ).called(1);
-      verify(
-        mockBatch.delete(mockExistingTaskDocRef),
-      ).called(1);
+      verify(mockBatch.delete(mockExistingTaskDocRef)).called(1);
       verify(mockTasksCollection.doc('task-uuid')).called(1);
       verify(
         mockBatch.set(


### PR DESCRIPTION
## 概要
- Firestore Mapper を新規作成用と更新用で分離
- 新規作成時は `createdAt` と `updatedAt` を付与し、更新時は `updatedAt` のみを付与
- Firestore Repository の既存ドキュメント更新を `set` ではなく `update` に統一
- 関連するインフラ層テストを追加・更新

## 対応したdone
- FirestoreのMapperは新規作成用と更新用で出し分ける方針に統一する
  - 新規作成時は`createdAt`と`updatedAt`の両方に`FieldValue.serverTimestamp()`を設定する
  - 更新時は`createdAt`を更新データに含めず、`updatedAt`のみ更新する
- FirestoreのRepositoryは既存ドキュメント更新時に全置換の`set`を使わず、`update`で差分更新する方針に統一する
  - 新規作成時のみ`add`または新規`doc`への`set`を使用する
  - 既存フィールドを保持したいが`update`を使えないケースがある場合のみ、理由を明記したうえで`set(..., SetOptions(merge: true))`を許容する

## 確認
- `./check.sh`