### PR TITLE
docs: メンバー別イベントのER図をユーザーストーリーに合わせて修正

### DIFF
--- a/docs/er_diagram.md
+++ b/docs/er_diagram.md
@@ -74,11 +74,8 @@ erDiagram
     member_events {
         string id PK
         string memberId FK "NOT NULL"
-        string type "NOT NULL"
-        string name
-        timestamp startDate "NOT NULL"
-        timestamp endDate "NOT NULL"
-        string memo
+        number year "NOT NULL"
+        string memo "NOT NULL"
     }
     member_invitations {
         string id PK


### PR DESCRIPTION
## 概要
- `docs/user_stories.md` のメンバー別イベントの振る舞いに合わせて `docs/er_diagram.md` の `member_events` テーブル定義を修正
- `group_events` と同様に、年表セル単位で扱う構造へ整理

## 変更内容
- `member_events` から `type` を削除
- `member_events` から `name` を削除
- `member_events` から `startDate` を削除
- `member_events` から `endDate` を削除
- `member_events` に `year` を追加
- `member_events.memo` を `NOT NULL` に変更

## 変更理由
- ユーザーストーリーではメンバー別イベントは「年表の2024年セルを選択し、フリー入力メモを保存する」単位で管理される
- そのため、日付範囲や種別を持つ現行ER図より、`group_events` と同じく `year + memo` を持つ形のほうが仕様に整合する

## 確認
- ドキュメント更新のみのためテストは未実施