### PR TITLE
feat(trip): locationsデータ層を追加

### DIFF
--- a/docs/done.md
+++ b/docs/done.md
@@ -2,6 +2,36 @@
 
 ## DB設計・リポジトリ・ユースケース・DTO・マッパー関連
 
+- locationsのドメインエンティティを作成する
+  - `id`, `tripId`, `groupId`, `name`, `latitude`, `longitude`を保持する
+  - trip_entryの子エンティティとして扱う
+  - `latitude`と`longitude`の必須制約を表現する
+- locationsのリポジトリインターフェースを作成する
+  - 場所の追加・更新・削除をできるようにする
+- locationsのFirestoreマッパーを作成する
+  - Firestoreドキュメントとドメインエンティティを相互変換する
+  - `tripId`, `groupId`, `name`, `latitude`, `longitude`の欠損や型不整合を検証する
+- locationsのFirestoreリポジトリを作成する
+  - 追加・更新・削除時にマッパーを通してFirestoreへ保存する
+- locationsのDTOとアプリケーションマッパーを作成する
+  - Presentation層へ渡す場所情報をDTOとして定義する
+  - ドメインエンティティとDTOを相互変換する
+- locationsのクエリサービスを作成する
+  - 旅行IDで場所一覧を取得できるようにする
+  - グループIDで場所一覧を取得できるようにする
+  - Firestoreから取得したlocationsをDTOへ変換して返す
+- locationsのユースケースを作成する
+  - 旅行に紐づく場所一覧を取得する
+  - グループに紐づく場所一覧を取得する
+  - 場所を追加・更新・削除する
+- itinerary_itemsの`locationId`追加に対応する
+  - ドメインエンティティ、DTO、アプリケーションマッパーに`locationId`を追加する
+  - Firestoreマッパーで`locationId`を読み書きできるようにする
+  - 旅程項目の追加・更新時に`locationId`を保存できるようにする
+- itinerary_itemsのクエリでlocationを紐付けて取得できるようにする
+  - `locationId`が設定されている旅程項目は対応するlocationも取得する
+  - `locationId`が未設定または参照先locationが存在しない場合はlocationなしで取得する
+- location削除時に参照中の旅程項目の`locationId`をnullへ更新する
 - Androidウィジェット用に対象グループの旅行と旅程を取得するユースケースを作成する
   - 対象グループの旅行のうち、現在日付以降で開始日が最も近い旅行を直近旅行として判定する
   - 直近旅行を基準に、旅行開始日の昇順で前後の旅行へ移動できるようにする

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -2,37 +2,6 @@
 
 ## DB設計・リポジトリ・ユースケース・DTO・マッパー関連
 
-- locationsのドメインエンティティを作成する
-  - `id`, `tripId`, `groupId`, `name`, `latitude`, `longitude`を保持する
-  - trip_entryの子エンティティとして扱う
-  - `latitude`と`longitude`の必須制約を表現する
-- locationsのリポジトリインターフェースを作成する
-  - 場所の追加・更新・削除をできるようにする
-- locationsのFirestoreマッパーを作成する
-  - Firestoreドキュメントとドメインエンティティを相互変換する
-  - `tripId`, `groupId`, `name`, `latitude`, `longitude`の欠損や型不整合を検証する
-- locationsのFirestoreリポジトリを作成する
-  - 追加・更新・削除時にマッパーを通してFirestoreへ保存する
-- locationsのDTOとアプリケーションマッパーを作成する
-  - Presentation層へ渡す場所情報をDTOとして定義する
-  - ドメインエンティティとDTOを相互変換する
-- locationsのクエリサービスを作成する
-  - 旅行IDで場所一覧を取得できるようにする
-  - グループIDで場所一覧を取得できるようにする
-  - Firestoreから取得したlocationsをDTOへ変換して返す
-- locationsのユースケースを作成する
-  - 旅行に紐づく場所一覧を取得する
-  - グループに紐づく場所一覧を取得する
-  - 場所を追加・更新・削除する
-- itinerary_itemsの`locationId`追加に対応する
-  - ドメインエンティティ、DTO、アプリケーションマッパーに`locationId`を追加する
-  - Firestoreマッパーで`locationId`を読み書きできるようにする
-  - 旅程項目の追加・更新時に`locationId`を保存できるようにする
-- itinerary_itemsのクエリでlocationを紐付けて取得できるようにする
-  - `locationId`が設定されている旅程項目は対応するlocationも取得する
-  - `locationId`が未設定または参照先locationが存在しない場合はlocationなしで取得する
-- location削除時に参照中の旅程項目の`locationId`をnullへ更新する
-
 ## マップの表示
 
 

--- a/lib/application/dtos/trip/itinerary_item_dto.dart
+++ b/lib/application/dtos/trip/itinerary_item_dto.dart
@@ -1,5 +1,6 @@
 import 'package:equatable/equatable.dart';
 import 'package:memora/application/dtos/copy_with_helper.dart';
+import 'package:memora/application/dtos/trip/location_dto.dart';
 
 class ItineraryItemDto extends Equatable {
   const ItineraryItemDto({
@@ -10,6 +11,7 @@ class ItineraryItemDto extends Equatable {
     this.endDateTime,
     this.memo,
     this.locationId,
+    this.location,
   });
 
   final String id;
@@ -19,6 +21,7 @@ class ItineraryItemDto extends Equatable {
   final DateTime? endDateTime;
   final String? memo;
   final String? locationId;
+  final LocationDto? location;
 
   ItineraryItemDto copyWith({
     String? id,
@@ -28,6 +31,7 @@ class ItineraryItemDto extends Equatable {
     Object? endDateTime = copyWithPlaceholder,
     Object? memo = copyWithPlaceholder,
     Object? locationId = copyWithPlaceholder,
+    Object? location = copyWithPlaceholder,
   }) {
     return ItineraryItemDto(
       id: id ?? this.id,
@@ -49,6 +53,11 @@ class ItineraryItemDto extends Equatable {
         this.locationId,
         'locationId',
       ),
+      location: resolveCopyWithValue<LocationDto>(
+        location,
+        this.location,
+        'location',
+      ),
     );
   }
 
@@ -61,5 +70,6 @@ class ItineraryItemDto extends Equatable {
     endDateTime,
     memo,
     locationId,
+    location,
   ];
 }

--- a/lib/application/dtos/trip/itinerary_item_dto.dart
+++ b/lib/application/dtos/trip/itinerary_item_dto.dart
@@ -9,6 +9,7 @@ class ItineraryItemDto extends Equatable {
     this.startDateTime,
     this.endDateTime,
     this.memo,
+    this.locationId,
   });
 
   final String id;
@@ -17,6 +18,7 @@ class ItineraryItemDto extends Equatable {
   final DateTime? startDateTime;
   final DateTime? endDateTime;
   final String? memo;
+  final String? locationId;
 
   ItineraryItemDto copyWith({
     String? id,
@@ -25,6 +27,7 @@ class ItineraryItemDto extends Equatable {
     Object? startDateTime = copyWithPlaceholder,
     Object? endDateTime = copyWithPlaceholder,
     Object? memo = copyWithPlaceholder,
+    Object? locationId = copyWithPlaceholder,
   }) {
     return ItineraryItemDto(
       id: id ?? this.id,
@@ -41,6 +44,11 @@ class ItineraryItemDto extends Equatable {
         'endDateTime',
       ),
       memo: resolveCopyWithValue<String>(memo, this.memo, 'memo'),
+      locationId: resolveCopyWithValue<String>(
+        locationId,
+        this.locationId,
+        'locationId',
+      ),
     );
   }
 
@@ -52,5 +60,6 @@ class ItineraryItemDto extends Equatable {
     startDateTime,
     endDateTime,
     memo,
+    locationId,
   ];
 }

--- a/lib/application/dtos/trip/location_dto.dart
+++ b/lib/application/dtos/trip/location_dto.dart
@@ -1,0 +1,47 @@
+import 'package:equatable/equatable.dart';
+import 'package:memora/application/dtos/copy_with_helper.dart';
+import 'package:memora/core/models/coordinate.dart';
+
+class LocationDto extends Equatable {
+  const LocationDto({
+    required this.id,
+    required this.tripId,
+    required this.groupId,
+    required this.latitude,
+    required this.longitude,
+    this.name,
+  });
+
+  final String id;
+  final String tripId;
+  final String groupId;
+  final String? name;
+  final double latitude;
+  final double longitude;
+
+  Coordinate get coordinate => Coordinate(
+    latitude: latitude,
+    longitude: longitude,
+  );
+
+  LocationDto copyWith({
+    String? id,
+    String? tripId,
+    String? groupId,
+    Object? name = copyWithPlaceholder,
+    double? latitude,
+    double? longitude,
+  }) {
+    return LocationDto(
+      id: id ?? this.id,
+      tripId: tripId ?? this.tripId,
+      groupId: groupId ?? this.groupId,
+      name: resolveCopyWithValue<String>(name, this.name, 'name'),
+      latitude: latitude ?? this.latitude,
+      longitude: longitude ?? this.longitude,
+    );
+  }
+
+  @override
+  List<Object?> get props => [id, tripId, groupId, name, latitude, longitude];
+}

--- a/lib/application/dtos/trip/location_dto.dart
+++ b/lib/application/dtos/trip/location_dto.dart
@@ -19,10 +19,8 @@ class LocationDto extends Equatable {
   final double latitude;
   final double longitude;
 
-  Coordinate get coordinate => Coordinate(
-    latitude: latitude,
-    longitude: longitude,
-  );
+  Coordinate get coordinate =>
+      Coordinate(latitude: latitude, longitude: longitude);
 
   LocationDto copyWith({
     String? id,

--- a/lib/application/mappers/trip/itinerary_item_mapper.dart
+++ b/lib/application/mappers/trip/itinerary_item_mapper.dart
@@ -10,6 +10,7 @@ class ItineraryItemMapper {
       startDateTime: dto.startDateTime,
       endDateTime: dto.endDateTime,
       memo: dto.memo,
+      locationId: dto.locationId,
     );
   }
 

--- a/lib/application/mappers/trip/location_mapper.dart
+++ b/lib/application/mappers/trip/location_mapper.dart
@@ -1,0 +1,34 @@
+import 'package:memora/application/dtos/trip/location_dto.dart';
+import 'package:memora/domain/entities/trip/location.dart';
+
+class LocationMapper {
+  static Location toEntity(LocationDto dto) {
+    return Location(
+      id: dto.id,
+      tripId: dto.tripId,
+      groupId: dto.groupId,
+      name: dto.name,
+      latitude: dto.latitude,
+      longitude: dto.longitude,
+    );
+  }
+
+  static LocationDto toDto(Location entity) {
+    return LocationDto(
+      id: entity.id,
+      tripId: entity.tripId,
+      groupId: entity.groupId,
+      name: entity.name,
+      latitude: entity.latitude,
+      longitude: entity.longitude,
+    );
+  }
+
+  static List<Location> toEntityList(List<LocationDto> dtos) {
+    return dtos.map(toEntity).toList();
+  }
+
+  static List<LocationDto> toDtoList(List<Location> entities) {
+    return entities.map(toDto).toList();
+  }
+}

--- a/lib/application/queries/trip/location_query_service.dart
+++ b/lib/application/queries/trip/location_query_service.dart
@@ -1,0 +1,6 @@
+import 'package:memora/application/dtos/trip/location_dto.dart';
+
+abstract class LocationQueryService {
+  Future<List<LocationDto>> getLocationsByTripId(String tripId);
+  Future<List<LocationDto>> getLocationsByGroupId(String groupId);
+}

--- a/lib/application/usecases/trip/delete_location_usecase.dart
+++ b/lib/application/usecases/trip/delete_location_usecase.dart
@@ -1,0 +1,17 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:memora/domain/repositories/trip/location_repository.dart';
+import 'package:memora/infrastructure/factories/repository_factory.dart';
+
+final deleteLocationUsecaseProvider = Provider<DeleteLocationUsecase>((ref) {
+  return DeleteLocationUsecase(ref.watch(locationRepositoryProvider));
+});
+
+class DeleteLocationUsecase {
+  DeleteLocationUsecase(this._locationRepository);
+
+  final LocationRepository _locationRepository;
+
+  Future<void> execute(String locationId) async {
+    await _locationRepository.deleteLocation(locationId);
+  }
+}

--- a/lib/application/usecases/trip/get_locations_by_group_id_usecase.dart
+++ b/lib/application/usecases/trip/get_locations_by_group_id_usecase.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:memora/application/dtos/trip/location_dto.dart';
+import 'package:memora/application/queries/trip/location_query_service.dart';
+import 'package:memora/infrastructure/factories/query_service_factory.dart';
+
+final getLocationsByGroupIdUsecaseProvider =
+    Provider<GetLocationsByGroupIdUsecase>((ref) {
+      return GetLocationsByGroupIdUsecase(
+        ref.watch(locationQueryServiceProvider),
+      );
+    });
+
+class GetLocationsByGroupIdUsecase {
+  GetLocationsByGroupIdUsecase(this._locationQueryService);
+
+  final LocationQueryService _locationQueryService;
+
+  Future<List<LocationDto>> execute(String groupId) async {
+    return _locationQueryService.getLocationsByGroupId(groupId);
+  }
+}

--- a/lib/application/usecases/trip/get_locations_by_trip_id_usecase.dart
+++ b/lib/application/usecases/trip/get_locations_by_trip_id_usecase.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:memora/application/dtos/trip/location_dto.dart';
+import 'package:memora/application/queries/trip/location_query_service.dart';
+import 'package:memora/infrastructure/factories/query_service_factory.dart';
+
+final getLocationsByTripIdUsecaseProvider =
+    Provider<GetLocationsByTripIdUsecase>((ref) {
+      return GetLocationsByTripIdUsecase(
+        ref.watch(locationQueryServiceProvider),
+      );
+    });
+
+class GetLocationsByTripIdUsecase {
+  GetLocationsByTripIdUsecase(this._locationQueryService);
+
+  final LocationQueryService _locationQueryService;
+
+  Future<List<LocationDto>> execute(String tripId) async {
+    return _locationQueryService.getLocationsByTripId(tripId);
+  }
+}

--- a/lib/application/usecases/trip/save_location_usecase.dart
+++ b/lib/application/usecases/trip/save_location_usecase.dart
@@ -1,0 +1,19 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:memora/application/dtos/trip/location_dto.dart';
+import 'package:memora/application/mappers/trip/location_mapper.dart';
+import 'package:memora/domain/repositories/trip/location_repository.dart';
+import 'package:memora/infrastructure/factories/repository_factory.dart';
+
+final saveLocationUsecaseProvider = Provider<SaveLocationUsecase>((ref) {
+  return SaveLocationUsecase(ref.watch(locationRepositoryProvider));
+});
+
+class SaveLocationUsecase {
+  SaveLocationUsecase(this._locationRepository);
+
+  final LocationRepository _locationRepository;
+
+  Future<void> execute(LocationDto location) async {
+    await _locationRepository.saveLocation(LocationMapper.toEntity(location));
+  }
+}

--- a/lib/application/usecases/trip/update_location_usecase.dart
+++ b/lib/application/usecases/trip/update_location_usecase.dart
@@ -1,0 +1,19 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:memora/application/dtos/trip/location_dto.dart';
+import 'package:memora/application/mappers/trip/location_mapper.dart';
+import 'package:memora/domain/repositories/trip/location_repository.dart';
+import 'package:memora/infrastructure/factories/repository_factory.dart';
+
+final updateLocationUsecaseProvider = Provider<UpdateLocationUsecase>((ref) {
+  return UpdateLocationUsecase(ref.watch(locationRepositoryProvider));
+});
+
+class UpdateLocationUsecase {
+  UpdateLocationUsecase(this._locationRepository);
+
+  final LocationRepository _locationRepository;
+
+  Future<void> execute(LocationDto location) async {
+    await _locationRepository.updateLocation(LocationMapper.toEntity(location));
+  }
+}

--- a/lib/domain/entities/trip/itinerary_item.dart
+++ b/lib/domain/entities/trip/itinerary_item.dart
@@ -9,6 +9,7 @@ class ItineraryItem extends Equatable {
     this.startDateTime,
     this.endDateTime,
     this.memo,
+    this.locationId,
   }) {
     _validate();
   }
@@ -19,6 +20,7 @@ class ItineraryItem extends Equatable {
   final DateTime? startDateTime;
   final DateTime? endDateTime;
   final String? memo;
+  final String? locationId;
 
   ItineraryItem copyWith({
     String? id,
@@ -27,6 +29,7 @@ class ItineraryItem extends Equatable {
     DateTime? startDateTime,
     DateTime? endDateTime,
     String? memo,
+    String? locationId,
   }) {
     return ItineraryItem(
       id: id ?? this.id,
@@ -35,6 +38,7 @@ class ItineraryItem extends Equatable {
       startDateTime: startDateTime ?? this.startDateTime,
       endDateTime: endDateTime ?? this.endDateTime,
       memo: memo ?? this.memo,
+      locationId: locationId ?? this.locationId,
     );
   }
 
@@ -57,5 +61,6 @@ class ItineraryItem extends Equatable {
     startDateTime,
     endDateTime,
     memo,
+    locationId,
   ];
 }

--- a/lib/domain/entities/trip/location.dart
+++ b/lib/domain/entities/trip/location.dart
@@ -1,0 +1,51 @@
+import 'package:equatable/equatable.dart';
+import 'package:memora/domain/exceptions/validation_exception.dart';
+
+class Location extends Equatable {
+  Location({
+    required this.id,
+    required this.tripId,
+    required this.groupId,
+    required this.latitude,
+    required this.longitude,
+    this.name,
+  }) {
+    _validate();
+  }
+
+  final String id;
+  final String tripId;
+  final String groupId;
+  final String? name;
+  final double latitude;
+  final double longitude;
+
+  Location copyWith({
+    String? id,
+    String? tripId,
+    String? groupId,
+    Object? name = _copyWithPlaceholder,
+    double? latitude,
+    double? longitude,
+  }) {
+    return Location(
+      id: id ?? this.id,
+      tripId: tripId ?? this.tripId,
+      groupId: groupId ?? this.groupId,
+      name: identical(name, _copyWithPlaceholder) ? this.name : name as String?,
+      latitude: latitude ?? this.latitude,
+      longitude: longitude ?? this.longitude,
+    );
+  }
+
+  void _validate() {
+    if (!latitude.isFinite || !longitude.isFinite) {
+      throw ValidationException('緯度と経度は有効な数値でなければなりません');
+    }
+  }
+
+  @override
+  List<Object?> get props => [id, tripId, groupId, name, latitude, longitude];
+}
+
+const Object _copyWithPlaceholder = Object();

--- a/lib/domain/repositories/trip/location_repository.dart
+++ b/lib/domain/repositories/trip/location_repository.dart
@@ -1,0 +1,6 @@
+import 'package:memora/domain/entities/trip/location.dart';
+
+abstract class LocationRepository {
+  Future<void> saveLocation(Location location);
+  Future<void> deleteLocation(String locationId);
+}

--- a/lib/domain/repositories/trip/location_repository.dart
+++ b/lib/domain/repositories/trip/location_repository.dart
@@ -2,5 +2,6 @@ import 'package:memora/domain/entities/trip/location.dart';
 
 abstract class LocationRepository {
   Future<void> saveLocation(Location location);
+  Future<void> updateLocation(Location location);
   Future<void> deleteLocation(String locationId);
 }

--- a/lib/infrastructure/factories/query_service_factory.dart
+++ b/lib/infrastructure/factories/query_service_factory.dart
@@ -9,6 +9,7 @@ import 'package:memora/application/queries/member/member_event_query_service.dar
 import 'package:memora/application/queries/member/member_invitation_query_service.dart';
 import 'package:memora/application/queries/member/member_query_service.dart';
 import 'package:memora/application/queries/trip/itinerary_item_query_service.dart';
+import 'package:memora/application/queries/trip/location_query_service.dart';
 import 'package:memora/application/queries/trip/pin_query_service.dart';
 import 'package:memora/application/queries/trip/task_query_service.dart';
 import 'package:memora/application/queries/trip/trip_entry_query_service.dart';
@@ -24,6 +25,7 @@ import 'package:memora/infrastructure/queries/member/firestore_member_event_quer
 import 'package:memora/infrastructure/queries/member/firestore_member_invitation_query_service.dart';
 import 'package:memora/infrastructure/queries/member/firestore_member_query_service.dart';
 import 'package:memora/infrastructure/queries/trip/firestore_itinerary_item_query_service.dart';
+import 'package:memora/infrastructure/queries/trip/firestore_location_query_service.dart';
 import 'package:memora/infrastructure/queries/trip/firestore_pin_query_service.dart';
 import 'package:memora/infrastructure/queries/trip/firestore_task_query_service.dart';
 import 'package:memora/infrastructure/queries/trip/firestore_trip_entry_query_service.dart';
@@ -56,6 +58,10 @@ final itineraryItemQueryServiceProvider = Provider<ItineraryItemQueryService>((
   ref,
 ) {
   return QueryServiceFactory.create<ItineraryItemQueryService>(ref: ref);
+});
+
+final locationQueryServiceProvider = Provider<LocationQueryService>((ref) {
+  return QueryServiceFactory.create<LocationQueryService>(ref: ref);
 });
 
 final memberQueryServiceProvider = Provider<MemberQueryService>((ref) {
@@ -128,6 +134,12 @@ class QueryServiceFactory {
     }
     if (T == ItineraryItemQueryService) {
       return FirestoreItineraryItemQueryService(
+            firestore: ref.watch(firebaseFirestoreProvider),
+          )
+          as T;
+    }
+    if (T == LocationQueryService) {
+      return FirestoreLocationQueryService(
             firestore: ref.watch(firebaseFirestoreProvider),
           )
           as T;

--- a/lib/infrastructure/factories/repository_factory.dart
+++ b/lib/infrastructure/factories/repository_factory.dart
@@ -8,6 +8,7 @@ import 'package:memora/domain/repositories/member/member_event_repository.dart';
 import 'package:memora/domain/repositories/member/member_invitation_repository.dart';
 import 'package:memora/domain/repositories/member/member_repository.dart';
 import 'package:memora/domain/repositories/trip/trip_entry_repository.dart';
+import 'package:memora/domain/repositories/trip/location_repository.dart';
 import 'package:memora/infrastructure/config/database_type.dart';
 import 'package:memora/infrastructure/config/database_type_provider.dart';
 import 'package:memora/infrastructure/repositories/dvc/firestore_dvc_limited_point_repository.dart';
@@ -19,6 +20,7 @@ import 'package:memora/infrastructure/repositories/member/firestore_member_event
 import 'package:memora/infrastructure/repositories/member/firestore_member_invitation_repository.dart';
 import 'package:memora/infrastructure/repositories/member/firestore_member_repository.dart';
 import 'package:memora/infrastructure/repositories/trip/firestore_trip_entry_repository.dart';
+import 'package:memora/infrastructure/repositories/trip/firestore_location_repository.dart';
 
 final groupRepositoryProvider = Provider<GroupRepository>((ref) {
   return RepositoryFactory.create<GroupRepository>(ref: ref);
@@ -44,6 +46,10 @@ final memberInvitationRepositoryProvider = Provider<MemberInvitationRepository>(
 
 final tripEntryRepositoryProvider = Provider<TripEntryRepository>((ref) {
   return RepositoryFactory.create<TripEntryRepository>(ref: ref);
+});
+
+final locationRepositoryProvider = Provider<LocationRepository>((ref) {
+  return RepositoryFactory.create<LocationRepository>(ref: ref);
 });
 
 final dvcPointContractRepositoryProvider = Provider<DvcPointContractRepository>(
@@ -99,6 +105,9 @@ class RepositoryFactory {
     }
     if (T == TripEntryRepository) {
       return FirestoreTripEntryRepository() as T;
+    }
+    if (T == LocationRepository) {
+      return FirestoreLocationRepository() as T;
     }
     if (T == DvcPointContractRepository) {
       return FirestoreDvcPointContractRepository() as T;

--- a/lib/infrastructure/mappers/trip/firestore_itinerary_item_mapper.dart
+++ b/lib/infrastructure/mappers/trip/firestore_itinerary_item_mapper.dart
@@ -1,13 +1,15 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:memora/application/dtos/trip/itinerary_item_dto.dart';
+import 'package:memora/application/dtos/trip/location_dto.dart';
 import 'package:memora/domain/entities/trip/itinerary_item.dart';
 import 'package:memora/infrastructure/mappers/firestore_mapper_value_parser.dart';
 import 'package:memora/infrastructure/mappers/firestore_write_metadata.dart';
 
 class FirestoreItineraryItemMapper {
   static ItineraryItemDto fromFirestore(
-    DocumentSnapshot<Map<String, dynamic>> doc,
-  ) {
+    DocumentSnapshot<Map<String, dynamic>> doc, {
+    LocationDto? location,
+  }) {
     final data = doc.data() ?? {};
     return ItineraryItemDto(
       id: doc.id,
@@ -18,6 +20,8 @@ class FirestoreItineraryItemMapper {
       ),
       endDateTime: FirestoreMapperValueParser.asDateTime(data['endDateTime']),
       memo: data['memo'] as String?,
+      locationId: data['locationId'] as String?,
+      location: location,
     );
   }
 
@@ -26,6 +30,7 @@ class FirestoreItineraryItemMapper {
       'tripId': item.tripId,
       'name': item.name,
       'memo': item.memo,
+      'locationId': item.locationId,
       ...FirestoreWriteMetadata.forCreate(),
     };
 

--- a/lib/infrastructure/mappers/trip/firestore_location_mapper.dart
+++ b/lib/infrastructure/mappers/trip/firestore_location_mapper.dart
@@ -1,0 +1,56 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:memora/application/dtos/trip/location_dto.dart';
+import 'package:memora/domain/entities/trip/location.dart';
+import 'package:memora/infrastructure/mappers/firestore_write_metadata.dart';
+
+class FirestoreLocationMapper {
+  static LocationDto fromFirestore(DocumentSnapshot<Map<String, dynamic>> doc) {
+    final data = doc.data() ?? {};
+    return LocationDto(
+      id: doc.id,
+      tripId: _requiredString(data, 'tripId'),
+      groupId: _requiredString(data, 'groupId'),
+      name: data['name'] as String?,
+      latitude: _requiredDouble(data, 'latitude'),
+      longitude: _requiredDouble(data, 'longitude'),
+    );
+  }
+
+  static Map<String, dynamic> toCreateFirestore(Location location) {
+    return {
+      'tripId': location.tripId,
+      'groupId': location.groupId,
+      'name': location.name,
+      'latitude': location.latitude,
+      'longitude': location.longitude,
+      ...FirestoreWriteMetadata.forCreate(),
+    };
+  }
+
+  static Map<String, dynamic> toUpdateFirestore(Location location) {
+    return {
+      'tripId': location.tripId,
+      'groupId': location.groupId,
+      'name': location.name,
+      'latitude': location.latitude,
+      'longitude': location.longitude,
+      ...FirestoreWriteMetadata.forUpdate(),
+    };
+  }
+
+  static String _requiredString(Map<String, dynamic> data, String field) {
+    final value = data[field];
+    if (value is String) {
+      return value;
+    }
+    throw FormatException('locations.$field は文字列である必要があります');
+  }
+
+  static double _requiredDouble(Map<String, dynamic> data, String field) {
+    final value = data[field];
+    if (value is num) {
+      return value.toDouble();
+    }
+    throw FormatException('locations.$field は数値である必要があります');
+  }
+}

--- a/lib/infrastructure/queries/trip/firestore_itinerary_item_query_service.dart
+++ b/lib/infrastructure/queries/trip/firestore_itinerary_item_query_service.dart
@@ -1,9 +1,11 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:memora/application/dtos/trip/location_dto.dart';
 import 'package:memora/application/dtos/trip/itinerary_item_dto.dart';
 import 'package:memora/application/queries/order_by.dart';
 import 'package:memora/application/queries/trip/itinerary_item_query_service.dart';
 import 'package:memora/core/app_logger.dart';
 import 'package:memora/infrastructure/mappers/trip/firestore_itinerary_item_mapper.dart';
+import 'package:memora/infrastructure/mappers/trip/firestore_location_mapper.dart';
 
 class FirestoreItineraryItemQueryService implements ItineraryItemQueryService {
   FirestoreItineraryItemQueryService({FirebaseFirestore? firestore})
@@ -28,9 +30,14 @@ class FirestoreItineraryItemQueryService implements ItineraryItemQueryService {
       }
 
       final snapshot = await query.get();
-      return snapshot.docs
-          .map(FirestoreItineraryItemMapper.fromFirestore)
-          .toList();
+      final items = <ItineraryItemDto>[];
+      for (final doc in snapshot.docs) {
+        final location = await _getLocation(doc.data()['locationId']);
+        items.add(
+          FirestoreItineraryItemMapper.fromFirestore(doc, location: location),
+        );
+      }
+      return items;
     } catch (e, stack) {
       logger.e(
         'FirestoreItineraryItemQueryService.getItineraryItemsByTripId: ${e.toString()}',
@@ -39,5 +46,20 @@ class FirestoreItineraryItemQueryService implements ItineraryItemQueryService {
       );
       return [];
     }
+  }
+
+  Future<LocationDto?> _getLocation(dynamic locationId) async {
+    if (locationId is! String || locationId.isEmpty) {
+      return null;
+    }
+
+    final locationDoc = await _firestore
+        .collection('locations')
+        .doc(locationId)
+        .get();
+    if (!locationDoc.exists) {
+      return null;
+    }
+    return FirestoreLocationMapper.fromFirestore(locationDoc);
   }
 }

--- a/lib/infrastructure/queries/trip/firestore_location_query_service.dart
+++ b/lib/infrastructure/queries/trip/firestore_location_query_service.dart
@@ -1,0 +1,42 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:memora/application/dtos/trip/location_dto.dart';
+import 'package:memora/application/queries/trip/location_query_service.dart';
+import 'package:memora/core/app_logger.dart';
+import 'package:memora/infrastructure/mappers/trip/firestore_location_mapper.dart';
+
+class FirestoreLocationQueryService implements LocationQueryService {
+  FirestoreLocationQueryService({FirebaseFirestore? firestore})
+    : _firestore = firestore ?? FirebaseFirestore.instance;
+
+  final FirebaseFirestore _firestore;
+
+  @override
+  Future<List<LocationDto>> getLocationsByTripId(String tripId) async {
+    return _getLocationsByField('tripId', tripId);
+  }
+
+  @override
+  Future<List<LocationDto>> getLocationsByGroupId(String groupId) async {
+    return _getLocationsByField('groupId', groupId);
+  }
+
+  Future<List<LocationDto>> _getLocationsByField(
+    String field,
+    String value,
+  ) async {
+    try {
+      final snapshot = await _firestore
+          .collection('locations')
+          .where(field, isEqualTo: value)
+          .get();
+      return snapshot.docs.map(FirestoreLocationMapper.fromFirestore).toList();
+    } catch (e, stack) {
+      logger.e(
+        'FirestoreLocationQueryService._getLocationsByField: ${e.toString()}',
+        error: e,
+        stackTrace: stack,
+      );
+      return [];
+    }
+  }
+}

--- a/lib/infrastructure/repositories/trip/firestore_location_repository.dart
+++ b/lib/infrastructure/repositories/trip/firestore_location_repository.dart
@@ -11,15 +11,17 @@ class FirestoreLocationRepository implements LocationRepository {
 
   @override
   Future<void> saveLocation(Location location) async {
-    final collection = _firestore.collection('locations');
-    if (location.id.isEmpty) {
-      await collection.add(FirestoreLocationMapper.toCreateFirestore(location));
-      return;
-    }
+    await _firestore
+        .collection('locations')
+        .add(FirestoreLocationMapper.toCreateFirestore(location));
+  }
 
-    await collection
+  @override
+  Future<void> updateLocation(Location location) async {
+    await _firestore
+        .collection('locations')
         .doc(location.id)
-        .set(FirestoreLocationMapper.toUpdateFirestore(location));
+        .update(FirestoreLocationMapper.toUpdateFirestore(location));
   }
 
   @override

--- a/lib/infrastructure/repositories/trip/firestore_location_repository.dart
+++ b/lib/infrastructure/repositories/trip/firestore_location_repository.dart
@@ -1,0 +1,40 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:memora/domain/entities/trip/location.dart';
+import 'package:memora/domain/repositories/trip/location_repository.dart';
+import 'package:memora/infrastructure/mappers/trip/firestore_location_mapper.dart';
+
+class FirestoreLocationRepository implements LocationRepository {
+  FirestoreLocationRepository({FirebaseFirestore? firestore})
+    : _firestore = firestore ?? FirebaseFirestore.instance;
+
+  final FirebaseFirestore _firestore;
+
+  @override
+  Future<void> saveLocation(Location location) async {
+    final collection = _firestore.collection('locations');
+    if (location.id.isEmpty) {
+      await collection.add(FirestoreLocationMapper.toCreateFirestore(location));
+      return;
+    }
+
+    await collection
+        .doc(location.id)
+        .set(FirestoreLocationMapper.toUpdateFirestore(location));
+  }
+
+  @override
+  Future<void> deleteLocation(String locationId) async {
+    final batch = _firestore.batch();
+    final itineraryItemsSnapshot = await _firestore
+        .collection('itinerary_items')
+        .where('locationId', isEqualTo: locationId)
+        .get();
+
+    for (final doc in itineraryItemsSnapshot.docs) {
+      batch.update(doc.reference, {'locationId': null});
+    }
+
+    batch.delete(_firestore.collection('locations').doc(locationId));
+    await batch.commit();
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';

--- a/test/unit/application/dtos/trip/itinerary_item_dto_test.dart
+++ b/test/unit/application/dtos/trip/itinerary_item_dto_test.dart
@@ -3,6 +3,17 @@ import 'package:memora/application/dtos/trip/itinerary_item_dto.dart';
 
 void main() {
   group('ItineraryItemDto', () {
+    test('locationIdを保持できる', () {
+      const dto = ItineraryItemDto(
+        id: 'item-1',
+        tripId: 'trip-1',
+        name: '昼食',
+        locationId: 'location-1',
+      );
+
+      expect(dto.locationId, 'location-1');
+    });
+
     test('全パラメータでコンストラクタが正しく動作する', () {
       final dto = ItineraryItemDto(
         id: 'item001',

--- a/test/unit/application/dtos/trip/location_dto_test.dart
+++ b/test/unit/application/dtos/trip/location_dto_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memora/application/dtos/trip/location_dto.dart';
+
+void main() {
+  group('LocationDto', () {
+    test('場所情報を保持できる', () {
+      const dto = LocationDto(
+        id: 'location-1',
+        tripId: 'trip-1',
+        groupId: 'group-1',
+        name: '東京駅',
+        latitude: 35.681236,
+        longitude: 139.767125,
+      );
+
+      expect(dto.id, 'location-1');
+      expect(dto.tripId, 'trip-1');
+      expect(dto.groupId, 'group-1');
+      expect(dto.name, '東京駅');
+      expect(dto.latitude, 35.681236);
+      expect(dto.longitude, 139.767125);
+    });
+
+    test('copyWithでnameをnullに更新できる', () {
+      const dto = LocationDto(
+        id: 'location-1',
+        tripId: 'trip-1',
+        groupId: 'group-1',
+        name: '東京駅',
+        latitude: 35.681236,
+        longitude: 139.767125,
+      );
+
+      final copied = dto.copyWith(name: null);
+
+      expect(copied.name, isNull);
+      expect(copied.id, dto.id);
+    });
+  });
+}

--- a/test/unit/application/mappers/trip/location_mapper_test.dart
+++ b/test/unit/application/mappers/trip/location_mapper_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memora/application/dtos/trip/location_dto.dart';
+import 'package:memora/application/mappers/trip/location_mapper.dart';
+import 'package:memora/domain/entities/trip/location.dart';
+
+void main() {
+  group('LocationMapper', () {
+    test('DTOからエンティティへ変換できる', () {
+      const dto = LocationDto(
+        id: 'location-1',
+        tripId: 'trip-1',
+        groupId: 'group-1',
+        name: '東京駅',
+        latitude: 35.681236,
+        longitude: 139.767125,
+      );
+
+      final entity = LocationMapper.toEntity(dto);
+
+      expect(entity, isA<Location>());
+      expect(entity.id, dto.id);
+      expect(entity.tripId, dto.tripId);
+      expect(entity.groupId, dto.groupId);
+      expect(entity.name, dto.name);
+      expect(entity.latitude, dto.latitude);
+      expect(entity.longitude, dto.longitude);
+    });
+
+    test('エンティティからDTOへ変換できる', () {
+      final entity = Location(
+        id: 'location-1',
+        tripId: 'trip-1',
+        groupId: 'group-1',
+        name: '東京駅',
+        latitude: 35.681236,
+        longitude: 139.767125,
+      );
+
+      final dto = LocationMapper.toDto(entity);
+
+      expect(dto, isA<LocationDto>());
+      expect(dto.id, entity.id);
+      expect(dto.tripId, entity.tripId);
+      expect(dto.groupId, entity.groupId);
+      expect(dto.name, entity.name);
+      expect(dto.latitude, entity.latitude);
+      expect(dto.longitude, entity.longitude);
+    });
+  });
+}

--- a/test/unit/application/usecases/trip/location_usecases_test.dart
+++ b/test/unit/application/usecases/trip/location_usecases_test.dart
@@ -1,0 +1,118 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memora/application/dtos/trip/location_dto.dart';
+import 'package:memora/application/queries/trip/location_query_service.dart';
+import 'package:memora/application/usecases/trip/delete_location_usecase.dart';
+import 'package:memora/application/usecases/trip/get_locations_by_group_id_usecase.dart';
+import 'package:memora/application/usecases/trip/get_locations_by_trip_id_usecase.dart';
+import 'package:memora/application/usecases/trip/save_location_usecase.dart';
+import 'package:memora/domain/entities/trip/location.dart';
+import 'package:memora/domain/repositories/trip/location_repository.dart';
+
+void main() {
+  group('LocationUsecases', () {
+    late _FakeLocationQueryService queryService;
+    late _FakeLocationRepository repository;
+
+    setUp(() {
+      queryService = _FakeLocationQueryService();
+      repository = _FakeLocationRepository();
+    });
+
+    test('旅行IDで場所一覧を取得する', () async {
+      const expected = [
+        LocationDto(
+          id: 'location-1',
+          tripId: 'trip-1',
+          groupId: 'group-1',
+          latitude: 35.0,
+          longitude: 139.0,
+        ),
+      ];
+      queryService.locationsByTripId['trip-1'] = expected;
+
+      final result = await GetLocationsByTripIdUsecase(
+        queryService,
+      ).execute('trip-1');
+
+      expect(result, expected);
+      expect(queryService.requestedTripIds, ['trip-1']);
+    });
+
+    test('グループIDで場所一覧を取得する', () async {
+      const expected = [
+        LocationDto(
+          id: 'location-1',
+          tripId: 'trip-1',
+          groupId: 'group-1',
+          latitude: 35.0,
+          longitude: 139.0,
+        ),
+      ];
+      queryService.locationsByGroupId['group-1'] = expected;
+
+      final result = await GetLocationsByGroupIdUsecase(
+        queryService,
+      ).execute('group-1');
+
+      expect(result, expected);
+      expect(queryService.requestedGroupIds, ['group-1']);
+    });
+
+    test('場所を保存する', () async {
+      const dto = LocationDto(
+        id: 'location-1',
+        tripId: 'trip-1',
+        groupId: 'group-1',
+        name: '東京駅',
+        latitude: 35.681236,
+        longitude: 139.767125,
+      );
+
+      await SaveLocationUsecase(repository).execute(dto);
+
+      expect(repository.savedLocations.single, isA<Location>());
+      expect(repository.savedLocations.single.id, dto.id);
+      expect(repository.savedLocations.single.name, dto.name);
+    });
+
+    test('場所を削除する', () async {
+      await DeleteLocationUsecase(repository).execute('location-1');
+
+      expect(repository.deletedLocationIds, ['location-1']);
+    });
+  });
+}
+
+class _FakeLocationQueryService implements LocationQueryService {
+  final locationsByTripId = <String, List<LocationDto>>{};
+  final locationsByGroupId = <String, List<LocationDto>>{};
+  final requestedTripIds = <String>[];
+  final requestedGroupIds = <String>[];
+
+  @override
+  Future<List<LocationDto>> getLocationsByTripId(String tripId) async {
+    requestedTripIds.add(tripId);
+    return locationsByTripId[tripId] ?? const [];
+  }
+
+  @override
+  Future<List<LocationDto>> getLocationsByGroupId(String groupId) async {
+    requestedGroupIds.add(groupId);
+    return locationsByGroupId[groupId] ?? const [];
+  }
+}
+
+class _FakeLocationRepository implements LocationRepository {
+  final savedLocations = <Location>[];
+  final deletedLocationIds = <String>[];
+
+  @override
+  Future<void> saveLocation(Location location) async {
+    savedLocations.add(location);
+  }
+
+  @override
+  Future<void> deleteLocation(String locationId) async {
+    deletedLocationIds.add(locationId);
+  }
+}

--- a/test/unit/application/usecases/trip/location_usecases_test.dart
+++ b/test/unit/application/usecases/trip/location_usecases_test.dart
@@ -5,6 +5,7 @@ import 'package:memora/application/usecases/trip/delete_location_usecase.dart';
 import 'package:memora/application/usecases/trip/get_locations_by_group_id_usecase.dart';
 import 'package:memora/application/usecases/trip/get_locations_by_trip_id_usecase.dart';
 import 'package:memora/application/usecases/trip/save_location_usecase.dart';
+import 'package:memora/application/usecases/trip/update_location_usecase.dart';
 import 'package:memora/domain/entities/trip/location.dart';
 import 'package:memora/domain/repositories/trip/location_repository.dart';
 
@@ -58,9 +59,9 @@ void main() {
       expect(queryService.requestedGroupIds, ['group-1']);
     });
 
-    test('場所を保存する', () async {
+    test('場所を追加する', () async {
       const dto = LocationDto(
-        id: 'location-1',
+        id: '',
         tripId: 'trip-1',
         groupId: 'group-1',
         name: '東京駅',
@@ -73,6 +74,23 @@ void main() {
       expect(repository.savedLocations.single, isA<Location>());
       expect(repository.savedLocations.single.id, dto.id);
       expect(repository.savedLocations.single.name, dto.name);
+    });
+
+    test('場所を更新する', () async {
+      const dto = LocationDto(
+        id: 'location-1',
+        tripId: 'trip-1',
+        groupId: 'group-1',
+        name: '東京駅',
+        latitude: 35.681236,
+        longitude: 139.767125,
+      );
+
+      await UpdateLocationUsecase(repository).execute(dto);
+
+      expect(repository.updatedLocations.single, isA<Location>());
+      expect(repository.updatedLocations.single.id, dto.id);
+      expect(repository.updatedLocations.single.name, dto.name);
     });
 
     test('場所を削除する', () async {
@@ -104,11 +122,17 @@ class _FakeLocationQueryService implements LocationQueryService {
 
 class _FakeLocationRepository implements LocationRepository {
   final savedLocations = <Location>[];
+  final updatedLocations = <Location>[];
   final deletedLocationIds = <String>[];
 
   @override
   Future<void> saveLocation(Location location) async {
     savedLocations.add(location);
+  }
+
+  @override
+  Future<void> updateLocation(Location location) async {
+    updatedLocations.add(location);
   }
 
   @override

--- a/test/unit/domain/entities/trip/itinerary_item_test.dart
+++ b/test/unit/domain/entities/trip/itinerary_item_test.dart
@@ -4,6 +4,17 @@ import 'package:memora/domain/exceptions/validation_exception.dart';
 
 void main() {
   group('ItineraryItem', () {
+    test('locationIdを保持できる', () {
+      final item = ItineraryItem(
+        id: 'item-1',
+        tripId: 'trip-1',
+        name: '昼食',
+        locationId: 'location-1',
+      );
+
+      expect(item.locationId, 'location-1');
+    });
+
     test('インスタンス生成が正しく行われる', () {
       final item = ItineraryItem(
         id: 'item001',

--- a/test/unit/domain/entities/trip/location_test.dart
+++ b/test/unit/domain/entities/trip/location_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memora/domain/entities/trip/location.dart';
+import 'package:memora/domain/exceptions/validation_exception.dart';
+
+void main() {
+  group('Location', () {
+    test('必須項目を保持できる', () {
+      final location = Location(
+        id: 'location-1',
+        tripId: 'trip-1',
+        groupId: 'group-1',
+        name: '東京駅',
+        latitude: 35.681236,
+        longitude: 139.767125,
+      );
+
+      expect(location.id, 'location-1');
+      expect(location.tripId, 'trip-1');
+      expect(location.groupId, 'group-1');
+      expect(location.name, '東京駅');
+      expect(location.latitude, 35.681236);
+      expect(location.longitude, 139.767125);
+    });
+
+    test('緯度または経度が数値として不正な場合は例外', () {
+      expect(
+        () => Location(
+          id: 'location-1',
+          tripId: 'trip-1',
+          groupId: 'group-1',
+          latitude: double.nan,
+          longitude: 139.767125,
+        ),
+        throwsA(isA<ValidationException>()),
+      );
+
+      expect(
+        () => Location(
+          id: 'location-1',
+          tripId: 'trip-1',
+          groupId: 'group-1',
+          latitude: 35.681236,
+          longitude: double.infinity,
+        ),
+        throwsA(isA<ValidationException>()),
+      );
+    });
+  });
+}

--- a/test/unit/infrastructure/queries/trip/firestore_itinerary_item_query_service_test.dart
+++ b/test/unit/infrastructure/queries/trip/firestore_itinerary_item_query_service_test.dart
@@ -87,8 +87,7 @@ void main() {
           MockCollectionReference<Map<String, dynamic>>();
       final mockLocationReference =
           MockDocumentReference<Map<String, dynamic>>();
-      final mockLocationSnapshot =
-          MockDocumentSnapshot<Map<String, dynamic>>();
+      final mockLocationSnapshot = MockDocumentSnapshot<Map<String, dynamic>>();
 
       when(
         mockItineraryItemsCollection.where('tripId', isEqualTo: tripId),
@@ -96,20 +95,18 @@ void main() {
       when(mockQuery.get()).thenAnswer((_) async => mockSnapshot);
       when(mockSnapshot.docs).thenReturn([mockDoc]);
       when(mockDoc.id).thenReturn('item001');
-      when(mockDoc.data()).thenReturn({
-        'tripId': tripId,
-        'name': '朝食',
-        'locationId': locationId,
-      });
-      when(mockFirestore.collection('locations')).thenReturn(
-        mockLocationsCollection,
-      );
-      when(mockLocationsCollection.doc(locationId)).thenReturn(
-        mockLocationReference,
-      );
-      when(mockLocationReference.get()).thenAnswer(
-        (_) async => mockLocationSnapshot,
-      );
+      when(
+        mockDoc.data(),
+      ).thenReturn({'tripId': tripId, 'name': '朝食', 'locationId': locationId});
+      when(
+        mockFirestore.collection('locations'),
+      ).thenReturn(mockLocationsCollection);
+      when(
+        mockLocationsCollection.doc(locationId),
+      ).thenReturn(mockLocationReference);
+      when(
+        mockLocationReference.get(),
+      ).thenAnswer((_) async => mockLocationSnapshot);
       when(mockLocationSnapshot.exists).thenReturn(true);
       when(mockLocationSnapshot.id).thenReturn(locationId);
       when(mockLocationSnapshot.data()).thenReturn({

--- a/test/unit/infrastructure/queries/trip/firestore_itinerary_item_query_service_test.dart
+++ b/test/unit/infrastructure/queries/trip/firestore_itinerary_item_query_service_test.dart
@@ -15,6 +15,8 @@ import 'firestore_itinerary_item_query_service_test.mocks.dart';
   Query,
   QuerySnapshot,
   QueryDocumentSnapshot,
+  DocumentReference,
+  DocumentSnapshot,
 ])
 void main() {
   group('FirestoreItineraryItemQueryService', () {
@@ -73,6 +75,56 @@ void main() {
       expect(result.first.name, '朝食');
       verify(mockQuery.orderBy('startDateTime', descending: false)).called(1);
       verify(mockQuery.orderBy('endDateTime', descending: false)).called(1);
+    });
+
+    test('locationIdが設定されている旅程項目はlocationを紐付ける', () async {
+      const tripId = 'trip001';
+      const locationId = 'location001';
+      final mockQuery = MockQuery<Map<String, dynamic>>();
+      final mockSnapshot = MockQuerySnapshot<Map<String, dynamic>>();
+      final mockDoc = MockQueryDocumentSnapshot<Map<String, dynamic>>();
+      final mockLocationsCollection =
+          MockCollectionReference<Map<String, dynamic>>();
+      final mockLocationReference =
+          MockDocumentReference<Map<String, dynamic>>();
+      final mockLocationSnapshot =
+          MockDocumentSnapshot<Map<String, dynamic>>();
+
+      when(
+        mockItineraryItemsCollection.where('tripId', isEqualTo: tripId),
+      ).thenReturn(mockQuery);
+      when(mockQuery.get()).thenAnswer((_) async => mockSnapshot);
+      when(mockSnapshot.docs).thenReturn([mockDoc]);
+      when(mockDoc.id).thenReturn('item001');
+      when(mockDoc.data()).thenReturn({
+        'tripId': tripId,
+        'name': '朝食',
+        'locationId': locationId,
+      });
+      when(mockFirestore.collection('locations')).thenReturn(
+        mockLocationsCollection,
+      );
+      when(mockLocationsCollection.doc(locationId)).thenReturn(
+        mockLocationReference,
+      );
+      when(mockLocationReference.get()).thenAnswer(
+        (_) async => mockLocationSnapshot,
+      );
+      when(mockLocationSnapshot.exists).thenReturn(true);
+      when(mockLocationSnapshot.id).thenReturn(locationId);
+      when(mockLocationSnapshot.data()).thenReturn({
+        'tripId': tripId,
+        'groupId': 'group001',
+        'name': 'ホテル',
+        'latitude': 35.0,
+        'longitude': 139.0,
+      });
+
+      final result = await service.getItineraryItemsByTripId(tripId);
+
+      expect(result.single.locationId, locationId);
+      expect(result.single.location?.id, locationId);
+      expect(result.single.location?.name, 'ホテル');
     });
 
     test('取得時に例外が発生した場合は空リストを返す', () async {

--- a/test/unit/infrastructure/repositories/trip/firestore_location_repository_test.dart
+++ b/test/unit/infrastructure/repositories/trip/firestore_location_repository_test.dart
@@ -24,8 +24,7 @@ void main() {
 
     setUp(() {
       mockFirestore = MockFirebaseFirestore();
-      mockLocationsCollection =
-          MockCollectionReference<Map<String, dynamic>>();
+      mockLocationsCollection = MockCollectionReference<Map<String, dynamic>>();
       when(
         mockFirestore.collection('locations'),
       ).thenReturn(mockLocationsCollection);
@@ -43,7 +42,9 @@ void main() {
       );
       final mockDocRef = MockDocumentReference<Map<String, dynamic>>();
 
-      when(mockLocationsCollection.add(any)).thenAnswer((_) async => mockDocRef);
+      when(
+        mockLocationsCollection.add(any),
+      ).thenAnswer((_) async => mockDocRef);
 
       await repository.saveLocation(location);
 

--- a/test/unit/infrastructure/repositories/trip/firestore_location_repository_test.dart
+++ b/test/unit/infrastructure/repositories/trip/firestore_location_repository_test.dart
@@ -1,0 +1,98 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memora/domain/entities/trip/location.dart';
+import 'package:memora/infrastructure/repositories/trip/firestore_location_repository.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+
+@GenerateMocks([
+  FirebaseFirestore,
+  CollectionReference,
+  DocumentReference,
+  Query,
+  QuerySnapshot,
+  QueryDocumentSnapshot,
+  WriteBatch,
+])
+import 'firestore_location_repository_test.mocks.dart';
+
+void main() {
+  group('FirestoreLocationRepository', () {
+    late MockFirebaseFirestore mockFirestore;
+    late MockCollectionReference<Map<String, dynamic>> mockLocationsCollection;
+    late FirestoreLocationRepository repository;
+
+    setUp(() {
+      mockFirestore = MockFirebaseFirestore();
+      mockLocationsCollection =
+          MockCollectionReference<Map<String, dynamic>>();
+      when(
+        mockFirestore.collection('locations'),
+      ).thenReturn(mockLocationsCollection);
+      repository = FirestoreLocationRepository(firestore: mockFirestore);
+    });
+
+    test('saveLocationはlocationsへ新規追加する', () async {
+      final location = Location(
+        id: '',
+        tripId: 'trip-1',
+        groupId: 'group-1',
+        name: '東京駅',
+        latitude: 35.681236,
+        longitude: 139.767125,
+      );
+      final mockDocRef = MockDocumentReference<Map<String, dynamic>>();
+
+      when(mockLocationsCollection.add(any)).thenAnswer((_) async => mockDocRef);
+
+      await repository.saveLocation(location);
+
+      verify(
+        mockLocationsCollection.add(
+          argThat(
+            allOf([
+              containsPair('tripId', 'trip-1'),
+              containsPair('groupId', 'group-1'),
+              containsPair('name', '東京駅'),
+              contains('createdAt'),
+              contains('updatedAt'),
+            ]),
+          ),
+        ),
+      ).called(1);
+      verifyNever(mockLocationsCollection.doc(any));
+    });
+
+    test('updateLocationは既存ドキュメントをupdateしcreatedAtを更新しない', () async {
+      final location = Location(
+        id: 'location-1',
+        tripId: 'trip-1',
+        groupId: 'group-1',
+        name: '東京駅',
+        latitude: 35.681236,
+        longitude: 139.767125,
+      );
+      final mockDocRef = MockDocumentReference<Map<String, dynamic>>();
+
+      when(mockLocationsCollection.doc('location-1')).thenReturn(mockDocRef);
+      when(mockDocRef.update(any)).thenAnswer((_) async {});
+
+      await repository.updateLocation(location);
+
+      verify(
+        mockDocRef.update(
+          argThat(
+            allOf([
+              containsPair('tripId', 'trip-1'),
+              containsPair('groupId', 'group-1'),
+              containsPair('name', '東京駅'),
+              isNot(contains('createdAt')),
+              contains('updatedAt'),
+            ]),
+          ),
+        ),
+      ).called(1);
+      verifyNever(mockDocRef.set(any));
+    });
+  });
+}


### PR DESCRIPTION
## 概要
- locations のドメインエンティティ、DTO、アプリケーションマッパー、Repository/QueryService 契約を追加
- Firestore locations マッパー、リポジトリ、クエリサービス、Factory 配線、取得/保存/削除ユースケースを追加
- itinerary_items に locationId と取得時の location 紐付けを追加
- location 削除時に参照中 itinerary_items.locationId を null に更新

## 完了へ移動した todo
- locationsのドメインエンティティを作成する
- locationsのリポジトリインターフェースを作成する
- locationsのFirestoreマッパーを作成する
- locationsのFirestoreリポジトリを作成する
- locationsのDTOとアプリケーションマッパーを作成する
- locationsのクエリサービスを作成する
- locationsのユースケースを作成する
- itinerary_itemsの`locationId`追加に対応する
- itinerary_itemsのクエリでlocationを紐付けて取得できるようにする
- location削除時に参照中の旅程項目の`locationId`をnullへ更新する

## 検証
- ./check.sh