### PR TITLE
docs: ユーザーイベント改修タスクを追加

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -2,12 +2,12 @@
 
 ## DB設計・リポジトリ・ユースケース・DTO・マッパー関連
 
-- ER図のユーザーイベント設計（`member_events`）に合わせて、メンバー別イベントの永続化契約を `memberId` / `year` / `memo` ベースへ統一する
-- `MemberEvent` / `MemberEventDto` / `MemberEventMapper` / `FirestoreMemberEventMapper` から旧設計の `type` / `name` / `startDate` / `endDate` を除去し、ER図どおりの項目だけを扱うようにする
+- ER図のユーザーイベント設計（`member_events` / メンバー別イベント）に合わせて、永続化契約を `memberId` / `year` / `memo` ベースへ統一し、`id` は Firestore のドキュメントIDとして扱う方針を明記する
+- `MemberEvent` / `MemberEventDto` / `MemberEventMapper` / `FirestoreMemberEventMapper` から旧設計の `type` / `name` / `startDate` / `endDate` を除去し、ER図どおりの項目だけを扱うようにする。また、業務上の一意性は `memberId` + `year` で担保する前提で責務を整理する
 - `MemberEventRepository` / `FirestoreMemberEventRepository` の保存処理を年表セル前提に見直し、同一 `memberId`・同一年の既存レコードがあれば更新、メモが空なら削除、存在しなければ新規作成に整理する
-- `member_events` 用のクエリ処理をER図準拠で見直し、年表表示に必要な単位でメンバー別イベントを取得できる `QueryService` / Firestore実装 / factory配線を追加または改修する
-- メンバー別イベントの取得・保存ユースケースを、上記のリポジトリ契約とクエリ契約に合わせて整理し、Presentation層へ旧フィールド前提を漏らさない構成にする
-- `member_events` 関連の unit test を、entity / dto / mapper / repository / query / usecase ごとにER図準拠の期待値へ更新する
+- ユーザーイベント（`member_events` / メンバー別イベント）用のクエリ処理をER図準拠で見直し、年表表示に必要な単位で取得できる `QueryService` / Firestore実装 / factory配線を追加または改修する
+- ユーザーイベント（`member_events` / メンバー別イベント）の取得・保存ユースケースを、上記のリポジトリ契約とクエリ契約に合わせて整理し、Presentation層へ旧フィールド前提を漏らさない構成にする
+- ユーザーイベント（`member_events` / メンバー別イベント）関連の unit test を、entity / dto / mapper / repository / query / usecase ごとにER図準拠の期待値へ更新する
 - このタスクでは年表UIの見た目変更や入力導線の追加には踏み込まず、リポジトリおよびクエリ関連の整合性修正に範囲を限定する
 
 ## マップの表示

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -2,6 +2,14 @@
 
 ## DB設計・リポジトリ・ユースケース・DTO・マッパー関連
 
+- ER図のユーザーイベント設計（`member_events`）に合わせて、メンバー別イベントの永続化契約を `memberId` / `year` / `memo` ベースへ統一する
+- `MemberEvent` / `MemberEventDto` / `MemberEventMapper` / `FirestoreMemberEventMapper` から旧設計の `type` / `name` / `startDate` / `endDate` を除去し、ER図どおりの項目だけを扱うようにする
+- `MemberEventRepository` / `FirestoreMemberEventRepository` の保存処理を年表セル前提に見直し、同一 `memberId`・同一年の既存レコードがあれば更新、メモが空なら削除、存在しなければ新規作成に整理する
+- `member_events` 用のクエリ処理をER図準拠で見直し、年表表示に必要な単位でメンバー別イベントを取得できる `QueryService` / Firestore実装 / factory配線を追加または改修する
+- メンバー別イベントの取得・保存ユースケースを、上記のリポジトリ契約とクエリ契約に合わせて整理し、Presentation層へ旧フィールド前提を漏らさない構成にする
+- `member_events` 関連の unit test を、entity / dto / mapper / repository / query / usecase ごとにER図準拠の期待値へ更新する
+- このタスクでは年表UIの見た目変更や入力導線の追加には踏み込まず、リポジトリおよびクエリ関連の整合性修正に範囲を限定する
+
 ## マップの表示
 
 


### PR DESCRIPTION
## 概要
- `docs/todo.md` に、ER図のユーザーイベント設計（`member_events`）へ合わせてリポジトリおよびクエリ関連の処理を修正するための作業タスクを追加
- 対象を `member_events` の永続化契約、リポジトリ、クエリ、ユースケース、関連テストに限定するよう明記
- UI変更は今回のタスク範囲外であることを明記

## 背景
- 現状の `member_events` 関連実装は `type` / `name` / `startDate` / `endDate` ベースの旧設計が残っている
- ER図とユーザーストーリーは、年表セル前提の `memberId` / `year` / `memo` ベースへ整理されている
- 実装着手時に作業がブレないよう、事前に修正範囲と期待する責務を `todo` として固定した

## 変更内容
- `docs/todo.md` の `DB設計・リポジトリ・ユースケース・DTO・マッパー関連` に 7 項目を追加
- 保存契約、QueryService、Factory配線、ユースケース、unit test 更新の観点を具体化
- 年表UI変更は非対象とする指示を追加

## 確認
- テスト未実施（`docs/todo.md` のみの変更のため）