### PR TITLE
docs: 旅程項目実装todoを追加

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -10,7 +10,7 @@
   - `TripEntry`集約に`itineraryItems`を追加し、`TripEntryRepository`、`TripEntryQueryService`、Firestore実装、Factory配線を対応させる
   - `TripEntryDto`、`TripEntryMapper`、`FirestoreTripEntryMapper`を`itineraryItems`に対応させる
   - 保存・更新・削除時に`itinerary_items`を旅行単位で同期し、取得時は`orderIndex`順に並べる
-  - `name`必須、`orderIndex`は0以上、終了日時は開始日時以降であることを検証する
+  - `name`必須、`orderIndex`は0以上、終了日時は開始日時以降、日時は旅行期間の開始2日前から終了2日後までの範囲内であることを検証する
   - 旅程項目の取得・保存に関するユースケースとテストを追加する
 
 ## マップの表示

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -11,7 +11,6 @@
   - `TripEntryDto`、`TripEntryMapper`、`FirestoreTripEntryMapper`を`itineraryItems`に対応させる
   - 保存・更新・削除時に`itinerary_items`を旅行単位で同期し、取得時は`orderIndex`順に並べる
   - `name`必須、`orderIndex`は0以上、終了日時は開始日時以降、日時は旅行期間の開始2日前から終了2日後までの範囲内であることを検証する
-  - 旅程項目の取得・保存に関するユースケースとテストを追加する
 
 ## マップの表示
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,6 +1,17 @@
 # ToDo List
 
 ## DB設計・リポジトリ・ユースケース・DTO・マッパー関連
+- ER図のitinerary_itemsテーブル定義を元に旅程項目を実装する
+  - `ItineraryItem`エンティティを作成する
+  - `ItineraryItemDto`を作成する
+  - `ItineraryItemMapper`を作成する
+  - `FirestoreItineraryItemMapper`を作成する
+  - `ItineraryItemQueryService`と`FirestoreItineraryItemQueryService`を作成し、`tripId`で旅程項目を取得できるようにする
+  - `TripEntry`集約に`itineraryItems`を追加し、`TripEntryRepository`、`TripEntryQueryService`、Firestore実装、Factory配線を対応させる
+  - `TripEntryDto`、`TripEntryMapper`、`FirestoreTripEntryMapper`を`itineraryItems`に対応させる
+  - 保存・更新・削除時に`itinerary_items`を旅行単位で同期し、取得時は`orderIndex`順に並べる
+  - `name`必須、`orderIndex`は0以上、終了日時は開始日時以降であることを検証する
+  - 旅程項目の取得・保存に関するユースケースとテストを追加する
 
 ## マップの表示
 


### PR DESCRIPTION
## 概要
- ER図の`itinerary_items`をベースに、旅程項目のエンティティ、DTO、Mapper、QueryService、Firestore実装を作成するtodoを追加
- `TripEntry`集約、Repository、QueryService、Firestore実装、Factory配線の対応をtodoに含める
- 日時検証は旅行期間や`year`との整合ではなく、終了日時が開始日時以降であることに限定

## 検証
- `./check.sh`