### PR TITLE
docs: pins廃止todoを追加

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -2,8 +2,24 @@
 
 ## DB設計・リポジトリ・ユースケース・DTO・マッパー関連
 
+- pinsを廃止してlocationsへ統一する
+  - ER図から`pins`テーブルと`trip_entries`/`groups`から`pins`への関連を削除する
+  - `Pin`エンティティ、`PinDto`、`PinMapper`、`FirestorePinMapper`を削除する
+  - `TripEntry`集約、`TripEntryDto`、`TripEntryMapper`から`pins`を削除する
+  - `TripEntry`の訪問開始日時・訪問終了日時に関する`pins`由来の検証を削除し、旅程項目とlocationsの検証に責務を寄せる
+  - `TripEntryQueryService.getTripEntryById`の`pinsOrderBy`引数を削除する
+  - `FirestoreTripEntryQueryService`で`pins`コレクションを取得して`TripEntryDto`へ詰める処理を削除する
+  - `FirestoreTripEntryRepository`で旅行作成・更新・削除時に`pins`コレクションへ保存・削除する処理を削除する
+  - `PinQueryService`、`FirestorePinQueryService`、`GetPinsByMemberIdUsecase`、`pinQueryServiceProvider`を削除する
+  - Firestore上の既存`pins`データの扱いを決める（削除、locationsへの移行、読み捨てのいずれか）
+
 ## マップの表示
 - 地図表示画面で表示するデータをpinsからlocationsに変更する
+  - `GetPinsByMemberIdUsecase`ではなく、所属グループのlocationsを取得するユースケースを使用する
+  - `MapViewBuilder`、`GoogleMapViewBuilder`、`PlaceholderMapViewBuilder`、`GoogleMapView`の入力を`PinDto`から`LocationDto`中心に変更する
+  - 地図上のmarker生成を`pinId`ではなく`location.id`または安定したlocation識別子で行う
+  - 読み取り専用地図で表示するボトムシートを`PinDetailBottomSheet`依存からlocations用の表示へ変更する
+  - 地図表示画面のテストをlocations取得・表示の期待値へ更新し、pins関連のモックを削除する
 
 ## トップ画面
 
@@ -34,6 +50,10 @@
 - 旅行管理画面からpins関連の処理を取り除く（pinsを廃止してlocationsに置き換えるための準備）
   - pins取得・表示・更新に関する状態管理を削除する
   - pins関連のユースケース・DTO・マッパー参照を削除する
+  - `TripEditModal`の`PinDto`ドラフト、ピン追加・更新・削除、`PinDetailBottomSheet`表示を削除する
+  - `TripEditFormView`の`pins`入力、訪問場所一覧、ピン削除ハンドラを削除する
+  - `SelectVisitLocationView`をlocations選択用に作り替えるか、不要であれば削除する
+  - 旅行保存時に`TripEntryDto.pins`へ反映していた処理を削除し、locations保存処理と旅程項目の`locationId`更新に分離する
 - 旅程の編集時に場所を指定できるようにする
   - 場所未指定の場合は「場所を指定」ボタンを表示する
   - 「場所を指定」ボタンタップで`google_map_view`を使った小さいマップ画面を表示する
@@ -52,6 +72,11 @@
 
 ## マップピンボトムシート
 
+- `PinDetailBottomSheet`を廃止する
+  - pinsの`locationName`、`visitStartDateTime`、`visitEndDateTime`、`memo`を編集するUIを削除する
+  - 地図上のlocations表示で必要な情報表示は、locations用の軽量な表示または既存の旅程・旅行詳細導線へ置き換える
+  - `PinDetailBottomSheet`関連テストを削除またはlocations用テストへ置き換える
+
 ## 招待機能
 
 ## グループイベント
@@ -63,6 +88,14 @@
 ## デザイン
 
 ## 全体
+
+- pins廃止に伴う仕様・テストを整理する
+  - ユーザーストーリーの「ピン」表現を、地図上のmarker表現かlocationsによる訪問場所表現に整理する
+  - ユースケース図の「旅行の訪問場所を追加」「訪問場所を地図上に表示」がlocations前提になっていることを明記する
+  - `pin_dto_test`、`pin_mapper_test`、`pin_test`、`firestore_pin_mapper_test`、`firestore_pin_query_service_test`を削除する
+  - `TripEntryDto`、`TripEntry`、`TripEntryMapper`、`FirestoreTripEntryMapper`、`FirestoreTripEntryQueryService`、`FirestoreTripEntryRepository`のテストからpins期待値を削除する
+  - `GoogleMapView`、`MapViewBuilder`、`TripEditModal`、`TripEditFormView`、`TripManagement`、`MapScreen`のテストをlocations前提に更新する
+  - `rg "PinDto|PinQueryService|FirestorePin|pinsOrderBy|collection\\('pins'\\)|PinDetailBottomSheet|pinId"`でpins廃止漏れがないことを確認する
 
 ## リファクタリング
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -11,7 +11,7 @@
   - `FirestoreTripEntryQueryService`で`pins`コレクションを取得して`TripEntryDto`へ詰める処理を削除する
   - `FirestoreTripEntryRepository`で旅行作成・更新・削除時に`pins`コレクションへ保存・削除する処理を削除する
   - `PinQueryService`、`FirestorePinQueryService`、`GetPinsByMemberIdUsecase`、`pinQueryServiceProvider`を削除する
-  - Firestore上の既存`pins`データの扱いを決める（削除、locationsへの移行、読み捨てのいずれか）
+  - Firestore上の既存`pins`データは破棄する想定(手動でやるため対応不要)
 
 ## マップの表示
 - 地図表示画面で表示するデータをpinsからlocationsに変更する
@@ -47,14 +47,14 @@
   - 訪問場所表示を削除する
   - 訪問場所編集ボタンを削除する
   - 訪問場所一覧を削除する
-- 旅行管理画面からpins関連の処理を取り除く（pinsを廃止してlocationsに置き換えるための準備）
+- 旅行管理画面からpins関連の処理を取り除く
   - pins取得・表示・更新に関する状態管理を削除する
   - pins関連のユースケース・DTO・マッパー参照を削除する
   - `TripEditModal`の`PinDto`ドラフト、ピン追加・更新・削除、`PinDetailBottomSheet`表示を削除する
   - `TripEditFormView`の`pins`入力、訪問場所一覧、ピン削除ハンドラを削除する
-  - `SelectVisitLocationView`をlocations選択用に作り替えるか、不要であれば削除する
-  - 旅行保存時に`TripEntryDto.pins`へ反映していた処理を削除し、locations保存処理と旅程項目の`locationId`更新に分離する
-- 旅程の編集時に場所を指定できるようにする
+  - `SelectVisitLocationView`を削除する
+  - 旅行保存時に`TripEntryDto.pins`へ反映していた処理を削除する
+- 旅程の編集時に場所を指定できるようにする(pin廃止後に対応)
   - 場所未指定の場合は「場所を指定」ボタンを表示する
   - 「場所を指定」ボタンタップで`google_map_view`を使った小さいマップ画面を表示する
   - マップ上の長押しで新しいlocationのピンを追加できるようにする
@@ -62,7 +62,7 @@
   - 灰色ピンをタップすると「この場所を指定する」を表示し、タップしたlocationの`locationId`を旅程に設定する
   - その旅程に紐づくlocationのピンだけ赤色で表示する
   - 赤色ピンをタップすると旅程との紐付けを解除できるようにする
-- 旅行編集画面の下部に旅行のlocationsマップを表示する
+- 旅行編集画面の下部に旅行のlocationsマップを表示する(pin廃止後に対応)
   - 旅程ボタンとタスクボタンの下に`google_map_view`を表示する
   - この旅行に紐づくlocationsを赤色ピンで表示する
   - ピンをタップすると紐づく旅程名を表示する
@@ -74,8 +74,8 @@
 
 - `PinDetailBottomSheet`を廃止する
   - pinsの`locationName`、`visitStartDateTime`、`visitEndDateTime`、`memo`を編集するUIを削除する
-  - 地図上のlocations表示で必要な情報表示は、locations用の軽量な表示または既存の旅程・旅行詳細導線へ置き換える
-  - `PinDetailBottomSheet`関連テストを削除またはlocations用テストへ置き換える
+  - 地図上のlocations表示で必要な情報表示は、locations用の軽量な表示へ置き換える
+  - `PinDetailBottomSheet`関連テストを削除する
 
 ## 招待機能
 
@@ -90,8 +90,6 @@
 ## 全体
 
 - pins廃止に伴う仕様・テストを整理する
-  - ユーザーストーリーの「ピン」表現を、地図上のmarker表現かlocationsによる訪問場所表現に整理する
-  - ユースケース図の「旅行の訪問場所を追加」「訪問場所を地図上に表示」がlocations前提になっていることを明記する
   - `pin_dto_test`、`pin_mapper_test`、`pin_test`、`firestore_pin_mapper_test`、`firestore_pin_query_service_test`を削除する
   - `TripEntryDto`、`TripEntry`、`TripEntryMapper`、`FirestoreTripEntryMapper`、`FirestoreTripEntryQueryService`、`FirestoreTripEntryRepository`のテストからpins期待値を削除する
   - `GoogleMapView`、`MapViewBuilder`、`TripEditModal`、`TripEditFormView`、`TripManagement`、`MapScreen`のテストをlocations前提に更新する


### PR DESCRIPTION
## 概要
- pins廃止に向けた影響範囲を整理し、`docs/todo.md`へ廃止用todoを追加
- 既存の地図表示・旅行管理画面の関連todoに、locations移行とpins除去の具体項目を追記
- `PinDetailBottomSheet`廃止、関連テスト、設計資料更新、既存Firestoreデータの扱い決定をtodo化

## 検証
- ドキュメントのみの変更のため `./check.sh` は未実行