### PR TITLE
旅程項目からorderIndexを削除

### DIFF
--- a/docs/done.md
+++ b/docs/done.md
@@ -2,6 +2,9 @@
 
 ## DB設計・リポジトリ・ユースケース・DTO・マッパー関連
 
+- 旅程項目から`orderIndex`を削除する
+  - DB、Entity、DTO、Mapper、Query、Repository、Usecaseから旅程項目の`orderIndex`を除外する
+  - 旅程項目の表示順は開始日時の昇順、開始日時が同じ場合は終了日時の昇順で決定する
 - ER図のitinerary_itemsテーブル定義を元に旅程項目を実装する
   - `ItineraryItem`エンティティを作成する
   - `ItineraryItemDto`を作成する
@@ -10,8 +13,8 @@
   - `ItineraryItemQueryService`と`FirestoreItineraryItemQueryService`を作成し、`tripId`で旅程項目を取得できるようにする
   - `TripEntry`集約に`itineraryItems`を追加し、`TripEntryRepository`、`TripEntryQueryService`、Firestore実装、Factory配線を対応させる
   - `TripEntryDto`、`TripEntryMapper`、`FirestoreTripEntryMapper`を`itineraryItems`に対応させる
-  - 保存・更新・削除時に`itinerary_items`を旅行単位で同期し、取得時は`orderIndex`順に並べる
-  - `name`必須、`orderIndex`は0以上、終了日時は開始日時以降、日時は旅行期間の開始2日前から終了2日後までの範囲内であることを検証する
+  - 保存・更新・削除時に`itinerary_items`を旅行単位で同期し、取得時は開始日時、終了日時順に並べる
+  - `name`必須、終了日時は開始日時以降、日時は旅行期間の開始2日前から終了2日後までの範囲内であることを検証する
 - ER図のメンバーイベントの変更に伴う対応
   - 永続化契約を `memberId` / `year` / `memo` ベースへ統一し、`id` は Firestore のドキュメントIDとして扱う
   - `MemberEvent` / `MemberEventDto` / `MemberEventMapper` / `FirestoreMemberEventMapper` から旧設計の `type` / `name` / `startDate` / `endDate` を除去し、ER図どおりの項目だけを扱うようにする。また、業務上の一意性は `memberId` + `year` で担保する前提で責務を整理する

--- a/docs/er_diagram.md
+++ b/docs/er_diagram.md
@@ -37,7 +37,6 @@ erDiagram
     itinerary_items {
         string id PK
         string tripId FK "NOT NULL"
-        number orderIndex "NOT NULL"
         string name "NOT NULL"
         timestamp startDateTime
         timestamp endDateTime

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,9 +1,6 @@
 # ToDo List
 
 ## DB設計・リポジトリ・ユースケース・DTO・マッパー関連
-- 旅程項目から`orderIndex`を削除する
-  - DB、Entity、DTO、Mapper、Query、Repository、Usecaseから旅程項目の`orderIndex`を除外する
-  - 旅程項目の表示順は開始日時の昇順、開始日時が同じ場合は終了日時の昇順で決定する
 
 ## マップの表示
 

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -123,7 +123,11 @@
           "order": "ASCENDING"
         },
         {
-          "fieldPath": "orderIndex",
+          "fieldPath": "startDateTime",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "endDateTime",
           "order": "ASCENDING"
         },
         {

--- a/lib/application/dtos/trip/itinerary_item_dto.dart
+++ b/lib/application/dtos/trip/itinerary_item_dto.dart
@@ -5,7 +5,6 @@ class ItineraryItemDto extends Equatable {
   const ItineraryItemDto({
     required this.id,
     required this.tripId,
-    required this.orderIndex,
     required this.name,
     this.startDateTime,
     this.endDateTime,
@@ -14,7 +13,6 @@ class ItineraryItemDto extends Equatable {
 
   final String id;
   final String tripId;
-  final int orderIndex;
   final String name;
   final DateTime? startDateTime;
   final DateTime? endDateTime;
@@ -23,7 +21,6 @@ class ItineraryItemDto extends Equatable {
   ItineraryItemDto copyWith({
     String? id,
     String? tripId,
-    int? orderIndex,
     String? name,
     Object? startDateTime = copyWithPlaceholder,
     Object? endDateTime = copyWithPlaceholder,
@@ -32,7 +29,6 @@ class ItineraryItemDto extends Equatable {
     return ItineraryItemDto(
       id: id ?? this.id,
       tripId: tripId ?? this.tripId,
-      orderIndex: orderIndex ?? this.orderIndex,
       name: name ?? this.name,
       startDateTime: resolveCopyWithValue<DateTime>(
         startDateTime,
@@ -52,7 +48,6 @@ class ItineraryItemDto extends Equatable {
   List<Object?> get props => [
     id,
     tripId,
-    orderIndex,
     name,
     startDateTime,
     endDateTime,

--- a/lib/application/mappers/trip/itinerary_item_mapper.dart
+++ b/lib/application/mappers/trip/itinerary_item_mapper.dart
@@ -6,7 +6,6 @@ class ItineraryItemMapper {
     return entity.ItineraryItem(
       id: dto.id,
       tripId: dto.tripId,
-      orderIndex: dto.orderIndex,
       name: dto.name,
       startDateTime: dto.startDateTime,
       endDateTime: dto.endDateTime,

--- a/lib/application/usecases/trip/get_itinerary_items_by_trip_id_usecase.dart
+++ b/lib/application/usecases/trip/get_itinerary_items_by_trip_id_usecase.dart
@@ -19,7 +19,10 @@ class GetItineraryItemsByTripIdUsecase {
   Future<List<ItineraryItemDto>> execute(String tripId) async {
     return await _itineraryItemQueryService.getItineraryItemsByTripId(
       tripId,
-      orderBy: [const OrderBy('orderIndex', descending: false)],
+      orderBy: const [
+        OrderBy('startDateTime', descending: false),
+        OrderBy('endDateTime', descending: false),
+      ],
     );
   }
 }

--- a/lib/application/usecases/trip/get_trip_entry_by_id_usecase.dart
+++ b/lib/application/usecases/trip/get_trip_entry_by_id_usecase.dart
@@ -20,7 +20,10 @@ class GetTripEntryByIdUsecase {
       tripId,
       pinsOrderBy: [const OrderBy('visitStartDateTime', descending: false)],
       tasksOrderBy: [const OrderBy('orderIndex', descending: false)],
-      itineraryItemsOrderBy: [const OrderBy('orderIndex', descending: false)],
+      itineraryItemsOrderBy: const [
+        OrderBy('startDateTime', descending: false),
+        OrderBy('endDateTime', descending: false),
+      ],
     );
   }
 }

--- a/lib/domain/entities/trip/itinerary_item.dart
+++ b/lib/domain/entities/trip/itinerary_item.dart
@@ -5,7 +5,6 @@ class ItineraryItem extends Equatable {
   ItineraryItem({
     required this.id,
     required this.tripId,
-    required this.orderIndex,
     required this.name,
     this.startDateTime,
     this.endDateTime,
@@ -16,7 +15,6 @@ class ItineraryItem extends Equatable {
 
   final String id;
   final String tripId;
-  final int orderIndex;
   final String name;
   final DateTime? startDateTime;
   final DateTime? endDateTime;
@@ -25,7 +23,6 @@ class ItineraryItem extends Equatable {
   ItineraryItem copyWith({
     String? id,
     String? tripId,
-    int? orderIndex,
     String? name,
     DateTime? startDateTime,
     DateTime? endDateTime,
@@ -34,7 +31,6 @@ class ItineraryItem extends Equatable {
     return ItineraryItem(
       id: id ?? this.id,
       tripId: tripId ?? this.tripId,
-      orderIndex: orderIndex ?? this.orderIndex,
       name: name ?? this.name,
       startDateTime: startDateTime ?? this.startDateTime,
       endDateTime: endDateTime ?? this.endDateTime,
@@ -43,9 +39,6 @@ class ItineraryItem extends Equatable {
   }
 
   void _validate() {
-    if (orderIndex < 0) {
-      throw ValidationException('旅程項目の順序は0以上でなければなりません');
-    }
     if (name.trim().isEmpty) {
       throw ValidationException('旅程項目名は必須です');
     }
@@ -60,7 +53,6 @@ class ItineraryItem extends Equatable {
   List<Object?> get props => [
     id,
     tripId,
-    orderIndex,
     name,
     startDateTime,
     endDateTime,

--- a/lib/infrastructure/mappers/trip/firestore_itinerary_item_mapper.dart
+++ b/lib/infrastructure/mappers/trip/firestore_itinerary_item_mapper.dart
@@ -12,7 +12,6 @@ class FirestoreItineraryItemMapper {
     return ItineraryItemDto(
       id: doc.id,
       tripId: data['tripId'] as String? ?? '',
-      orderIndex: FirestoreMapperValueParser.asInt(data['orderIndex']),
       name: data['name'] as String? ?? '',
       startDateTime: FirestoreMapperValueParser.asDateTime(
         data['startDateTime'],
@@ -25,7 +24,6 @@ class FirestoreItineraryItemMapper {
   static Map<String, dynamic> toCreateFirestore(ItineraryItem item) {
     final data = <String, dynamic>{
       'tripId': item.tripId,
-      'orderIndex': item.orderIndex,
       'name': item.name,
       'memo': item.memo,
       ...FirestoreWriteMetadata.forCreate(),

--- a/lib/infrastructure/queries/trip/firestore_trip_entry_query_service.dart
+++ b/lib/infrastructure/queries/trip/firestore_trip_entry_query_service.dart
@@ -74,7 +74,10 @@ class FirestoreTripEntryQueryService implements TripEntryQueryService {
 
       final effectiveItineraryItemsOrderBy =
           itineraryItemsOrderBy ??
-          const [OrderBy('orderIndex', descending: false)];
+          const [
+            OrderBy('startDateTime', descending: false),
+            OrderBy('endDateTime', descending: false),
+          ];
       for (final order in effectiveItineraryItemsOrderBy) {
         itineraryItemsQuery = itineraryItemsQuery.orderBy(
           order.field,

--- a/test/unit/application/dtos/trip/itinerary_item_dto_test.dart
+++ b/test/unit/application/dtos/trip/itinerary_item_dto_test.dart
@@ -7,7 +7,6 @@ void main() {
       final dto = ItineraryItemDto(
         id: 'item001',
         tripId: 'trip001',
-        orderIndex: 0,
         name: '朝食',
         startDateTime: DateTime(2024, 1, 2, 8),
         endDateTime: DateTime(2024, 1, 2, 9),
@@ -16,7 +15,6 @@ void main() {
 
       expect(dto.id, 'item001');
       expect(dto.tripId, 'trip001');
-      expect(dto.orderIndex, 0);
       expect(dto.name, '朝食');
       expect(dto.startDateTime, DateTime(2024, 1, 2, 8));
       expect(dto.endDateTime, DateTime(2024, 1, 2, 9));
@@ -27,7 +25,6 @@ void main() {
       final dto = ItineraryItemDto(
         id: 'item001',
         tripId: 'trip001',
-        orderIndex: 0,
         name: '朝食',
         startDateTime: DateTime(2024, 1, 2, 8),
         endDateTime: DateTime(2024, 1, 2, 9),
@@ -35,7 +32,6 @@ void main() {
       );
 
       final copiedDto = dto.copyWith(
-        orderIndex: 1,
         name: '昼食',
         startDateTime: null,
         endDateTime: null,
@@ -44,7 +40,6 @@ void main() {
 
       expect(copiedDto.id, 'item001');
       expect(copiedDto.tripId, 'trip001');
-      expect(copiedDto.orderIndex, 1);
       expect(copiedDto.name, '昼食');
       expect(copiedDto.startDateTime, isNull);
       expect(copiedDto.endDateTime, isNull);
@@ -55,7 +50,6 @@ void main() {
       final dto1 = ItineraryItemDto(
         id: 'item001',
         tripId: 'trip001',
-        orderIndex: 0,
         name: '朝食',
         startDateTime: DateTime(2024, 1, 2, 8),
         endDateTime: DateTime(2024, 1, 2, 9),
@@ -64,7 +58,6 @@ void main() {
       final dto2 = ItineraryItemDto(
         id: 'item001',
         tripId: 'trip001',
-        orderIndex: 0,
         name: '朝食',
         startDateTime: DateTime(2024, 1, 2, 8),
         endDateTime: DateTime(2024, 1, 2, 9),

--- a/test/unit/application/dtos/trip/trip_entry_dto_test.dart
+++ b/test/unit/application/dtos/trip/trip_entry_dto_test.dart
@@ -56,11 +56,7 @@ void main() {
         ),
       ];
       const itineraryItems = [
-        ItineraryItemDto(
-          id: 'item-1',
-          tripId: 'trip-entry-123',
-          name: '朝食',
-        ),
+        ItineraryItemDto(id: 'item-1', tripId: 'trip-entry-123', name: '朝食'),
       ];
 
       final dto = TripEntryDto(
@@ -123,11 +119,7 @@ void main() {
           ),
         ],
         itineraryItems: const [
-          ItineraryItemDto(
-            id: 'item-1',
-            tripId: 'trip-entry-123',
-            name: '朝食',
-          ),
+          ItineraryItemDto(id: 'item-1', tripId: 'trip-entry-123', name: '朝食'),
         ],
       );
 
@@ -145,11 +137,7 @@ void main() {
           ),
         ],
         itineraryItems: const [
-          ItineraryItemDto(
-            id: 'item-2',
-            tripId: 'trip-entry-123',
-            name: '観光',
-          ),
+          ItineraryItemDto(id: 'item-2', tripId: 'trip-entry-123', name: '観光'),
         ],
       );
 
@@ -212,11 +200,7 @@ void main() {
         ),
       ];
       const itineraryItems = [
-        ItineraryItemDto(
-          id: 'item-1',
-          tripId: 'trip-entry-123',
-          name: '朝食',
-        ),
+        ItineraryItemDto(id: 'item-1', tripId: 'trip-entry-123', name: '朝食'),
       ];
       final originalDto = TripEntryDto(
         id: 'trip-entry-123',
@@ -248,11 +232,7 @@ void main() {
         ),
       ];
       const itineraryItems = [
-        ItineraryItemDto(
-          id: 'item-1',
-          tripId: 'trip-entry-123',
-          name: '朝食',
-        ),
+        ItineraryItemDto(id: 'item-1', tripId: 'trip-entry-123', name: '朝食'),
       ];
 
       final dto1 = TripEntryDto(
@@ -305,11 +285,7 @@ void main() {
           ),
         ],
         itineraryItems: const [
-          ItineraryItemDto(
-            id: 'item-1',
-            tripId: 'trip-entry-123',
-            name: '朝食',
-          ),
+          ItineraryItemDto(id: 'item-1', tripId: 'trip-entry-123', name: '朝食'),
         ],
       );
 
@@ -332,11 +308,7 @@ void main() {
           ),
         ],
         itineraryItems: const [
-          ItineraryItemDto(
-            id: 'item-2',
-            tripId: 'trip-entry-999',
-            name: '観光',
-          ),
+          ItineraryItemDto(id: 'item-2', tripId: 'trip-entry-999', name: '観光'),
         ],
       );
 

--- a/test/unit/application/dtos/trip/trip_entry_dto_test.dart
+++ b/test/unit/application/dtos/trip/trip_entry_dto_test.dart
@@ -59,7 +59,6 @@ void main() {
         ItineraryItemDto(
           id: 'item-1',
           tripId: 'trip-entry-123',
-          orderIndex: 0,
           name: '朝食',
         ),
       ];
@@ -127,7 +126,6 @@ void main() {
           ItineraryItemDto(
             id: 'item-1',
             tripId: 'trip-entry-123',
-            orderIndex: 0,
             name: '朝食',
           ),
         ],
@@ -150,7 +148,6 @@ void main() {
           ItineraryItemDto(
             id: 'item-2',
             tripId: 'trip-entry-123',
-            orderIndex: 1,
             name: '観光',
           ),
         ],
@@ -218,7 +215,6 @@ void main() {
         ItineraryItemDto(
           id: 'item-1',
           tripId: 'trip-entry-123',
-          orderIndex: 0,
           name: '朝食',
         ),
       ];
@@ -255,7 +251,6 @@ void main() {
         ItineraryItemDto(
           id: 'item-1',
           tripId: 'trip-entry-123',
-          orderIndex: 0,
           name: '朝食',
         ),
       ];
@@ -313,7 +308,6 @@ void main() {
           ItineraryItemDto(
             id: 'item-1',
             tripId: 'trip-entry-123',
-            orderIndex: 0,
             name: '朝食',
           ),
         ],
@@ -341,7 +335,6 @@ void main() {
           ItineraryItemDto(
             id: 'item-2',
             tripId: 'trip-entry-999',
-            orderIndex: 1,
             name: '観光',
           ),
         ],

--- a/test/unit/application/mappers/trip/itinerary_item_mapper_test.dart
+++ b/test/unit/application/mappers/trip/itinerary_item_mapper_test.dart
@@ -9,7 +9,6 @@ void main() {
       final dto = ItineraryItemDto(
         id: 'item001',
         tripId: 'trip001',
-        orderIndex: 0,
         name: '朝食',
         startDateTime: DateTime(2024, 1, 2, 8),
         endDateTime: DateTime(2024, 1, 2, 9),
@@ -23,7 +22,6 @@ void main() {
         entity.ItineraryItem(
           id: 'item001',
           tripId: 'trip001',
-          orderIndex: 0,
           name: '朝食',
           startDateTime: DateTime(2024, 1, 2, 8),
           endDateTime: DateTime(2024, 1, 2, 9),
@@ -37,13 +35,11 @@ void main() {
         ItineraryItemDto(
           id: 'item001',
           tripId: 'trip001',
-          orderIndex: 0,
           name: '朝食',
         ),
         ItineraryItemDto(
           id: 'item002',
           tripId: 'trip001',
-          orderIndex: 1,
           name: '観光',
         ),
       ];

--- a/test/unit/application/mappers/trip/itinerary_item_mapper_test.dart
+++ b/test/unit/application/mappers/trip/itinerary_item_mapper_test.dart
@@ -32,16 +32,8 @@ void main() {
 
     test('ItineraryItemDtoのリストをエンティティリストに変換できる', () {
       const dtos = [
-        ItineraryItemDto(
-          id: 'item001',
-          tripId: 'trip001',
-          name: '朝食',
-        ),
-        ItineraryItemDto(
-          id: 'item002',
-          tripId: 'trip001',
-          name: '観光',
-        ),
+        ItineraryItemDto(id: 'item001', tripId: 'trip001', name: '朝食'),
+        ItineraryItemDto(id: 'item002', tripId: 'trip001', name: '観光'),
       ];
 
       final items = ItineraryItemMapper.toEntityList(dtos);

--- a/test/unit/application/mappers/trip/trip_entry_mapper_test.dart
+++ b/test/unit/application/mappers/trip/trip_entry_mapper_test.dart
@@ -43,7 +43,6 @@ void main() {
           ItineraryItemDto(
             id: 'item-010',
             tripId: 'trip-003',
-            orderIndex: 0,
             name: '朝食',
             startDateTime: DateTime(2024, 7, 2, 8),
             endDateTime: DateTime(2024, 7, 2, 9),
@@ -87,7 +86,6 @@ void main() {
             ItineraryItem(
               id: 'item-010',
               tripId: 'trip-003',
-              orderIndex: 0,
               name: '朝食',
               startDateTime: DateTime(2024, 7, 2, 8),
               endDateTime: DateTime(2024, 7, 2, 9),

--- a/test/unit/application/usecases/trip/create_trip_entry_usecase_test.dart
+++ b/test/unit/application/usecases/trip/create_trip_entry_usecase_test.dart
@@ -31,11 +31,7 @@ void main() {
         startDate: DateTime(2024, 1, 1),
         endDate: DateTime(2024, 1, 3),
         itineraryItems: const [
-          ItineraryItemDto(
-            id: 'item001',
-            tripId: '',
-            name: '朝食',
-          ),
+          ItineraryItemDto(id: 'item001', tripId: '', name: '朝食'),
         ],
       );
       const generatedId = 'generated-trip-id';

--- a/test/unit/application/usecases/trip/create_trip_entry_usecase_test.dart
+++ b/test/unit/application/usecases/trip/create_trip_entry_usecase_test.dart
@@ -34,7 +34,6 @@ void main() {
           ItineraryItemDto(
             id: 'item001',
             tripId: '',
-            orderIndex: 0,
             name: '朝食',
           ),
         ],

--- a/test/unit/application/usecases/trip/get_itinerary_items_by_trip_id_usecase_test.dart
+++ b/test/unit/application/usecases/trip/get_itinerary_items_by_trip_id_usecase_test.dart
@@ -22,11 +22,7 @@ void main() {
     test('旅行IDで旅程項目を開始日時、終了日時の昇順で取得する', () async {
       const tripId = 'trip001';
       const items = [
-        ItineraryItemDto(
-          id: 'item001',
-          tripId: tripId,
-          name: '朝食',
-        ),
+        ItineraryItemDto(id: 'item001', tripId: tripId, name: '朝食'),
       ];
       when(
         mockQueryService.getItineraryItemsByTripId(

--- a/test/unit/application/usecases/trip/get_itinerary_items_by_trip_id_usecase_test.dart
+++ b/test/unit/application/usecases/trip/get_itinerary_items_by_trip_id_usecase_test.dart
@@ -19,13 +19,12 @@ void main() {
       usecase = GetItineraryItemsByTripIdUsecase(mockQueryService);
     });
 
-    test('旅行IDで旅程項目をorderIndex昇順で取得する', () async {
+    test('旅行IDで旅程項目を開始日時、終了日時の昇順で取得する', () async {
       const tripId = 'trip001';
       const items = [
         ItineraryItemDto(
           id: 'item001',
           tripId: tripId,
-          orderIndex: 0,
           name: '朝食',
         ),
       ];
@@ -42,7 +41,10 @@ void main() {
       verify(
         mockQueryService.getItineraryItemsByTripId(
           tripId,
-          orderBy: const [OrderBy('orderIndex', descending: false)],
+          orderBy: const [
+            OrderBy('startDateTime', descending: false),
+            OrderBy('endDateTime', descending: false),
+          ],
         ),
       ).called(1);
     });

--- a/test/unit/application/usecases/trip/get_trip_entry_by_id_usecase_test.dart
+++ b/test/unit/application/usecases/trip/get_trip_entry_by_id_usecase_test.dart
@@ -56,7 +56,10 @@ void main() {
       final itineraryItemsOrderBy = verification.captured[2] as List<OrderBy>;
       expect(pinsOrderBy.single.field, 'visitStartDateTime');
       expect(tasksOrderBy.single.field, 'orderIndex');
-      expect(itineraryItemsOrderBy.single.field, 'orderIndex');
+      expect(
+        itineraryItemsOrderBy.map((orderBy) => orderBy.field),
+        ['startDateTime', 'endDateTime'],
+      );
     });
 
     test('存在しない旅行IDの場合はnullを返すこと', () async {

--- a/test/unit/application/usecases/trip/get_trip_entry_by_id_usecase_test.dart
+++ b/test/unit/application/usecases/trip/get_trip_entry_by_id_usecase_test.dart
@@ -56,10 +56,10 @@ void main() {
       final itineraryItemsOrderBy = verification.captured[2] as List<OrderBy>;
       expect(pinsOrderBy.single.field, 'visitStartDateTime');
       expect(tasksOrderBy.single.field, 'orderIndex');
-      expect(
-        itineraryItemsOrderBy.map((orderBy) => orderBy.field),
-        ['startDateTime', 'endDateTime'],
-      );
+      expect(itineraryItemsOrderBy.map((orderBy) => orderBy.field), [
+        'startDateTime',
+        'endDateTime',
+      ]);
     });
 
     test('存在しない旅行IDの場合はnullを返すこと', () async {

--- a/test/unit/application/usecases/trip/update_trip_entry_usecase_test.dart
+++ b/test/unit/application/usecases/trip/update_trip_entry_usecase_test.dart
@@ -35,7 +35,6 @@ void main() {
           ItineraryItemDto(
             id: 'item001',
             tripId: 'trip-id',
-            orderIndex: 0,
             name: '朝食',
           ),
         ],

--- a/test/unit/application/usecases/trip/update_trip_entry_usecase_test.dart
+++ b/test/unit/application/usecases/trip/update_trip_entry_usecase_test.dart
@@ -32,11 +32,7 @@ void main() {
         endDate: DateTime(2024, 1, 3),
         memo: '更新されたメモ',
         itineraryItems: const [
-          ItineraryItemDto(
-            id: 'item001',
-            tripId: 'trip-id',
-            name: '朝食',
-          ),
+          ItineraryItemDto(id: 'item001', tripId: 'trip-id', name: '朝食'),
         ],
       );
 

--- a/test/unit/domain/entities/trip/itinerary_item_test.dart
+++ b/test/unit/domain/entities/trip/itinerary_item_test.dart
@@ -8,7 +8,6 @@ void main() {
       final item = ItineraryItem(
         id: 'item001',
         tripId: 'trip001',
-        orderIndex: 0,
         name: '朝食',
         startDateTime: DateTime(2024, 1, 2, 8),
         endDateTime: DateTime(2024, 1, 2, 9),
@@ -17,7 +16,6 @@ void main() {
 
       expect(item.id, 'item001');
       expect(item.tripId, 'trip001');
-      expect(item.orderIndex, 0);
       expect(item.name, '朝食');
       expect(item.startDateTime, DateTime(2024, 1, 2, 8));
       expect(item.endDateTime, DateTime(2024, 1, 2, 9));
@@ -28,19 +26,13 @@ void main() {
       final item = ItineraryItem(
         id: 'item001',
         tripId: 'trip001',
-        orderIndex: 0,
         name: '朝食',
       );
 
-      final updatedItem = item.copyWith(
-        orderIndex: 1,
-        name: '昼食',
-        memo: '予約確認',
-      );
+      final updatedItem = item.copyWith(name: '昼食', memo: '予約確認');
 
       expect(updatedItem.id, 'item001');
       expect(updatedItem.tripId, 'trip001');
-      expect(updatedItem.orderIndex, 1);
       expect(updatedItem.name, '昼食');
       expect(updatedItem.memo, '予約確認');
     });
@@ -50,20 +42,7 @@ void main() {
         () => ItineraryItem(
           id: 'item001',
           tripId: 'trip001',
-          orderIndex: 0,
           name: '  ',
-        ),
-        throwsA(isA<ValidationException>()),
-      );
-    });
-
-    test('orderIndexが0未満の場合は例外が発生する', () {
-      expect(
-        () => ItineraryItem(
-          id: 'item001',
-          tripId: 'trip001',
-          orderIndex: -1,
-          name: '朝食',
         ),
         throwsA(isA<ValidationException>()),
       );
@@ -74,7 +53,6 @@ void main() {
         () => ItineraryItem(
           id: 'item001',
           tripId: 'trip001',
-          orderIndex: 0,
           name: '朝食',
           startDateTime: DateTime(2024, 1, 2, 9),
           endDateTime: DateTime(2024, 1, 2, 8),

--- a/test/unit/domain/entities/trip/itinerary_item_test.dart
+++ b/test/unit/domain/entities/trip/itinerary_item_test.dart
@@ -23,11 +23,7 @@ void main() {
     });
 
     test('copyWithメソッドが正しく動作する', () {
-      final item = ItineraryItem(
-        id: 'item001',
-        tripId: 'trip001',
-        name: '朝食',
-      );
+      final item = ItineraryItem(id: 'item001', tripId: 'trip001', name: '朝食');
 
       final updatedItem = item.copyWith(name: '昼食', memo: '予約確認');
 
@@ -39,11 +35,7 @@ void main() {
 
     test('nameが空の場合は例外が発生する', () {
       expect(
-        () => ItineraryItem(
-          id: 'item001',
-          tripId: 'trip001',
-          name: '  ',
-        ),
+        () => ItineraryItem(id: 'item001', tripId: 'trip001', name: '  '),
         throwsA(isA<ValidationException>()),
       );
     });

--- a/test/unit/domain/entities/trip/trip_entry_test.dart
+++ b/test/unit/domain/entities/trip/trip_entry_test.dart
@@ -150,11 +150,7 @@ void main() {
           ),
         ],
         itineraryItems: [
-          ItineraryItem(
-            id: 'item-2',
-            tripId: 'abc123',
-            name: '夕食',
-          ),
+          ItineraryItem(id: 'item-2', tripId: 'abc123', name: '夕食'),
         ],
       );
       expect(updatedEntry.id, 'abc123');

--- a/test/unit/domain/entities/trip/trip_entry_test.dart
+++ b/test/unit/domain/entities/trip/trip_entry_test.dart
@@ -42,7 +42,6 @@ void main() {
           ItineraryItem(
             id: 'item-1',
             tripId: 'abc123',
-            orderIndex: 0,
             name: '朝食',
             startDateTime: DateTime(2025, 6, 2, 8),
             endDateTime: DateTime(2025, 6, 2, 9),
@@ -154,7 +153,6 @@ void main() {
           ItineraryItem(
             id: 'item-2',
             tripId: 'abc123',
-            orderIndex: 0,
             name: '夕食',
           ),
         ],
@@ -413,14 +411,12 @@ void main() {
           ItineraryItem(
             id: 'item-1',
             tripId: 'trip123',
-            orderIndex: 0,
             name: '前泊移動',
             startDateTime: DateTime(2025, 6, 8),
           ),
           ItineraryItem(
             id: 'item-2',
             tripId: 'trip123',
-            orderIndex: 1,
             name: '帰宅',
             endDateTime: DateTime(2025, 6, 14, 23, 59),
           ),
@@ -439,7 +435,6 @@ void main() {
           ItineraryItem(
             id: 'item-1',
             tripId: 'trip123',
-            orderIndex: 0,
             name: '年またぎ移動',
             startDateTime: DateTime(2024, 12, 31, 23),
             endDateTime: DateTime(2026, 1, 1),
@@ -462,7 +457,6 @@ void main() {
             ItineraryItem(
               id: 'item-1',
               tripId: 'trip123',
-              orderIndex: 0,
               name: '早すぎる移動',
               startDateTime: DateTime(2025, 6, 7, 23, 59),
             ),
@@ -484,7 +478,6 @@ void main() {
             ItineraryItem(
               id: 'item-1',
               tripId: 'trip123',
-              orderIndex: 0,
               name: '遅すぎる帰宅',
               endDateTime: DateTime(2025, 6, 15),
             ),

--- a/test/unit/infrastructure/mappers/trip/firestore_itinerary_item_mapper_test.dart
+++ b/test/unit/infrastructure/mappers/trip/firestore_itinerary_item_mapper_test.dart
@@ -16,7 +16,6 @@ void main() {
       when(doc.id).thenReturn('item001');
       when(doc.data()).thenReturn({
         'tripId': 'trip001',
-        'orderIndex': 0,
         'name': '朝食',
         'startDateTime': Timestamp.fromDate(DateTime(2024, 1, 2, 8)),
         'endDateTime': Timestamp.fromDate(DateTime(2024, 1, 2, 9)),
@@ -29,7 +28,6 @@ void main() {
 
       expect(dto.id, 'item001');
       expect(dto.tripId, 'trip001');
-      expect(dto.orderIndex, 0);
       expect(dto.name, '朝食');
       expect(dto.startDateTime, DateTime(2024, 1, 2, 8));
       expect(dto.endDateTime, DateTime(2024, 1, 2, 9));
@@ -40,7 +38,6 @@ void main() {
       final item = ItineraryItem(
         id: 'item001',
         tripId: 'trip001',
-        orderIndex: 0,
         name: '朝食',
         startDateTime: DateTime(2024, 1, 2, 8),
         endDateTime: DateTime(2024, 1, 2, 9),
@@ -51,7 +48,7 @@ void main() {
           firestore_mapper.FirestoreItineraryItemMapper.toCreateFirestore(item);
 
       expect(map['tripId'], 'trip001');
-      expect(map['orderIndex'], 0);
+      expect(map, isNot(contains('orderIndex')));
       expect(map['name'], '朝食');
       expect(map['startDateTime'], Timestamp.fromDate(DateTime(2024, 1, 2, 8)));
       expect(map['endDateTime'], Timestamp.fromDate(DateTime(2024, 1, 2, 9)));

--- a/test/unit/infrastructure/mappers/trip/firestore_itinerary_item_mapper_test.dart
+++ b/test/unit/infrastructure/mappers/trip/firestore_itinerary_item_mapper_test.dart
@@ -48,7 +48,6 @@ void main() {
           firestore_mapper.FirestoreItineraryItemMapper.toCreateFirestore(item);
 
       expect(map['tripId'], 'trip001');
-      expect(map, isNot(contains('orderIndex')));
       expect(map['name'], '朝食');
       expect(map['startDateTime'], Timestamp.fromDate(DateTime(2024, 1, 2, 8)));
       expect(map['endDateTime'], Timestamp.fromDate(DateTime(2024, 1, 2, 9)));

--- a/test/unit/infrastructure/mappers/trip/firestore_trip_entry_mapper_test.dart
+++ b/test/unit/infrastructure/mappers/trip/firestore_trip_entry_mapper_test.dart
@@ -38,7 +38,6 @@ void main() {
         ItineraryItemDto(
           id: 'item001',
           tripId: 'trip001',
-          orderIndex: 0,
           name: '朝食',
         ),
       ];

--- a/test/unit/infrastructure/mappers/trip/firestore_trip_entry_mapper_test.dart
+++ b/test/unit/infrastructure/mappers/trip/firestore_trip_entry_mapper_test.dart
@@ -35,11 +35,7 @@ void main() {
         ),
       ];
       const itineraryItems = [
-        ItineraryItemDto(
-          id: 'item001',
-          tripId: 'trip001',
-          name: '朝食',
-        ),
+        ItineraryItemDto(id: 'item001', tripId: 'trip001', name: '朝食'),
       ];
 
       final result = FirestoreTripEntryMapper.fromFirestore(

--- a/test/unit/infrastructure/queries/trip/firestore_itinerary_item_query_service_test.dart
+++ b/test/unit/infrastructure/queries/trip/firestore_itinerary_item_query_service_test.dart
@@ -33,7 +33,7 @@ void main() {
       service = FirestoreItineraryItemQueryService(firestore: mockFirestore);
     });
 
-    test('旅行IDで旅程項目一覧を取得しorderByを適用できる', () async {
+    test('旅行IDで旅程項目一覧を取得しorderByを複数適用できる', () async {
       const tripId = 'trip001';
       final mockQuery = MockQuery<Map<String, dynamic>>();
       final mockSnapshot = MockQuerySnapshot<Map<String, dynamic>>();
@@ -43,14 +43,16 @@ void main() {
         mockItineraryItemsCollection.where('tripId', isEqualTo: tripId),
       ).thenReturn(mockQuery);
       when(
-        mockQuery.orderBy('orderIndex', descending: false),
+        mockQuery.orderBy('startDateTime', descending: false),
+      ).thenReturn(mockQuery);
+      when(
+        mockQuery.orderBy('endDateTime', descending: false),
       ).thenReturn(mockQuery);
       when(mockQuery.get()).thenAnswer((_) async => mockSnapshot);
       when(mockSnapshot.docs).thenReturn([mockDoc]);
       when(mockDoc.id).thenReturn('item001');
       when(mockDoc.data()).thenReturn({
         'tripId': tripId,
-        'orderIndex': 0,
         'name': '朝食',
         'startDateTime': Timestamp.fromDate(DateTime(2024, 1, 2, 8)),
         'endDateTime': Timestamp.fromDate(DateTime(2024, 1, 2, 9)),
@@ -59,14 +61,18 @@ void main() {
 
       final result = await service.getItineraryItemsByTripId(
         tripId,
-        orderBy: const [OrderBy('orderIndex', descending: false)],
+        orderBy: const [
+          OrderBy('startDateTime', descending: false),
+          OrderBy('endDateTime', descending: false),
+        ],
       );
 
       expect(result, hasLength(1));
       expect(result.first, isA<ItineraryItemDto>());
       expect(result.first.id, 'item001');
       expect(result.first.name, '朝食');
-      verify(mockQuery.orderBy('orderIndex', descending: false)).called(1);
+      verify(mockQuery.orderBy('startDateTime', descending: false)).called(1);
+      verify(mockQuery.orderBy('endDateTime', descending: false)).called(1);
     });
 
     test('取得時に例外が発生した場合は空リストを返す', () async {

--- a/test/unit/infrastructure/queries/trip/firestore_trip_entry_query_service_test.dart
+++ b/test/unit/infrastructure/queries/trip/firestore_trip_entry_query_service_test.dart
@@ -120,7 +120,10 @@ void main() {
         mockItineraryItemsCollection.where('tripId', isEqualTo: tripId),
       ).thenReturn(mockItineraryItemsQuery);
       when(
-        mockItineraryItemsQuery.orderBy('orderIndex', descending: false),
+        mockItineraryItemsQuery.orderBy('startDateTime', descending: false),
+      ).thenReturn(mockItineraryItemsQuery);
+      when(
+        mockItineraryItemsQuery.orderBy('endDateTime', descending: false),
       ).thenReturn(mockItineraryItemsQuery);
       when(
         mockItineraryItemsQuery.get(),
@@ -128,7 +131,6 @@ void main() {
       when(mockItineraryItemsSnapshot.docs).thenReturn([mockItineraryItemDoc]);
       when(mockItineraryItemDoc.data()).thenReturn({
         'tripId': tripId,
-        'orderIndex': 0,
         'name': '朝食',
         'startDateTime': Timestamp.fromDate(DateTime(2024, 8, 2, 8)),
         'endDateTime': Timestamp.fromDate(DateTime(2024, 8, 2, 9)),
@@ -140,7 +142,10 @@ void main() {
         tripId,
         pinsOrderBy: const [OrderBy('visitStartDateTime', descending: false)],
         tasksOrderBy: const [OrderBy('orderIndex', descending: false)],
-        itineraryItemsOrderBy: const [OrderBy('orderIndex', descending: false)],
+        itineraryItemsOrderBy: const [
+          OrderBy('startDateTime', descending: false),
+          OrderBy('endDateTime', descending: false),
+        ],
       );
 
       expect(result, isNotNull);
@@ -159,7 +164,10 @@ void main() {
       ).called(1);
       verify(mockTasksQuery.orderBy('orderIndex', descending: false)).called(1);
       verify(
-        mockItineraryItemsQuery.orderBy('orderIndex', descending: false),
+        mockItineraryItemsQuery.orderBy('startDateTime', descending: false),
+      ).called(1);
+      verify(
+        mockItineraryItemsQuery.orderBy('endDateTime', descending: false),
       ).called(1);
     });
 
@@ -214,7 +222,10 @@ void main() {
         mockItineraryItemsCollection.where('tripId', isEqualTo: tripId),
       ).thenReturn(mockItineraryItemsQuery);
       when(
-        mockItineraryItemsQuery.orderBy('orderIndex', descending: false),
+        mockItineraryItemsQuery.orderBy('startDateTime', descending: false),
+      ).thenReturn(mockItineraryItemsQuery);
+      when(
+        mockItineraryItemsQuery.orderBy('endDateTime', descending: false),
       ).thenReturn(mockItineraryItemsQuery);
       when(
         mockItineraryItemsQuery.get(),
@@ -226,7 +237,10 @@ void main() {
       expect(result, isNotNull);
       expect(result!.year, 2027);
       verify(
-        mockItineraryItemsQuery.orderBy('orderIndex', descending: false),
+        mockItineraryItemsQuery.orderBy('startDateTime', descending: false),
+      ).called(1);
+      verify(
+        mockItineraryItemsQuery.orderBy('endDateTime', descending: false),
       ).called(1);
     });
 

--- a/test/unit/infrastructure/repositories/trip/firestore_trip_entry_repository_test.dart
+++ b/test/unit/infrastructure/repositories/trip/firestore_trip_entry_repository_test.dart
@@ -74,7 +74,6 @@ void main() {
             ItineraryItem(
               id: 'item-001',
               tripId: 'trip001',
-              orderIndex: 0,
               name: '朝食',
             ),
           ],
@@ -125,7 +124,7 @@ void main() {
               allOf([
                 containsPair('tripId', 'generated-doc-id'),
                 containsPair('name', '朝食'),
-                containsPair('orderIndex', 0),
+                isNot(contains('orderIndex')),
                 contains('createdAt'),
                 contains('updatedAt'),
               ]),
@@ -154,7 +153,6 @@ void main() {
           ItineraryItem(
             id: 'item-uuid',
             tripId: 'trip001',
-            orderIndex: 0,
             name: '朝食',
           ),
         ],

--- a/test/unit/infrastructure/repositories/trip/firestore_trip_entry_repository_test.dart
+++ b/test/unit/infrastructure/repositories/trip/firestore_trip_entry_repository_test.dart
@@ -71,11 +71,7 @@ void main() {
             ),
           ],
           itineraryItems: [
-            ItineraryItem(
-              id: 'item-001',
-              tripId: 'trip001',
-              name: '朝食',
-            ),
+            ItineraryItem(id: 'item-001', tripId: 'trip001', name: '朝食'),
           ],
         );
 
@@ -150,11 +146,7 @@ void main() {
           ),
         ],
         itineraryItems: [
-          ItineraryItem(
-            id: 'item-uuid',
-            tripId: 'trip001',
-            name: '朝食',
-          ),
+          ItineraryItem(id: 'item-uuid', tripId: 'trip001', name: '朝食'),
         ],
       );
 

--- a/test/unit/infrastructure/repositories/trip/firestore_trip_entry_repository_test.dart
+++ b/test/unit/infrastructure/repositories/trip/firestore_trip_entry_repository_test.dart
@@ -120,7 +120,6 @@ void main() {
               allOf([
                 containsPair('tripId', 'generated-doc-id'),
                 containsPair('name', '朝食'),
-                isNot(contains('orderIndex')),
                 contains('createdAt'),
                 contains('updatedAt'),
               ]),


### PR DESCRIPTION
## 対応内容
- 旅程項目から`orderIndex`を削除
- 旅程項目の取得順を`startDateTime`昇順、同一開始日時では`endDateTime`昇順に変更
- ER図と`firestore.indexes.json`を新しい並び順に更新
- 対応todoを`docs/done.md`へ移動

## 完了したtodo
- 旅程項目から`orderIndex`を削除する
  - DB、Entity、DTO、Mapper、Query、Repository、Usecaseから旅程項目の`orderIndex`を除外する
  - 旅程項目の表示順は開始日時の昇順、開始日時が同じ場合は終了日時の昇順で決定する

## 検証
- `flutter test test/unit/domain/entities/trip test/unit/application/dtos/trip test/unit/application/mappers/trip test/unit/application/usecases/trip test/unit/infrastructure/mappers/trip test/unit/infrastructure/queries/trip test/unit/infrastructure/repositories/trip`
- `./check.sh`