### PR TITLE
refactor: 単純なFakeを生成モックへ置換

### DIFF
--- a/docs/done.md
+++ b/docs/done.md
@@ -760,6 +760,21 @@
 
 ## リファクタリング
 
+- 単純な手書きFake/MockをMockito生成モックへ置き換える
+  - `test/unit/application/usecases/account/get_current_user_usecase_test.dart`の手書き`MockAuthService`を`@GenerateMocks([AuthService])`へ置き換える
+  - DVCユースケースの単純な手書きRepository/QueryService Fakeを生成モックへ置き換える
+    - `test/unit/application/usecases/dvc/get_dvc_point_contracts_usecase_test.dart`
+    - `test/unit/application/usecases/dvc/get_dvc_limited_points_usecase_test.dart`
+    - `test/unit/application/usecases/dvc/get_dvc_point_usages_usecase_test.dart`
+    - `test/unit/application/usecases/dvc/delete_dvc_limited_point_usecase_test.dart`
+    - `test/unit/application/usecases/dvc/delete_dvc_point_usage_usecase_test.dart`
+    - `test/unit/application/usecases/dvc/save_dvc_limited_point_usecase_test.dart`
+    - `test/unit/application/usecases/dvc/save_dvc_point_usage_usecase_test.dart`
+    - `test/unit/application/usecases/dvc/save_dvc_point_contracts_usecase_test.dart`
+  - `test/unit/presentation/shared/map_views/google_map_view_test.dart`の`FakeGetCurrentLocationUsecase`と`FakeSearchLocationsUsecase`を生成モックへ置き換える
+  - `test/unit/presentation/shared/inputs/custom_search_bar_test.dart`の`FakeSearchLocationsUsecase`と`ThrowingSearchLocationsUsecase`を生成モックへ置き換える
+  - `test/unit/presentation/features/trip/task_view_test.dart`の`FakeTaskQueryService`と`FailingTaskQueryService`を生成モックへ置き換える
+  - `test/unit/presentation/features/trip/trip_edit_modal_test.dart`の`FakeGetNearbyLocationNameUsecase`を生成モックへ置き換える
 - trip_entriesのフィールド名を変更し、関連箇所を修正
   - tripName→name
   - tripYear→year

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -38,20 +38,5 @@
 ## 全体
 
 ## リファクタリング
-- 単純な手書きFake/MockをMockito生成モックへ置き換える
-  - `test/unit/application/usecases/account/get_current_user_usecase_test.dart`の手書き`MockAuthService`を`@GenerateMocks([AuthService])`へ置き換える
-  - DVCユースケースの単純な手書きRepository/QueryService Fakeを生成モックへ置き換える
-    - `test/unit/application/usecases/dvc/get_dvc_point_contracts_usecase_test.dart`
-    - `test/unit/application/usecases/dvc/get_dvc_limited_points_usecase_test.dart`
-    - `test/unit/application/usecases/dvc/get_dvc_point_usages_usecase_test.dart`
-    - `test/unit/application/usecases/dvc/delete_dvc_limited_point_usecase_test.dart`
-    - `test/unit/application/usecases/dvc/delete_dvc_point_usage_usecase_test.dart`
-    - `test/unit/application/usecases/dvc/save_dvc_limited_point_usecase_test.dart`
-    - `test/unit/application/usecases/dvc/save_dvc_point_usage_usecase_test.dart`
-    - `test/unit/application/usecases/dvc/save_dvc_point_contracts_usecase_test.dart`
-  - `test/unit/presentation/shared/map_views/google_map_view_test.dart`の`FakeGetCurrentLocationUsecase`と`FakeSearchLocationsUsecase`を生成モックへ置き換える
-  - `test/unit/presentation/shared/inputs/custom_search_bar_test.dart`の`FakeSearchLocationsUsecase`と`ThrowingSearchLocationsUsecase`を生成モックへ置き換える
-  - `test/unit/presentation/features/trip/task_view_test.dart`の`FakeTaskQueryService`と`FailingTaskQueryService`を生成モックへ置き換える
-  - `test/unit/presentation/features/trip/trip_edit_modal_test.dart`の`FakeGetNearbyLocationNameUsecase`を生成モックへ置き換える
 
 ## 不具合修正

--- a/test/unit/application/usecases/account/get_current_user_usecase_test.dart
+++ b/test/unit/application/usecases/account/get_current_user_usecase_test.dart
@@ -3,22 +3,13 @@ import 'package:memora/application/dtos/account/user_dto.dart';
 import 'package:memora/application/usecases/account/get_current_user_usecase.dart';
 import 'package:memora/application/services/auth_service.dart';
 import 'package:memora/domain/entities/account/user.dart';
+import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 
 import '../../../../helpers/test_exception.dart';
+import 'get_current_user_usecase_test.mocks.dart';
 
-class MockAuthService extends Mock implements AuthService {
-  @override
-  Future<User?> getCurrentUser() {
-    return super.noSuchMethod(
-          Invocation.method(#getCurrentUser, []),
-          returnValue: Future<User?>.value(),
-          returnValueForMissingStub: Future<User?>.value(),
-        )
-        as Future<User?>;
-  }
-}
-
+@GenerateMocks([AuthService])
 void main() {
   group('GetCurrentUserUseCase', () {
     late MockAuthService mockAuthService;

--- a/test/unit/application/usecases/dvc/delete_dvc_limited_point_usecase_test.dart
+++ b/test/unit/application/usecases/dvc/delete_dvc_limited_point_usecase_test.dart
@@ -1,32 +1,24 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:memora/application/usecases/dvc/delete_dvc_limited_point_usecase.dart';
-import 'package:memora/domain/entities/dvc/dvc_limited_point.dart';
 import 'package:memora/domain/repositories/dvc/dvc_limited_point_repository.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
 
+import 'delete_dvc_limited_point_usecase_test.mocks.dart';
+
+@GenerateMocks([DvcLimitedPointRepository])
 void main() {
   group('DeleteDvcLimitedPointUsecase', () {
     test('期間限定ポイントを削除できること', () async {
-      final repository = _FakeDvcLimitedPointRepository();
+      final repository = MockDvcLimitedPointRepository();
       final usecase = DeleteDvcLimitedPointUsecase(repository);
+      when(
+        repository.deleteDvcLimitedPoint('limited-1'),
+      ).thenAnswer((_) async {});
 
       await usecase.execute('limited-1');
 
-      expect(repository.deletedIds, equals(['limited-1']));
+      verify(repository.deleteDvcLimitedPoint('limited-1')).called(1);
     });
   });
-}
-
-class _FakeDvcLimitedPointRepository implements DvcLimitedPointRepository {
-  final List<String> deletedIds = [];
-
-  @override
-  Future<void> deleteDvcLimitedPoint(String limitedPointId) async {
-    deletedIds.add(limitedPointId);
-  }
-
-  @override
-  Future<void> deleteDvcLimitedPointsByGroupId(String groupId) async {}
-
-  @override
-  Future<void> saveDvcLimitedPoint(DvcLimitedPoint limitedPoint) async {}
 }

--- a/test/unit/application/usecases/dvc/delete_dvc_point_usage_usecase_test.dart
+++ b/test/unit/application/usecases/dvc/delete_dvc_point_usage_usecase_test.dart
@@ -1,32 +1,22 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:memora/application/usecases/dvc/delete_dvc_point_usage_usecase.dart';
-import 'package:memora/domain/entities/dvc/dvc_point_usage.dart';
 import 'package:memora/domain/repositories/dvc/dvc_point_usage_repository.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
 
+import 'delete_dvc_point_usage_usecase_test.mocks.dart';
+
+@GenerateMocks([DvcPointUsageRepository])
 void main() {
   group('DeleteDvcPointUsageUsecase', () {
     test('利用ポイントを削除できること', () async {
-      final repository = _FakeDvcPointUsageRepository();
+      final repository = MockDvcPointUsageRepository();
       final usecase = DeleteDvcPointUsageUsecase(repository);
+      when(repository.deleteDvcPointUsage('usage-1')).thenAnswer((_) async {});
 
       await usecase.execute('usage-1');
 
-      expect(repository.deletedIds, equals(['usage-1']));
+      verify(repository.deleteDvcPointUsage('usage-1')).called(1);
     });
   });
-}
-
-class _FakeDvcPointUsageRepository implements DvcPointUsageRepository {
-  final List<String> deletedIds = [];
-
-  @override
-  Future<void> deleteDvcPointUsage(String pointUsageId) async {
-    deletedIds.add(pointUsageId);
-  }
-
-  @override
-  Future<void> deleteDvcPointUsagesByGroupId(String groupId) async {}
-
-  @override
-  Future<void> saveDvcPointUsage(DvcPointUsage pointUsage) async {}
 }

--- a/test/unit/application/usecases/dvc/get_dvc_limited_points_usecase_test.dart
+++ b/test/unit/application/usecases/dvc/get_dvc_limited_points_usecase_test.dart
@@ -3,7 +3,12 @@ import 'package:memora/application/dtos/dvc/dvc_limited_point_dto.dart';
 import 'package:memora/application/queries/dvc/dvc_limited_point_query_service.dart';
 import 'package:memora/application/usecases/dvc/get_dvc_limited_points_usecase.dart';
 import 'package:memora/application/queries/order_by.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
 
+import 'get_dvc_limited_points_usecase_test.mocks.dart';
+
+@GenerateMocks([DvcLimitedPointQueryService])
 void main() {
   group('GetDvcLimitedPointsUsecase', () {
     test('グループIDで期間限定ポイントを取得できること', () async {
@@ -18,35 +23,28 @@ void main() {
           memo: 'キャンペーン',
         ),
       ];
-      final queryService = _FakeDvcLimitedPointQueryService(expectedPoints);
+      final queryService = MockDvcLimitedPointQueryService();
       final usecase = GetDvcLimitedPointsUsecase(queryService);
+      when(
+        queryService.getDvcLimitedPointsByGroupId(
+          groupId,
+          orderBy: anyNamed('orderBy'),
+        ),
+      ).thenAnswer((_) async => expectedPoints);
 
       final result = await usecase.execute(groupId);
 
       expect(result, equals(expectedPoints));
-      expect(queryService.receivedGroupId, equals(groupId));
+      final verification = verify(
+        queryService.getDvcLimitedPointsByGroupId(
+          groupId,
+          orderBy: captureAnyNamed('orderBy'),
+        ),
+      )..called(1);
       expect(
-        queryService.receivedOrderBy,
+        verification.captured.single,
         equals([const OrderBy('startYearMonth', descending: false)]),
       );
     });
   });
-}
-
-class _FakeDvcLimitedPointQueryService implements DvcLimitedPointQueryService {
-  _FakeDvcLimitedPointQueryService(this._points);
-
-  final List<DvcLimitedPointDto> _points;
-  String? receivedGroupId;
-  List<OrderBy>? receivedOrderBy;
-
-  @override
-  Future<List<DvcLimitedPointDto>> getDvcLimitedPointsByGroupId(
-    String groupId, {
-    List<OrderBy>? orderBy,
-  }) async {
-    receivedGroupId = groupId;
-    receivedOrderBy = orderBy;
-    return _points;
-  }
 }

--- a/test/unit/application/usecases/dvc/get_dvc_point_contracts_usecase_test.dart
+++ b/test/unit/application/usecases/dvc/get_dvc_point_contracts_usecase_test.dart
@@ -3,7 +3,12 @@ import 'package:memora/application/dtos/dvc/dvc_point_contract_dto.dart';
 import 'package:memora/application/queries/dvc/dvc_point_contract_query_service.dart';
 import 'package:memora/application/usecases/dvc/get_dvc_point_contracts_usecase.dart';
 import 'package:memora/application/queries/order_by.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
 
+import 'get_dvc_point_contracts_usecase_test.mocks.dart';
+
+@GenerateMocks([DvcPointContractQueryService])
 void main() {
   group('GetDvcPointContractsUsecase', () {
     test('グループIDで契約一覧を取得できること', () async {
@@ -19,36 +24,28 @@ void main() {
           annualPoint: 200,
         ),
       ];
-      final queryService = _FakeDvcPointContractQueryService(expectedContracts);
+      final queryService = MockDvcPointContractQueryService();
       final usecase = GetDvcPointContractsUsecase(queryService);
+      when(
+        queryService.getDvcPointContractsByGroupId(
+          groupId,
+          orderBy: anyNamed('orderBy'),
+        ),
+      ).thenAnswer((_) async => expectedContracts);
 
       final result = await usecase.execute(groupId);
 
       expect(result, equals(expectedContracts));
-      expect(queryService.receivedGroupId, equals(groupId));
+      final verification = verify(
+        queryService.getDvcPointContractsByGroupId(
+          groupId,
+          orderBy: captureAnyNamed('orderBy'),
+        ),
+      )..called(1);
       expect(
-        queryService.receivedOrderBy,
+        verification.captured.single,
         equals([const OrderBy('contractName', descending: false)]),
       );
     });
   });
-}
-
-class _FakeDvcPointContractQueryService
-    implements DvcPointContractQueryService {
-  _FakeDvcPointContractQueryService(this._contracts);
-
-  final List<DvcPointContractDto> _contracts;
-  String? receivedGroupId;
-  List<OrderBy>? receivedOrderBy;
-
-  @override
-  Future<List<DvcPointContractDto>> getDvcPointContractsByGroupId(
-    String groupId, {
-    List<OrderBy>? orderBy,
-  }) async {
-    receivedGroupId = groupId;
-    receivedOrderBy = orderBy;
-    return _contracts;
-  }
 }

--- a/test/unit/application/usecases/dvc/get_dvc_point_usages_usecase_test.dart
+++ b/test/unit/application/usecases/dvc/get_dvc_point_usages_usecase_test.dart
@@ -3,7 +3,12 @@ import 'package:memora/application/dtos/dvc/dvc_point_usage_dto.dart';
 import 'package:memora/application/queries/dvc/dvc_point_usage_query_service.dart';
 import 'package:memora/application/usecases/dvc/get_dvc_point_usages_usecase.dart';
 import 'package:memora/application/queries/order_by.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
 
+import 'get_dvc_point_usages_usecase_test.mocks.dart';
+
+@GenerateMocks([DvcPointUsageQueryService])
 void main() {
   group('GetDvcPointUsagesUsecase', () {
     test('グループIDでDVCポイント利用が取得できること', () async {
@@ -18,37 +23,30 @@ void main() {
           memo: '春の利用',
         ),
       ];
-      final queryService = _FakeDvcPointUsageQueryService(expectedUsages);
+      final queryService = MockDvcPointUsageQueryService();
       final usecase = GetDvcPointUsagesUsecase(queryService);
+      when(
+        queryService.getDvcPointUsagesByGroupId(
+          groupId,
+          orderBy: anyNamed('orderBy'),
+        ),
+      ).thenAnswer((_) async => expectedUsages);
 
       // Act
       final result = await usecase.execute(groupId);
 
       // Assert
       expect(result, equals(expectedUsages));
-      expect(queryService.receivedGroupId, equals(groupId));
+      final verification = verify(
+        queryService.getDvcPointUsagesByGroupId(
+          groupId,
+          orderBy: captureAnyNamed('orderBy'),
+        ),
+      )..called(1);
       expect(
-        queryService.receivedOrderBy,
+        verification.captured.single,
         equals([const OrderBy('usageYearMonth', descending: false)]),
       );
     });
   });
-}
-
-class _FakeDvcPointUsageQueryService implements DvcPointUsageQueryService {
-  _FakeDvcPointUsageQueryService(this._usages);
-
-  final List<DvcPointUsageDto> _usages;
-  String? receivedGroupId;
-  List<OrderBy>? receivedOrderBy;
-
-  @override
-  Future<List<DvcPointUsageDto>> getDvcPointUsagesByGroupId(
-    String groupId, {
-    List<OrderBy>? orderBy,
-  }) async {
-    receivedGroupId = groupId;
-    receivedOrderBy = orderBy;
-    return _usages;
-  }
 }

--- a/test/unit/application/usecases/dvc/save_dvc_limited_point_usecase_test.dart
+++ b/test/unit/application/usecases/dvc/save_dvc_limited_point_usecase_test.dart
@@ -3,11 +3,16 @@ import 'package:memora/application/dtos/dvc/dvc_limited_point_dto.dart';
 import 'package:memora/application/usecases/dvc/save_dvc_limited_point_usecase.dart';
 import 'package:memora/domain/entities/dvc/dvc_limited_point.dart';
 import 'package:memora/domain/repositories/dvc/dvc_limited_point_repository.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
 
+import 'save_dvc_limited_point_usecase_test.mocks.dart';
+
+@GenerateMocks([DvcLimitedPointRepository])
 void main() {
   group('SaveDvcLimitedPointUsecase', () {
     test('期間限定ポイントを保存できること', () async {
-      final repository = _FakeDvcLimitedPointRepository();
+      final repository = MockDvcLimitedPointRepository();
       final usecase = SaveDvcLimitedPointUsecase(repository);
       final limitedPoint = DvcLimitedPointDto(
         id: '',
@@ -17,28 +22,16 @@ void main() {
         point: 30,
         memo: 'メモ',
       );
+      when(repository.saveDvcLimitedPoint(any)).thenAnswer((_) async {});
 
       await usecase.execute(limitedPoint);
 
-      expect(repository.savedLimitedPoints, hasLength(1));
-      expect(repository.savedLimitedPoints.first.groupId, equals('group-1'));
-      expect(repository.savedLimitedPoints.first.point, equals(30));
-      expect(repository.savedLimitedPoints.first.memo, equals('メモ'));
+      final verification = verify(repository.saveDvcLimitedPoint(captureAny))
+        ..called(1);
+      final savedLimitedPoint = verification.captured.single as DvcLimitedPoint;
+      expect(savedLimitedPoint.groupId, equals('group-1'));
+      expect(savedLimitedPoint.point, equals(30));
+      expect(savedLimitedPoint.memo, equals('メモ'));
     });
   });
-}
-
-class _FakeDvcLimitedPointRepository implements DvcLimitedPointRepository {
-  final List<DvcLimitedPoint> savedLimitedPoints = [];
-
-  @override
-  Future<void> deleteDvcLimitedPoint(String limitedPointId) async {}
-
-  @override
-  Future<void> deleteDvcLimitedPointsByGroupId(String groupId) async {}
-
-  @override
-  Future<void> saveDvcLimitedPoint(DvcLimitedPoint limitedPoint) async {
-    savedLimitedPoints.add(limitedPoint);
-  }
 }

--- a/test/unit/application/usecases/dvc/save_dvc_point_contracts_usecase_test.dart
+++ b/test/unit/application/usecases/dvc/save_dvc_point_contracts_usecase_test.dart
@@ -3,11 +3,16 @@ import 'package:memora/application/dtos/dvc/dvc_point_contract_dto.dart';
 import 'package:memora/application/usecases/dvc/save_dvc_point_contracts_usecase.dart';
 import 'package:memora/domain/entities/dvc/dvc_point_contract.dart';
 import 'package:memora/domain/repositories/dvc/dvc_point_contract_repository.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
 
+import 'save_dvc_point_contracts_usecase_test.mocks.dart';
+
+@GenerateMocks([DvcPointContractRepository])
 void main() {
   group('SaveDvcPointContractsUsecase', () {
     test('既存契約を削除して契約一覧を保存できること', () async {
-      final repository = _FakeDvcPointContractRepository();
+      final repository = MockDvcPointContractRepository();
       final usecase = SaveDvcPointContractsUsecase(repository);
       const groupId = 'group-1';
       final contracts = [
@@ -21,31 +26,19 @@ void main() {
           annualPoint: 200,
         ),
       ];
+      when(
+        repository.deleteDvcPointContractsByGroupId(groupId),
+      ).thenAnswer((_) async {});
+      when(repository.saveDvcPointContract(any)).thenAnswer((_) async {});
 
       await usecase.execute(groupId: groupId, contracts: contracts);
 
-      expect(repository.deletedGroupIds, equals([groupId]));
-      expect(repository.savedContracts, hasLength(1));
-      expect(repository.savedContracts.first.contractName, equals('契約A'));
-      expect(repository.savedContracts.first.groupId, equals(groupId));
+      verify(repository.deleteDvcPointContractsByGroupId(groupId)).called(1);
+      final verification = verify(repository.saveDvcPointContract(captureAny))
+        ..called(1);
+      final savedContract = verification.captured.single as DvcPointContract;
+      expect(savedContract.contractName, equals('契約A'));
+      expect(savedContract.groupId, equals(groupId));
     });
   });
-}
-
-class _FakeDvcPointContractRepository implements DvcPointContractRepository {
-  final List<String> deletedGroupIds = [];
-  final List<DvcPointContract> savedContracts = [];
-
-  @override
-  Future<void> deleteDvcPointContract(String contractId) async {}
-
-  @override
-  Future<void> deleteDvcPointContractsByGroupId(String groupId) async {
-    deletedGroupIds.add(groupId);
-  }
-
-  @override
-  Future<void> saveDvcPointContract(DvcPointContract contract) async {
-    savedContracts.add(contract);
-  }
 }

--- a/test/unit/application/usecases/dvc/save_dvc_point_usage_usecase_test.dart
+++ b/test/unit/application/usecases/dvc/save_dvc_point_usage_usecase_test.dart
@@ -3,11 +3,16 @@ import 'package:memora/application/dtos/dvc/dvc_point_usage_dto.dart';
 import 'package:memora/application/usecases/dvc/save_dvc_point_usage_usecase.dart';
 import 'package:memora/domain/entities/dvc/dvc_point_usage.dart';
 import 'package:memora/domain/repositories/dvc/dvc_point_usage_repository.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
 
+import 'save_dvc_point_usage_usecase_test.mocks.dart';
+
+@GenerateMocks([DvcPointUsageRepository])
 void main() {
   group('SaveDvcPointUsageUsecase', () {
     test('利用ポイントを保存できること', () async {
-      final repository = _FakeDvcPointUsageRepository();
+      final repository = MockDvcPointUsageRepository();
       final usecase = SaveDvcPointUsageUsecase(repository);
       final usage = DvcPointUsageDto(
         id: '',
@@ -16,28 +21,16 @@ void main() {
         usedPoint: 25,
         memo: 'レストラン',
       );
+      when(repository.saveDvcPointUsage(any)).thenAnswer((_) async {});
 
       await usecase.execute(usage);
 
-      expect(repository.savedUsages, hasLength(1));
-      expect(repository.savedUsages.first.groupId, equals('group-1'));
-      expect(repository.savedUsages.first.usedPoint, equals(25));
-      expect(repository.savedUsages.first.memo, equals('レストラン'));
+      final verification = verify(repository.saveDvcPointUsage(captureAny))
+        ..called(1);
+      final savedUsage = verification.captured.single as DvcPointUsage;
+      expect(savedUsage.groupId, equals('group-1'));
+      expect(savedUsage.usedPoint, equals(25));
+      expect(savedUsage.memo, equals('レストラン'));
     });
   });
-}
-
-class _FakeDvcPointUsageRepository implements DvcPointUsageRepository {
-  final List<DvcPointUsage> savedUsages = [];
-
-  @override
-  Future<void> deleteDvcPointUsage(String pointUsageId) async {}
-
-  @override
-  Future<void> deleteDvcPointUsagesByGroupId(String groupId) async {}
-
-  @override
-  Future<void> saveDvcPointUsage(DvcPointUsage pointUsage) async {
-    savedUsages.add(pointUsage);
-  }
 }

--- a/test/unit/presentation/features/trip/task_view_test.dart
+++ b/test/unit/presentation/features/trip/task_view_test.dart
@@ -4,7 +4,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:memora/application/dtos/group/group_member_dto.dart';
 import 'package:memora/application/dtos/trip/task_dto.dart';
 import 'package:memora/application/queries/trip/task_query_service.dart';
-import 'package:memora/application/queries/order_by.dart';
 import 'package:memora/infrastructure/factories/query_service_factory.dart';
 import 'package:memora/presentation/features/trip/task_view.dart';
 import 'package:mockito/annotations.dart';

--- a/test/unit/presentation/features/trip/task_view_test.dart
+++ b/test/unit/presentation/features/trip/task_view_test.dart
@@ -7,34 +7,31 @@ import 'package:memora/application/queries/trip/task_query_service.dart';
 import 'package:memora/application/queries/order_by.dart';
 import 'package:memora/infrastructure/factories/query_service_factory.dart';
 import 'package:memora/presentation/features/trip/task_view.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+
 import '../../../../helpers/test_exception.dart';
+import 'task_view_test.mocks.dart';
 
 final _uuidV7Pattern = RegExp(
   r'^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$',
 );
 
-class FakeTaskQueryService implements TaskQueryService {
-  FakeTaskQueryService(this.tasks);
-
-  final List<TaskDto> tasks;
-
-  @override
-  Future<List<TaskDto>> getTasksByTripId(
-    String tripId, {
-    List<OrderBy>? orderBy,
-  }) async {
-    return tasks;
-  }
+@GenerateMocks([TaskQueryService])
+MockTaskQueryService _mockTaskQueryService(List<TaskDto> tasks) {
+  final queryService = MockTaskQueryService();
+  when(
+    queryService.getTasksByTripId(any, orderBy: anyNamed('orderBy')),
+  ).thenAnswer((_) async => tasks);
+  return queryService;
 }
 
-class FailingTaskQueryService implements TaskQueryService {
-  @override
-  Future<List<TaskDto>> getTasksByTripId(
-    String tripId, {
-    List<OrderBy>? orderBy,
-  }) {
-    throw TestException('通信エラー');
-  }
+MockTaskQueryService _failingTaskQueryService() {
+  final queryService = MockTaskQueryService();
+  when(
+    queryService.getTasksByTripId(any, orderBy: anyNamed('orderBy')),
+  ).thenThrow(TestException('通信エラー'));
+  return queryService;
 }
 
 Widget _wrapWithApp(Widget child, {List<Override> overrides = const []}) {
@@ -868,7 +865,7 @@ void main() {
           isCompleted: false,
         ),
       ];
-      final fakeQueryService = FakeTaskQueryService(copiedTasks);
+      final mockQueryService = _mockTaskQueryService(copiedTasks);
 
       await tester.pumpWidget(
         _wrapWithApp(
@@ -881,7 +878,7 @@ void main() {
             },
           ),
           overrides: [
-            taskQueryServiceProvider.overrideWithValue(fakeQueryService),
+            taskQueryServiceProvider.overrideWithValue(mockQueryService),
           ],
         ),
       );
@@ -920,7 +917,7 @@ void main() {
           isCompleted: false,
         ),
       ];
-      final fakeQueryService = FakeTaskQueryService(copiedTasks);
+      final mockQueryService = _mockTaskQueryService(copiedTasks);
 
       await tester.pumpWidget(
         _wrapWithApp(
@@ -933,7 +930,7 @@ void main() {
             },
           ),
           overrides: [
-            taskQueryServiceProvider.overrideWithValue(fakeQueryService),
+            taskQueryServiceProvider.overrideWithValue(mockQueryService),
           ],
         ),
       );
@@ -972,7 +969,7 @@ void main() {
           ),
           overrides: [
             taskQueryServiceProvider.overrideWithValue(
-              FailingTaskQueryService(),
+              _failingTaskQueryService(),
             ),
           ],
         ),
@@ -1008,7 +1005,7 @@ void main() {
           parentTaskId: 'parent-1',
         ),
       ];
-      final fakeQueryService = FakeTaskQueryService(copiedTasks);
+      final mockQueryService = _mockTaskQueryService(copiedTasks);
 
       await tester.pumpWidget(
         _wrapWithApp(
@@ -1021,7 +1018,7 @@ void main() {
             },
           ),
           overrides: [
-            taskQueryServiceProvider.overrideWithValue(fakeQueryService),
+            taskQueryServiceProvider.overrideWithValue(mockQueryService),
           ],
         ),
       );

--- a/test/unit/presentation/features/trip/trip_edit_modal_test.dart
+++ b/test/unit/presentation/features/trip/trip_edit_modal_test.dart
@@ -12,10 +12,14 @@ import 'package:memora/presentation/features/trip/trip_edit_modal.dart';
 import 'package:memora/presentation/features/trip/select_visit_location_view.dart';
 import 'package:memora/presentation/shared/map_views/google_map_view.dart';
 import 'package:memora/presentation/shared/sheets/pin_detail_bottom_sheet.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+
+import 'trip_edit_modal_test.mocks.dart';
 
 Widget _createApp({
   required Widget child,
-  FakeGetNearbyLocationNameUsecase? getNearbyLocationNameUsecase,
+  GetNearbyLocationNameUsecase? getNearbyLocationNameUsecase,
 }) {
   return ProviderScope(
     overrides: [
@@ -28,19 +32,13 @@ Widget _createApp({
   );
 }
 
-class FakeGetNearbyLocationNameUsecase implements GetNearbyLocationNameUsecase {
-  FakeGetNearbyLocationNameUsecase({this.locationName});
-
-  final String? locationName;
-  int callCount = 0;
-  Coordinate? lastCoordinate;
-
-  @override
-  Future<String?> execute(Coordinate coordinate) async {
-    callCount += 1;
-    lastCoordinate = coordinate;
-    return locationName;
-  }
+@GenerateMocks([GetNearbyLocationNameUsecase])
+MockGetNearbyLocationNameUsecase _mockGetNearbyLocationNameUsecase({
+  String? locationName,
+}) {
+  final usecase = MockGetNearbyLocationNameUsecase();
+  when(usecase.execute(any)).thenAnswer((_) async => locationName);
+  return usecase;
 }
 
 final _uuidV7Pattern = RegExp(
@@ -228,14 +226,13 @@ void main() {
     });
 
     testWidgets('手動でピンを追加した時だけ場所名を取得すること', (WidgetTester tester) async {
-      final fakeGetNearbyLocationNameUsecase = FakeGetNearbyLocationNameUsecase(
-        locationName: '取得した場所名',
-      );
+      final mockGetNearbyLocationNameUsecase =
+          _mockGetNearbyLocationNameUsecase(locationName: '取得した場所名');
       TripEntryDto? savedTripEntry;
 
       await tester.pumpWidget(
         _createApp(
-          getNearbyLocationNameUsecase: fakeGetNearbyLocationNameUsecase,
+          getNearbyLocationNameUsecase: mockGetNearbyLocationNameUsecase,
           child: TripEditModal(
             groupId: 'test-group-id',
             groupMembers: const [],
@@ -263,9 +260,11 @@ void main() {
       });
       await tester.pumpAndSettle();
 
-      expect(fakeGetNearbyLocationNameUsecase.callCount, 1);
+      final verification = verify(
+        mockGetNearbyLocationNameUsecase.execute(captureAny),
+      )..called(1);
       expect(
-        fakeGetNearbyLocationNameUsecase.lastCoordinate,
+        verification.captured.single,
         const Coordinate(latitude: 35.681236, longitude: 139.767125),
       );
 
@@ -290,9 +289,8 @@ void main() {
     testWidgets('検索結果からピンを追加した時は選択した場所名をそのまま使用すること', (
       WidgetTester tester,
     ) async {
-      final fakeGetNearbyLocationNameUsecase = FakeGetNearbyLocationNameUsecase(
-        locationName: '取得してはいけない場所名',
-      );
+      final mockGetNearbyLocationNameUsecase =
+          _mockGetNearbyLocationNameUsecase(locationName: '取得してはいけない場所名');
       TripEntryDto? savedTripEntry;
       const candidate = LocationCandidateDto(
         name: '検索結果の場所名',
@@ -302,7 +300,7 @@ void main() {
 
       await tester.pumpWidget(
         _createApp(
-          getNearbyLocationNameUsecase: fakeGetNearbyLocationNameUsecase,
+          getNearbyLocationNameUsecase: mockGetNearbyLocationNameUsecase,
           child: TripEditModal(
             groupId: 'test-group-id',
             groupMembers: const [],
@@ -326,7 +324,7 @@ void main() {
       googleMapView.onSearchedLocationSelected?.call(candidate);
       await tester.pumpAndSettle();
 
-      expect(fakeGetNearbyLocationNameUsecase.callCount, 0);
+      verifyNever(mockGetNearbyLocationNameUsecase.execute(any));
 
       final selectVisitLocationView = tester.widget<SelectVisitLocationView>(
         find.byType(SelectVisitLocationView),

--- a/test/unit/presentation/shared/inputs/custom_search_bar_test.dart
+++ b/test/unit/presentation/shared/inputs/custom_search_bar_test.dart
@@ -6,24 +6,25 @@ import 'package:memora/application/dtos/location/location_candidate_dto.dart';
 import 'package:memora/application/usecases/location/search_locations_usecase.dart';
 import 'package:memora/core/models/coordinate.dart';
 import 'package:memora/presentation/shared/inputs/custom_search_bar.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+
 import '../../../../helpers/test_exception.dart';
+import 'custom_search_bar_test.mocks.dart';
 
-class FakeSearchLocationsUsecase implements SearchLocationsUsecase {
-  FakeSearchLocationsUsecase(this.candidates);
-
-  final List<LocationCandidateDto> candidates;
-
-  @override
-  Future<List<LocationCandidateDto>> execute(String keyword) async {
-    return candidates;
-  }
+@GenerateMocks([SearchLocationsUsecase])
+MockSearchLocationsUsecase _mockSearchLocationsUsecase(
+  List<LocationCandidateDto> candidates,
+) {
+  final usecase = MockSearchLocationsUsecase();
+  when(usecase.execute(any)).thenAnswer((_) async => candidates);
+  return usecase;
 }
 
-class ThrowingSearchLocationsUsecase implements SearchLocationsUsecase {
-  @override
-  Future<List<LocationCandidateDto>> execute(String keyword) {
-    throw TestException('場所検索失敗');
-  }
+MockSearchLocationsUsecase _throwingSearchLocationsUsecase() {
+  final usecase = MockSearchLocationsUsecase();
+  when(usecase.execute(any)).thenThrow(TestException('場所検索失敗'));
+  return usecase;
 }
 
 class LifecycleAwareSearchLocationsUsecase implements SearchLocationsUsecase {
@@ -68,7 +69,7 @@ Widget buildTestApp({
   return ProviderScope(
     overrides: [
       searchLocationsUsecaseProvider.overrideWithValue(
-        searchLocationsUsecase ?? FakeSearchLocationsUsecase(const []),
+        searchLocationsUsecase ?? _mockSearchLocationsUsecase(const []),
       ),
     ],
     child: MaterialApp(home: Scaffold(body: child)),
@@ -92,7 +93,7 @@ void main() {
       LocationCandidateDto? tappedCandidate;
       await tester.pumpWidget(
         buildTestApp(
-          searchLocationsUsecase: FakeSearchLocationsUsecase(mockCandidates),
+          searchLocationsUsecase: _mockSearchLocationsUsecase(mockCandidates),
           child: CustomSearchBar(
             hintText: '場所を検索',
             onCandidateSelected: (candidate) {
@@ -136,7 +137,7 @@ void main() {
       final mockCandidates = mockCandidatesDefault;
       await tester.pumpWidget(
         buildTestApp(
-          searchLocationsUsecase: FakeSearchLocationsUsecase(mockCandidates),
+          searchLocationsUsecase: _mockSearchLocationsUsecase(mockCandidates),
           child: const CustomSearchBar(hintText: '場所を検索'),
         ),
       );
@@ -156,7 +157,7 @@ void main() {
     testWidgets('検索失敗時でもローディング表示が解除される', (WidgetTester tester) async {
       await tester.pumpWidget(
         buildTestApp(
-          searchLocationsUsecase: ThrowingSearchLocationsUsecase(),
+          searchLocationsUsecase: _throwingSearchLocationsUsecase(),
           child: const CustomSearchBar(hintText: '場所を検索'),
         ),
       );

--- a/test/unit/presentation/shared/map_views/google_map_view_test.dart
+++ b/test/unit/presentation/shared/map_views/google_map_view_test.dart
@@ -10,27 +10,26 @@ import 'package:memora/presentation/notifiers/coordinate_notifier.dart';
 import 'package:memora/core/models/coordinate.dart';
 import 'package:memora/presentation/shared/map_views/google_map_view.dart';
 import 'package:memora/presentation/shared/sheets/pin_detail_bottom_sheet.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
 
-class FakeGetCurrentLocationUsecase implements GetCurrentLocationUsecase {
-  FakeGetCurrentLocationUsecase([this._coordinate]);
+import 'google_map_view_test.mocks.dart';
 
-  final Coordinate? _coordinate;
-
-  @override
-  Future<Coordinate?> execute() async {
-    return _coordinate;
-  }
+@GenerateMocks([GetCurrentLocationUsecase, SearchLocationsUsecase])
+MockGetCurrentLocationUsecase _mockGetCurrentLocationUsecase([
+  Coordinate? coordinate,
+]) {
+  final usecase = MockGetCurrentLocationUsecase();
+  when(usecase.execute()).thenAnswer((_) async => coordinate);
+  return usecase;
 }
 
-class FakeSearchLocationsUsecase implements SearchLocationsUsecase {
-  FakeSearchLocationsUsecase(this._candidates);
-
-  final List<LocationCandidateDto> _candidates;
-
-  @override
-  Future<List<LocationCandidateDto>> execute(String keyword) async {
-    return _candidates;
-  }
+MockSearchLocationsUsecase _mockSearchLocationsUsecase(
+  List<LocationCandidateDto> candidates,
+) {
+  final usecase = MockSearchLocationsUsecase();
+  when(usecase.execute(any)).thenAnswer((_) async => candidates);
+  return usecase;
 }
 
 void main() {
@@ -80,10 +79,10 @@ void main() {
       final container = ProviderContainer(
         overrides: [
           getCurrentLocationUsecaseProvider.overrideWithValue(
-            FakeGetCurrentLocationUsecase(),
+            _mockGetCurrentLocationUsecase(),
           ),
           searchLocationsUsecaseProvider.overrideWithValue(
-            FakeSearchLocationsUsecase(const []),
+            _mockSearchLocationsUsecase(const []),
           ),
         ],
       );
@@ -118,10 +117,10 @@ void main() {
       final container = ProviderContainer(
         overrides: [
           getCurrentLocationUsecaseProvider.overrideWithValue(
-            FakeGetCurrentLocationUsecase(),
+            _mockGetCurrentLocationUsecase(),
           ),
           searchLocationsUsecaseProvider.overrideWithValue(
-            FakeSearchLocationsUsecase(const []),
+            _mockSearchLocationsUsecase(const []),
           ),
         ],
       );
@@ -171,10 +170,10 @@ void main() {
       final container = ProviderContainer(
         overrides: [
           getCurrentLocationUsecaseProvider.overrideWithValue(
-            FakeGetCurrentLocationUsecase(),
+            _mockGetCurrentLocationUsecase(),
           ),
           searchLocationsUsecaseProvider.overrideWithValue(
-            FakeSearchLocationsUsecase(const []),
+            _mockSearchLocationsUsecase(const []),
           ),
         ],
       );
@@ -274,10 +273,10 @@ void main() {
         ProviderScope(
           overrides: [
             searchLocationsUsecaseProvider.overrideWithValue(
-              FakeSearchLocationsUsecase(searchCandidates),
+              _mockSearchLocationsUsecase(searchCandidates),
             ),
             getCurrentLocationUsecaseProvider.overrideWithValue(
-              FakeGetCurrentLocationUsecase(),
+              _mockGetCurrentLocationUsecase(),
             ),
           ],
           child: MaterialApp(


### PR DESCRIPTION
## 概要
- 単純な手書きFake/MockをMockitoの`@GenerateMocks`生成モックへ置き換え
- DVCユースケース、現在ユーザー取得、地図/検索/タスク/旅行編集系テストの依存差し替えをMockito検証へ統一
- 対応したリファクタリングtodoを`docs/done.md`へ移動

## 完了したtodo
- 単純な手書きFake/MockをMockito生成モックへ置き換える

## 検証
- `flutter test` 対象テスト一式
- `./check.sh`

補足: `build_runner`実行時に既存依存関係由来のanalyzer/SDKバージョン警告が出ましたが、生成・解析・テストは成功しています。