### PR TITLE
docs: Google API整理方針のtodoを追加

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -23,7 +23,21 @@
 
 ## 旅行管理画面
 
+- 経路検索機能を廃止する
+  - `RouteInfoView`、`RouteMap`、経路検索ボタン、経路検索結果表示、経路検索結果保存処理を削除する
+  - `FetchRouteInfoUsecase`、`RouteInfoService`、`GoogleRoutesApiRouteInfoService`、関連factory/config/providerを削除する
+  - Routes API呼び出し、Routes API用テスト、経路検索用DTO・画面テストを整理する
+  - 旅行の訪問場所・タスク管理は維持し、経路検索廃止後も既存の旅行編集フローが成立するようにする
+  - 仕様書・done/todo内の経路検索に関する記述を廃止方針に合わせて整理する
+
 ## 地図画面
+
+- Places API呼び出しを`googleapis`の`places_v1`経由に移行し、URL直接呼び出しを廃止する
+  - `googleapis`を依存関係に追加し、Context7で最新の利用方法を確認してから実装する
+  - 地名検索はPlaces API NewのText Searchへ寄せ、`PlacesApi.places.searchText`から`LocationCandidateDto`へ変換する
+  - ピン位置からの場所名取得は`PlacesApi.places.searchNearby`へ寄せ、`NearbyLocationService`の外部契約を維持する
+  - `http`による`maps.googleapis.com`・`places.googleapis.com`へのPlaces API直接呼び出しを削除する
+  - FieldMask、言語指定、空結果、エラー時の扱いを既存仕様に合わせてテストで確認する
 
 ## マップピンボトムシート
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -33,7 +33,7 @@
 ## 地図画面
 
 - Places API呼び出しを`googleapis`の`places_v1`経由に移行し、URL直接呼び出しを廃止する
-  - `googleapis`を依存関係に追加し、Context7で最新の利用方法を確認してから実装する
+  - `googleapis`を依存関係に追加し、最新の利用方法を確認してから実装する
   - 地名検索はPlaces API NewのText Searchへ寄せ、`PlacesApi.places.searchText`から`LocationCandidateDto`へ変換する
   - ピン位置からの場所名取得は`PlacesApi.places.searchNearby`へ寄せ、`NearbyLocationService`の外部契約を維持する
   - `http`による`maps.googleapis.com`・`places.googleapis.com`へのPlaces API直接呼び出しを削除する


### PR DESCRIPTION
## 概要

- Places API呼び出しを`googleapis`の`places_v1`経由に寄せ、URL直接呼び出しを廃止するtodoを追加
- Routes APIを使った経路検索機能を廃止するtodoを追加

## 確認

- `./check.sh`

## 補足

- 今回はtodo作成のみのため、`docs/done.md`への移動は行っていません。