### PR TITLE
fix(trip): 旅行編集の詳細取得を安定化

### DIFF
--- a/lib/infrastructure/queries/trip/firestore_trip_entry_query_service.dart
+++ b/lib/infrastructure/queries/trip/firestore_trip_entry_query_service.dart
@@ -36,37 +36,21 @@ class FirestoreTripEntryQueryService implements TripEntryQueryService {
           .collection('pins')
           .where('tripId', isEqualTo: tripId);
 
-      if (pinsOrderBy != null && pinsOrderBy.isNotEmpty) {
-        for (final order in pinsOrderBy) {
-          pinsQuery = pinsQuery.orderBy(
-            order.field,
-            descending: order.descending,
-          );
-        }
-      }
-
       final pinsSnapshot = await pinsQuery.get();
-      final pins = pinsSnapshot.docs
-          .map((pinDoc) => FirestorePinMapper.fromFirestore(pinDoc))
-          .toList();
+      final pins = _sortDocuments(
+        pinsSnapshot.docs,
+        pinsOrderBy,
+      ).map((pinDoc) => FirestorePinMapper.fromFirestore(pinDoc)).toList();
 
       Query<Map<String, dynamic>> tasksQuery = _firestore
           .collection('tasks')
           .where('tripId', isEqualTo: tripId);
 
-      if (tasksOrderBy != null && tasksOrderBy.isNotEmpty) {
-        for (final order in tasksOrderBy) {
-          tasksQuery = tasksQuery.orderBy(
-            order.field,
-            descending: order.descending,
-          );
-        }
-      }
-
       final tasksSnapshot = await tasksQuery.get();
-      final tasks = tasksSnapshot.docs
-          .map((taskDoc) => FirestoreTaskMapper.fromFirestore(taskDoc))
-          .toList();
+      final tasks = _sortDocuments(
+        tasksSnapshot.docs,
+        tasksOrderBy,
+      ).map((taskDoc) => FirestoreTaskMapper.fromFirestore(taskDoc)).toList();
 
       Query<Map<String, dynamic>> itineraryItemsQuery = _firestore
           .collection('itinerary_items')
@@ -75,20 +59,19 @@ class FirestoreTripEntryQueryService implements TripEntryQueryService {
       final effectiveItineraryItemsOrderBy =
           itineraryItemsOrderBy ??
           const [OrderBy('orderIndex', descending: false)];
-      for (final order in effectiveItineraryItemsOrderBy) {
-        itineraryItemsQuery = itineraryItemsQuery.orderBy(
-          order.field,
-          descending: order.descending,
-        );
-      }
-
       final itineraryItemsSnapshot = await itineraryItemsQuery.get();
-      final itineraryItems = itineraryItemsSnapshot.docs
-          .map(
-            (itineraryItemDoc) =>
-                FirestoreItineraryItemMapper.fromFirestore(itineraryItemDoc),
-          )
-          .toList();
+      final itineraryItems =
+          _sortDocuments(
+                itineraryItemsSnapshot.docs,
+                effectiveItineraryItemsOrderBy,
+              )
+              .map(
+                (itineraryItemDoc) =>
+                    FirestoreItineraryItemMapper.fromFirestore(
+                      itineraryItemDoc,
+                    ),
+              )
+              .toList();
 
       return FirestoreTripEntryMapper.fromFirestore(
         doc,
@@ -142,5 +125,65 @@ class FirestoreTripEntryQueryService implements TripEntryQueryService {
       );
       return [];
     }
+  }
+
+  List<QueryDocumentSnapshot<Map<String, dynamic>>> _sortDocuments(
+    List<QueryDocumentSnapshot<Map<String, dynamic>>> docs,
+    List<OrderBy>? orderBy,
+  ) {
+    if (orderBy == null || orderBy.isEmpty) {
+      return docs;
+    }
+
+    return List<QueryDocumentSnapshot<Map<String, dynamic>>>.from(docs)
+      ..sort((a, b) {
+        for (final order in orderBy) {
+          final comparison = _compareFieldValues(
+            a.data()[order.field],
+            b.data()[order.field],
+          );
+          if (comparison != 0) {
+            return order.descending ? -comparison : comparison;
+          }
+        }
+        return 0;
+      });
+  }
+
+  int _compareFieldValues(Object? a, Object? b) {
+    if (a == null && b == null) {
+      return 0;
+    }
+    if (a == null) {
+      return 1;
+    }
+    if (b == null) {
+      return -1;
+    }
+
+    final normalizedA = _normalizeComparableValue(a);
+    final normalizedB = _normalizeComparableValue(b);
+
+    if (normalizedA is num && normalizedB is num) {
+      return normalizedA.compareTo(normalizedB);
+    }
+    if (normalizedA is DateTime && normalizedB is DateTime) {
+      return normalizedA.compareTo(normalizedB);
+    }
+    if (normalizedA is String && normalizedB is String) {
+      return normalizedA.compareTo(normalizedB);
+    }
+    if (normalizedA is bool && normalizedB is bool) {
+      return normalizedA == normalizedB ? 0 : (normalizedA ? 1 : -1);
+    }
+
+    return normalizedA.toString().compareTo(normalizedB.toString());
+  }
+
+  Object _normalizeComparableValue(Object value) {
+    if (value is Timestamp) {
+      return value.toDate();
+    }
+    return value;
   }
 }

--- a/test/unit/infrastructure/queries/trip/firestore_trip_entry_query_service_test.dart
+++ b/test/unit/infrastructure/queries/trip/firestore_trip_entry_query_service_test.dart
@@ -52,20 +52,26 @@ void main() {
       service = FirestoreTripEntryQueryService(firestore: mockFirestore);
     });
 
-    test('旅行IDで旅行情報を取得し、関連するピンも取得する', () async {
+    test('旅行IDで旅行情報を取得し、関連データを取得後に並び替える', () async {
       const tripId = 'trip123';
       final mockDocRef = MockDocumentReference<Map<String, dynamic>>();
       final mockDocSnapshot = MockDocumentSnapshot<Map<String, dynamic>>();
       final mockPinsQuery = MockQuery<Map<String, dynamic>>();
       final mockPinsSnapshot = MockQuerySnapshot<Map<String, dynamic>>();
       final mockPinDoc = MockQueryDocumentSnapshot<Map<String, dynamic>>();
+      final mockSecondPinDoc =
+          MockQueryDocumentSnapshot<Map<String, dynamic>>();
       final mockTasksQuery = MockQuery<Map<String, dynamic>>();
       final mockTasksSnapshot = MockQuerySnapshot<Map<String, dynamic>>();
       final mockTaskDoc = MockQueryDocumentSnapshot<Map<String, dynamic>>();
+      final mockSecondTaskDoc =
+          MockQueryDocumentSnapshot<Map<String, dynamic>>();
       final mockItineraryItemsQuery = MockQuery<Map<String, dynamic>>();
       final mockItineraryItemsSnapshot =
           MockQuerySnapshot<Map<String, dynamic>>();
       final mockItineraryItemDoc =
+          MockQueryDocumentSnapshot<Map<String, dynamic>>();
+      final mockSecondItineraryItemDoc =
           MockQueryDocumentSnapshot<Map<String, dynamic>>();
 
       when(mockTripEntriesCollection.doc(tripId)).thenReturn(mockDocRef);
@@ -83,11 +89,8 @@ void main() {
       when(
         mockPinsCollection.where('tripId', isEqualTo: tripId),
       ).thenReturn(mockPinsQuery);
-      when(
-        mockPinsQuery.orderBy('visitStartDateTime', descending: false),
-      ).thenReturn(mockPinsQuery);
       when(mockPinsQuery.get()).thenAnswer((_) async => mockPinsSnapshot);
-      when(mockPinsSnapshot.docs).thenReturn([mockPinDoc]);
+      when(mockPinsSnapshot.docs).thenReturn([mockPinDoc, mockSecondPinDoc]);
       when(mockPinDoc.data()).thenReturn({
         'pinId': 'pin001',
         'tripId': tripId,
@@ -99,42 +102,69 @@ void main() {
         'visitEndDateTime': Timestamp.fromDate(DateTime(2024, 8, 2, 15)),
         'memo': '景色が綺麗',
       });
+      when(mockSecondPinDoc.data()).thenReturn({
+        'pinId': 'pin002',
+        'tripId': tripId,
+        'groupId': 'group001',
+        'latitude': 34.0,
+        'longitude': 135.0,
+        'locationName': '京都駅',
+        'visitStartDateTime': Timestamp.fromDate(DateTime(2024, 8, 1, 10)),
+        'visitEndDateTime': Timestamp.fromDate(DateTime(2024, 8, 1, 15)),
+        'memo': '集合',
+      });
 
       when(
         mockTasksCollection.where('tripId', isEqualTo: tripId),
       ).thenReturn(mockTasksQuery);
-      when(
-        mockTasksQuery.orderBy('orderIndex', descending: false),
-      ).thenReturn(mockTasksQuery);
       when(mockTasksQuery.get()).thenAnswer((_) async => mockTasksSnapshot);
-      when(mockTasksSnapshot.docs).thenReturn([mockTaskDoc]);
+      when(mockTasksSnapshot.docs).thenReturn([
+        mockTaskDoc,
+        mockSecondTaskDoc,
+      ]);
       when(mockTaskDoc.data()).thenReturn({
         'tripId': tripId,
-        'orderIndex': 0,
-        'name': '準備',
+        'orderIndex': 2,
+        'name': '荷造り',
         'isCompleted': false,
       });
       when(mockTaskDoc.id).thenReturn('task001');
+      when(mockSecondTaskDoc.data()).thenReturn({
+        'tripId': tripId,
+        'orderIndex': 1,
+        'name': '予約確認',
+        'isCompleted': false,
+      });
+      when(mockSecondTaskDoc.id).thenReturn('task002');
 
       when(
         mockItineraryItemsCollection.where('tripId', isEqualTo: tripId),
       ).thenReturn(mockItineraryItemsQuery);
       when(
-        mockItineraryItemsQuery.orderBy('orderIndex', descending: false),
-      ).thenReturn(mockItineraryItemsQuery);
-      when(
         mockItineraryItemsQuery.get(),
       ).thenAnswer((_) async => mockItineraryItemsSnapshot);
-      when(mockItineraryItemsSnapshot.docs).thenReturn([mockItineraryItemDoc]);
+      when(mockItineraryItemsSnapshot.docs).thenReturn([
+        mockItineraryItemDoc,
+        mockSecondItineraryItemDoc,
+      ]);
       when(mockItineraryItemDoc.data()).thenReturn({
         'tripId': tripId,
-        'orderIndex': 0,
-        'name': '朝食',
+        'orderIndex': 3,
+        'name': '夕食',
         'startDateTime': Timestamp.fromDate(DateTime(2024, 8, 2, 8)),
         'endDateTime': Timestamp.fromDate(DateTime(2024, 8, 2, 9)),
         'memo': 'ホテルで朝食',
       });
       when(mockItineraryItemDoc.id).thenReturn('item001');
+      when(mockSecondItineraryItemDoc.data()).thenReturn({
+        'tripId': tripId,
+        'orderIndex': 1,
+        'name': '朝食',
+        'startDateTime': Timestamp.fromDate(DateTime(2024, 8, 2, 8)),
+        'endDateTime': Timestamp.fromDate(DateTime(2024, 8, 2, 9)),
+        'memo': 'ホテルで朝食',
+      });
+      when(mockSecondItineraryItemDoc.id).thenReturn('item002');
 
       final result = await service.getTripEntryById(
         tripId,
@@ -146,21 +176,19 @@ void main() {
       expect(result, isNotNull);
       expect(result!.id, equals(tripId));
       expect(result.name, equals('夏旅行'));
-      expect(result.pins, hasLength(1));
+      expect(result.pins, hasLength(2));
       final PinDto pin = result.pins!.first;
-      expect(pin.locationName, equals('東京タワー'));
-      expect(result.tasks, hasLength(1));
-      expect(result.tasks!.first.name, '準備');
-      expect(result.itineraryItems, hasLength(1));
+      expect(pin.locationName, equals('京都駅'));
+      expect(result.tasks, hasLength(2));
+      expect(result.tasks!.first.name, '予約確認');
+      expect(result.itineraryItems, hasLength(2));
       final ItineraryItemDto itineraryItem = result.itineraryItems!.first;
       expect(itineraryItem.name, '朝食');
-      verify(
-        mockPinsQuery.orderBy('visitStartDateTime', descending: false),
-      ).called(1);
-      verify(mockTasksQuery.orderBy('orderIndex', descending: false)).called(1);
-      verify(
-        mockItineraryItemsQuery.orderBy('orderIndex', descending: false),
-      ).called(1);
+      verifyNever(mockPinsQuery.orderBy(any, descending: anyNamed('descending')));
+      verifyNever(mockTasksQuery.orderBy(any, descending: anyNamed('descending')));
+      verifyNever(
+        mockItineraryItemsQuery.orderBy(any, descending: anyNamed('descending')),
+      );
     });
 
     test('旅行が存在しない場合はnullを返す', () async {
@@ -214,9 +242,6 @@ void main() {
         mockItineraryItemsCollection.where('tripId', isEqualTo: tripId),
       ).thenReturn(mockItineraryItemsQuery);
       when(
-        mockItineraryItemsQuery.orderBy('orderIndex', descending: false),
-      ).thenReturn(mockItineraryItemsQuery);
-      when(
         mockItineraryItemsQuery.get(),
       ).thenAnswer((_) async => mockItineraryItemsSnapshot);
       when(mockItineraryItemsSnapshot.docs).thenReturn([]);
@@ -225,9 +250,9 @@ void main() {
 
       expect(result, isNotNull);
       expect(result!.year, 2027);
-      verify(
-        mockItineraryItemsQuery.orderBy('orderIndex', descending: false),
-      ).called(1);
+      verifyNever(
+        mockItineraryItemsQuery.orderBy(any, descending: anyNamed('descending')),
+      );
     });
 
     test('旅行取得時に例外が発生した場合はnullを返す', () async {

--- a/test/unit/infrastructure/queries/trip/firestore_trip_entry_query_service_test.dart
+++ b/test/unit/infrastructure/queries/trip/firestore_trip_entry_query_service_test.dart
@@ -118,10 +118,7 @@ void main() {
         mockTasksCollection.where('tripId', isEqualTo: tripId),
       ).thenReturn(mockTasksQuery);
       when(mockTasksQuery.get()).thenAnswer((_) async => mockTasksSnapshot);
-      when(mockTasksSnapshot.docs).thenReturn([
-        mockTaskDoc,
-        mockSecondTaskDoc,
-      ]);
+      when(mockTasksSnapshot.docs).thenReturn([mockTaskDoc, mockSecondTaskDoc]);
       when(mockTaskDoc.data()).thenReturn({
         'tripId': tripId,
         'orderIndex': 2,
@@ -143,10 +140,9 @@ void main() {
       when(
         mockItineraryItemsQuery.get(),
       ).thenAnswer((_) async => mockItineraryItemsSnapshot);
-      when(mockItineraryItemsSnapshot.docs).thenReturn([
-        mockItineraryItemDoc,
-        mockSecondItineraryItemDoc,
-      ]);
+      when(
+        mockItineraryItemsSnapshot.docs,
+      ).thenReturn([mockItineraryItemDoc, mockSecondItineraryItemDoc]);
       when(mockItineraryItemDoc.data()).thenReturn({
         'tripId': tripId,
         'orderIndex': 3,
@@ -184,10 +180,17 @@ void main() {
       expect(result.itineraryItems, hasLength(2));
       final ItineraryItemDto itineraryItem = result.itineraryItems!.first;
       expect(itineraryItem.name, '朝食');
-      verifyNever(mockPinsQuery.orderBy(any, descending: anyNamed('descending')));
-      verifyNever(mockTasksQuery.orderBy(any, descending: anyNamed('descending')));
       verifyNever(
-        mockItineraryItemsQuery.orderBy(any, descending: anyNamed('descending')),
+        mockPinsQuery.orderBy(any, descending: anyNamed('descending')),
+      );
+      verifyNever(
+        mockTasksQuery.orderBy(any, descending: anyNamed('descending')),
+      );
+      verifyNever(
+        mockItineraryItemsQuery.orderBy(
+          any,
+          descending: anyNamed('descending'),
+        ),
       );
     });
 
@@ -251,7 +254,10 @@ void main() {
       expect(result, isNotNull);
       expect(result!.year, 2027);
       verifyNever(
-        mockItineraryItemsQuery.orderBy(any, descending: anyNamed('descending')),
+        mockItineraryItemsQuery.orderBy(
+          any,
+          descending: anyNamed('descending'),
+        ),
       );
     });
 


### PR DESCRIPTION
## 概要
- 旅行詳細取得時、関連データの `orderBy` を Firestore クエリに直接適用せず、取得後にアプリ側で並び替えるよう変更
- 複合インデックス未作成などで関連データ取得が失敗し、既存旅行が「データが見つかりません」扱いになる経路を防止
- 関連データの並び替えを検証するテストを更新

## 検証
- `flutter test test/unit/infrastructure/queries/trip/firestore_trip_entry_query_service_test.dart`
- `flutter test test/unit/presentation/features/trip/trip_management_test.dart`
- `./check.sh`

## todo
- todo更新はユーザー指示により省略