### PR TITLE
docs: todoにマップとウィジェット対応を追記

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -37,6 +37,9 @@
   - `tripId`から`GetTripEntryByIdUsecase`で旅行詳細を取得し、取得できた`groupId`と`year`でグループ年表の旅行管理画面へ遷移する
   - `GroupTimelineTripManagementDestination`または`TripManagement`に初期編集対象`tripId`を渡せる口を追加する
   - `TripManagement`は旅行一覧とグループメンバー読み込み後、初期編集対象`tripId`の詳細を取得して`TripEditModal`を一度だけ開く
+  - ウィジェット経由で開いた場合も、編集モーダルの親画面は対象旅行を含む年の旅行管理画面にする
+  - 編集モーダルで保存、キャンセル、または破棄確認後に閉じた場合は、対象年の旅行管理画面に戻る
+  - 旅行管理画面の戻る操作では対象グループの年表画面に戻り、以降は通常の年表ナビゲーションに従う
   - 未ログイン時はログイン後に保留URIを再処理し、対象旅行が取得できない場合はSnackBarで通知して通常のグループ年表へ戻す
   - 同じURIを複数回処理しないよう、処理済み`tripId`またはURIをNotifier側でクリアする
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -22,11 +22,35 @@
 
 ## Androidウィジェット
 
+- Androidウィジェットを1日単位などで定期的に自動更新する
+  - `workmanager`を導入し、Androidの定期バックグラウンドタスクから既存のウィジェットキャッシュ更新ユースケースを呼び出す
+  - アプリ起動時とウィジェット表示対象グループ設定時に、重複しない一意名で定期タスクを登録する
+  - 表示対象グループが未設定の場合は定期タスク内でウィジェット表示のみ更新し、Firestore取得は行わない
+  - 更新時は現在日時を基準に`selectedItineraryDateId`を再選択し、表示位置を当日以降の直近旅程へ移動する
+  - ネットワーク未接続や取得失敗時は既存キャッシュを残し、エラーメッセージだけを保存してウィジェットを更新する
+  - 定期更新の最小間隔はAndroidの制約に合わせ、要件上は1日単位、実装上は`Duration(hours: 24)`を基本にする
+- ウィジェットタップでアプリを開くようにする
+  - Kotlin側の`WidgetItineraryDate`でキャッシュJSONの`tripId`を読み込む
+  - Glanceの旅程ヘッダーまたは旅程表示領域に`actionStartActivity<MainActivity>`を設定し、`memoraWidget://openTrip?tripId=...`形式のURIを渡す
+  - Flutter側で`HomeWidget.initiallyLaunchedFromHomeWidget()`と`HomeWidget.widgetClicked`を購読し、起動時と起動済みの両方でURIを受け取る
+  - 受け取ったURIは専用Notifierに保留し、認証完了と`currentMember`読み込み完了後に処理する
+  - `tripId`から`GetTripEntryByIdUsecase`で旅行詳細を取得し、取得できた`groupId`と`year`でグループ年表の旅行管理画面へ遷移する
+  - `GroupTimelineTripManagementDestination`または`TripManagement`に初期編集対象`tripId`を渡せる口を追加する
+  - `TripManagement`は旅行一覧とグループメンバー読み込み後、初期編集対象`tripId`の詳細を取得して`TripEditModal`を一度だけ開く
+  - 未ログイン時はログイン後に保留URIを再処理し、対象旅行が取得できない場合はSnackBarで通知して通常のグループ年表へ戻す
+  - 同じURIを複数回処理しないよう、処理済み`tripId`またはURIをNotifier側でクリアする
+
 ## グループ年表画面
 
 ## 旅行管理画面
 
 ## マップピンボトムシート
+
+- マップのピンをタップして開くパネルの左右に、前後のピンへ移動するボタンを配置する
+  - ボタンはパネル左右の縦マージン中央に配置する
+  - `<` タップで前のピン、`>` タップで次のピンへ移動する
+  - ピンの並び順は取得時の順番を使用する
+  - 末尾で `>` をタップした場合は先頭へ移動し、先頭で `<` をタップした場合は末尾へ移動する
 
 ## 招待機能
 
@@ -43,3 +67,5 @@
 ## リファクタリング
 
 ## 不具合修正
+
+- 旅程の場所指定時に、新たな場所を指定後、変更を保存せずに旅程編集を閉じると、どの旅程にも紐付かないlocationが削除されずに残る不具合を修正する


### PR DESCRIPTION
## 概要

- マップピンボトムシートで前後のピンへ移動する操作をtodoに追加
- 旅程編集で未保存終了時に孤立locationが残る不具合修正をtodoに追加
- Androidウィジェットの定期自動更新とタップ起動をtodoに追加
- ウィジェットタップで旅行編集画面を開く方針を、現行のRiverpod状態遷移とTripManagementのモーダル構造に合わせて具体化

## 実装方針メモ

- 定期更新は`workmanager`と`home_widget`を組み合わせ、既存のウィジェットキャッシュ更新ユースケースをバックグラウンドから再利用する想定
- ウィジェットタップはGlanceの`actionStartActivity<MainActivity>`で`tripId`付きURIを渡し、Flutter側で`HomeWidget.initiallyLaunchedFromHomeWidget()`と`HomeWidget.widgetClicked`を処理する想定
- 旅行編集画面への遷移は`tripId`から旅行詳細を取得し、`groupId/year`で旅行管理画面へ移動後、`TripManagement`から`TripEditModal`を一度だけ開く方針

## 検証

- ドキュメント更新のみのため`./check.sh`は未実行
- Context7で`home_widget`と`workmanager`の関連APIを確認