### PR TITLE
test: 期待例外のログ出力を抑制

### DIFF
--- a/lib/core/app_logger.dart
+++ b/lib/core/app_logger.dart
@@ -18,6 +18,8 @@ Future<void> initLogger() async {
   );
 }
 
+abstract interface class ConsoleLogSuppressedException implements Exception {}
+
 class AppLogger {
   static bool _suppressLogging = false;
 
@@ -26,13 +28,21 @@ class AppLogger {
   }
 
   static bool get isLoggingSuppressed => _suppressLogging;
+
+  static bool shouldSuppressConsoleOutput(OutputEvent event) {
+    if (_suppressLogging) {
+      _suppressLogging = false;
+      return true;
+    }
+
+    return event.origin.error is ConsoleLogSuppressedException;
+  }
 }
 
 class ConsoleOutput extends LogOutput {
   @override
   void output(OutputEvent event) {
-    if (AppLogger.isLoggingSuppressed) {
-      AppLogger.suppressLogging(false);
+    if (AppLogger.shouldSuppressConsoleOutput(event)) {
       return;
     }
 

--- a/test/helpers/test_exception.dart
+++ b/test/helpers/test_exception.dart
@@ -1,11 +1,9 @@
 import 'package:memora/core/app_logger.dart';
 
-class TestException implements Exception {
+class TestException implements ConsoleLogSuppressedException {
   final String message;
 
-  TestException([this.message = 'テストエラー']) {
-    AppLogger.suppressLogging(true);
-  }
+  TestException([this.message = 'テストエラー']);
 
   @override
   String toString() => 'TestException: $message';

--- a/test/unit/infrastructure/services/places_sdk_nearby_location_service_test.dart
+++ b/test/unit/infrastructure/services/places_sdk_nearby_location_service_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:memora/core/app_logger.dart';
 import 'package:memora/core/models/coordinate.dart';
 import 'package:memora/infrastructure/services/places_sdk_nearby_location_service.dart';
 
@@ -46,6 +47,7 @@ void main() {
 
       final service = PlacesSdkNearbyLocationService(channel: channel);
 
+      AppLogger.suppressLogging(true);
       final result = await service.getLocationName(
         const Coordinate(latitude: 35.6586, longitude: 139.7454),
       );

--- a/test/unit/presentation/features/group/group_event_edit_modal_test.dart
+++ b/test/unit/presentation/features/group/group_event_edit_modal_test.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:memora/presentation/features/group/group_event_edit_modal.dart';
 
+import '../../../../helpers/test_exception.dart';
+
 void main() {
   group('showGroupEventEditModal', () {
     Widget buildSubject({
@@ -92,7 +94,7 @@ void main() {
     testWidgets('保存失敗時はSnackBarでフィードバックする', (tester) async {
       await tester.pumpWidget(
         buildSubject(
-          onSave: (_) async => throw Exception('保存失敗'),
+          onSave: (_) async => throw TestException('保存失敗'),
           selectedYear: 2026,
           initialMemo: '',
         ),


### PR DESCRIPTION
## 概要
- 期待例外を表す `ConsoleLogSuppressedException` を追加し、`AppLogger` のコンソール出力で該当例外を抑制
- `TestException` は `ConsoleLogSuppressedException` を実装するだけにし、`AppLogger.suppressLogging(true)` の副作用は廃止
- MethodChannel 経由で `PlatformException` に包まれる失敗テストは、該当テスト側で `AppLogger.suppressLogging(true)` を明示して抑制
- 保存失敗やグループ一覧取得失敗など、期待例外を検証するテストを `TestException` に統一

## 確認
- `./check.sh`
- `/tmp/memora_check_pr.log` を ANSI 除去後に検索し、`PlatformException` / `TestException` / `Exception:` / ログ枠出力が残っていないことを確認