### PR TITLE
Androidウィジェットの通知表示をToastへ移行

### DIFF
--- a/android/app/src/main/kotlin/com/example/memora/ItineraryWidget.kt
+++ b/android/app/src/main/kotlin/com/example/memora/ItineraryWidget.kt
@@ -1,7 +1,6 @@
 package com.example.memora
 
 import android.content.Context
-import android.net.Uri
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
@@ -35,7 +34,6 @@ import androidx.glance.text.FontWeight
 import androidx.glance.text.Text
 import androidx.glance.text.TextAlign
 import androidx.glance.text.TextStyle
-import es.antonborri.home_widget.HomeWidgetBackgroundIntent
 import es.antonborri.home_widget.HomeWidgetGlanceState
 import es.antonborri.home_widget.HomeWidgetGlanceStateDefinition
 import java.io.File
@@ -63,7 +61,6 @@ private fun ItineraryWidgetContent(
 ) {
     val prefs = state.preferences
     val targetGroupId = prefs.getString(TARGET_GROUP_ID_KEY, null).orEmpty()
-    val errorMessage = prefs.getString(ERROR_MESSAGE_KEY, null).orEmpty()
     val cache = readCache(prefs.getString(CACHE_FILE_KEY, null))
     val selectedItineraryDateId = prefs.getString(SELECTED_ITINERARY_DATE_ID_KEY, null)
         ?: cache?.selectedItineraryDateId
@@ -86,7 +83,6 @@ private fun ItineraryWidgetContent(
                 selectedItineraryDate == null -> EmptyMessage("表示できる旅程がありません")
                 else -> ItineraryDateContent(selectedItineraryDate)
             }
-            FooterRow(errorMessage)
         }
         HeaderRow(cache?.lastUpdatedAt)
     }
@@ -320,14 +316,6 @@ private fun EmptyMessage(message: String) {
     }
 }
 
-@Composable
-private fun FooterRow(errorMessage: String) {
-    if (errorMessage.isBlank()) {
-        return
-    }
-    Text(text = errorMessage, maxLines = 1, style = TextStyle(fontSize = 10.sp))
-}
-
 class RefreshWidgetAction : ActionCallback {
     override suspend fun onAction(
         context: Context,
@@ -359,9 +347,7 @@ class NextItineraryDateAction : ActionCallback {
 }
 
 private fun sendAction(context: Context, action: String) {
-    HomeWidgetBackgroundIntent
-        .getBroadcast(context, Uri.parse("memoraWidget://$action"))
-        .send()
+    MemoraWidgetActionWorker.enqueue(context, action)
 }
 
 private fun readCache(path: String?): WidgetCache? {
@@ -455,7 +441,6 @@ private sealed interface WidgetItineraryListEntry {
 private const val TARGET_GROUP_ID_KEY = "memora_widget_target_group_id"
 private const val SELECTED_ITINERARY_DATE_ID_KEY =
     "memora_widget_selected_itinerary_date_id"
-private const val ERROR_MESSAGE_KEY = "memora_widget_error_message"
 private const val CACHE_FILE_KEY = "memora_widget_itinerary_cache"
 private const val WIDGET_PADDING_DP = 8
 private const val CONTENT_TOP_SPACE_DP = 10

--- a/android/app/src/main/kotlin/com/example/memora/MemoraWidgetActionWorker.kt
+++ b/android/app/src/main/kotlin/com/example/memora/MemoraWidgetActionWorker.kt
@@ -1,0 +1,232 @@
+package com.example.memora
+
+import android.content.Context
+import android.net.Uri
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import android.widget.Toast
+import androidx.work.CoroutineWorker
+import androidx.work.Data
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import es.antonborri.home_widget.HomeWidgetPlugin
+import io.flutter.FlutterInjector
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.embedding.engine.dart.DartExecutor
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import io.flutter.view.FlutterCallbackInformation
+import java.util.ArrayDeque
+import java.util.UUID
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import org.json.JSONObject
+
+class MemoraWidgetActionWorker(
+    private val context: Context,
+    workerParams: WorkerParameters,
+) : CoroutineWorker(context, workerParams), MethodChannel.MethodCallHandler {
+    private lateinit var channel: MethodChannel
+
+    override suspend fun doWork(): Result {
+        val action = inputData.getString(ACTION_KEY).orEmpty()
+        val actionId = inputData.getString(ACTION_ID_KEY).orEmpty()
+        val uri = inputData.getString(URI_KEY).orEmpty()
+
+        val callbackCompleted = runCatching {
+            ensureFlutterEngine()
+            engine?.let {
+                channel = MethodChannel(it.dartExecutor.binaryMessenger, CHANNEL_NAME)
+                channel.setMethodCallHandler(this)
+            }
+            invokeDartCallback(listOf(HomeWidgetPlugin.getHandle(context), uri))
+        }.getOrElse { error ->
+            Log.e(TAG, "Failed to run widget action", error)
+            false
+        }
+
+        val message = readToastMessage(context, actionId)
+            ?: fallbackFailureMessage(action)
+        clearActionResult(context, actionId)
+        if (message.isNotBlank()) {
+            showToast(context, message)
+        }
+
+        return if (callbackCompleted) Result.success() else Result.failure()
+    }
+
+    private suspend fun ensureFlutterEngine() {
+        if (engine != null) {
+            return
+        }
+
+        val callbackHandle = HomeWidgetPlugin.getDispatcherHandle(context)
+        if (callbackHandle == 0L) {
+            throw IllegalStateException(
+                "No callbackHandle saved. Did you call HomeWidget.registerInteractivityCallback?",
+            )
+        }
+
+        val callbackInfo = FlutterCallbackInformation
+            .lookupCallbackInformation(callbackHandle)
+            ?: throw IllegalStateException("Failed to lookup callback information")
+
+        withContext(Dispatchers.Main) {
+            engine = FlutterEngine(context)
+            val callback = DartExecutor.DartCallback(
+                context.assets,
+                FlutterInjector.instance().flutterLoader().findAppBundlePath(),
+                callbackInfo,
+            )
+            engine?.dartExecutor?.executeDartCallback(callback)
+        }
+    }
+
+    private suspend fun invokeDartCallback(args: List<Any>): Boolean {
+        val completed = CompletableDeferred<Boolean>()
+        synchronized(queueLock) {
+            if (!serviceStarted) {
+                queue.add(PendingInvocation(args, completed))
+            } else {
+                postInvocation(args, completed)
+            }
+        }
+        return withTimeoutOrNull(CALLBACK_TIMEOUT_MILLIS) {
+            completed.await()
+        } == true
+    }
+
+    override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
+        when (call.method) {
+            "HomeWidget.backgroundInitialized" -> {
+                handleBackgroundInitialized()
+                result.success(null)
+            }
+            else -> result.notImplemented()
+        }
+    }
+
+    private fun handleBackgroundInitialized() {
+        synchronized(queueLock) {
+            while (queue.isNotEmpty()) {
+                val invocation = queue.remove()
+                postInvocation(invocation.args, invocation.completed)
+            }
+            serviceStarted = true
+        }
+    }
+
+    private fun postInvocation(
+        args: List<Any>,
+        completed: CompletableDeferred<Boolean>,
+    ) {
+        mainHandler.post {
+            channel.invokeMethod(
+                "",
+                args,
+                object : MethodChannel.Result {
+                    override fun success(result: Any?) {
+                        completed.complete(true)
+                    }
+
+                    override fun error(
+                        errorCode: String,
+                        errorMessage: String?,
+                        errorDetails: Any?,
+                    ) {
+                        completed.complete(false)
+                    }
+
+                    override fun notImplemented() {
+                        completed.complete(false)
+                    }
+                },
+            )
+        }
+    }
+
+    private data class PendingInvocation(
+        val args: List<Any>,
+        val completed: CompletableDeferred<Boolean>,
+    )
+
+    companion object {
+        private const val TAG = "MemoraWidgetWorker"
+        private const val ACTION_KEY = "action"
+        private const val ACTION_ID_KEY = "action_id"
+        private const val URI_KEY = "uri"
+        private const val CHANNEL_NAME = "home_widget/background"
+        private const val UNIQUE_WORK_NAME = "memora_widget_action"
+        private const val CALLBACK_TIMEOUT_MILLIS = 60000L
+        private const val ACTION_RESULT_KEY_PREFIX = "memora_widget_action_result_"
+
+        @Volatile private var engine: FlutterEngine? = null
+        private val queue = ArrayDeque<PendingInvocation>()
+        private val queueLock = Any()
+        private var serviceStarted = false
+        private val mainHandler = Handler(Looper.getMainLooper())
+
+        fun enqueue(context: Context, action: String) {
+            val actionId = UUID.randomUUID().toString()
+            val uri = Uri.parse("memoraWidget://$action?actionId=$actionId").toString()
+            val data = Data.Builder()
+                .putString(ACTION_KEY, action)
+                .putString(ACTION_ID_KEY, actionId)
+                .putString(URI_KEY, uri)
+                .build()
+            val workRequest = OneTimeWorkRequestBuilder<MemoraWidgetActionWorker>()
+                .setInputData(data)
+                .build()
+            WorkManager.getInstance(context).enqueueUniqueWork(
+                UNIQUE_WORK_NAME,
+                ExistingWorkPolicy.APPEND,
+                workRequest,
+            )
+        }
+
+        private fun readToastMessage(context: Context, actionId: String): String? {
+            if (actionId.isBlank()) {
+                return null
+            }
+            val raw = HomeWidgetPlugin.getData(context)
+                .getString("$ACTION_RESULT_KEY_PREFIX$actionId", null)
+                ?: return null
+            return runCatching {
+                JSONObject(raw).optString("message")
+            }.getOrNull()
+        }
+
+        private fun clearActionResult(context: Context, actionId: String) {
+            if (actionId.isBlank()) {
+                return
+            }
+            HomeWidgetPlugin.getData(context)
+                .edit()
+                .remove("$ACTION_RESULT_KEY_PREFIX$actionId")
+                .apply()
+        }
+
+        private fun fallbackFailureMessage(action: String): String {
+            return when (action) {
+                "refresh" -> "更新に失敗しました"
+                "previous", "next" -> "切り替えに失敗しました"
+                else -> "操作に失敗しました"
+            }
+        }
+
+        private fun showToast(context: Context, message: String) {
+            mainHandler.post {
+                Toast.makeText(
+                    context.applicationContext,
+                    message,
+                    Toast.LENGTH_SHORT,
+                ).show()
+            }
+        }
+    }
+}

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -22,17 +22,6 @@
 
 ## Androidウィジェット
 
-- Androidウィジェットの通知表示をToastに移行する
-  - ウィジェットの更新・前後切り替えアクションには一意な`actionId`を付与し、Android側の背景WorkerからDart背景コールバックへ渡す
-  - Dart側は`androidWidgetInteractivityCallback`で処理を実行し、処理完了後に`actionId`へ紐づく結果データ（通知種別・メッセージ・成功/失敗）をHomeWidget共有データへ保存する
-  - Android側の背景WorkerはDart背景コールバックの完了を待ち、`actionId`に対応する結果データを読み取ってからToastを表示する
-  - 更新ボタン押下直後ではなく、`RefreshAndroidWidgetItineraryCacheUsecase.execute`が成功した結果データを保存した後だけ「更新しました。」を表示する
-  - 更新失敗時はDart側で失敗結果データを保存し、Android側でToastとして「更新に失敗しました」を表示する
-  - 旅程日の前後切り替え失敗時はDart側で失敗結果データを保存し、Android側でToastとして「切り替えに失敗しました」を表示する
-  - Android側でDart処理自体を開始できない、または結果データを読み取れない場合は、対象アクションに応じた失敗Toastを表示し、成功Toastは表示しない
-  - Toast表示後は`actionId`に対応する結果データを削除し、古い結果による誤表示を防ぐ
-  - Kotlin側ではAndroid標準の`Toast.makeText(context.applicationContext, message, Toast.LENGTH_SHORT).show()`相当をメインスレッドで実行し、Androidホーム画面上にToastを表示する
-  - `ERROR_MESSAGE_KEY`、`FooterRow`、`saveErrorMessage`による通知表示は廃止または通知用途から外し、ウィジェット表示にエラーメッセージを残さない
 - Androidウィジェットを1日単位などで定期的に自動更新する
   - `workmanager`を導入し、Androidの定期バックグラウンドタスクから既存のウィジェットキャッシュ更新ユースケースを呼び出す
   - アプリ起動時とウィジェット表示対象グループ設定時に、重複しない一意名で定期タスクを登録する

--- a/lib/application/dtos/android_widget/android_widget_action_result_dto.dart
+++ b/lib/application/dtos/android_widget/android_widget_action_result_dto.dart
@@ -1,0 +1,20 @@
+import 'package:equatable/equatable.dart';
+
+enum AndroidWidgetActionResultStatus { success, failure }
+
+class AndroidWidgetActionResultDto extends Equatable {
+  const AndroidWidgetActionResultDto({
+    required this.status,
+    required this.message,
+  });
+
+  final AndroidWidgetActionResultStatus status;
+  final String message;
+
+  Map<String, dynamic> toJson() {
+    return {'status': status.name, 'message': message};
+  }
+
+  @override
+  List<Object?> get props => [status, message];
+}

--- a/lib/application/services/android_widget_cache_storage.dart
+++ b/lib/application/services/android_widget_cache_storage.dart
@@ -1,3 +1,4 @@
+import 'package:memora/application/dtos/android_widget/android_widget_action_result_dto.dart';
 import 'package:memora/application/dtos/android_widget/android_widget_itinerary_cache_dto.dart';
 
 abstract interface class AndroidWidgetCacheStorage {
@@ -15,7 +16,10 @@ abstract interface class AndroidWidgetCacheStorage {
 
   Future<void> saveItineraryCache(AndroidWidgetItineraryCacheDto cache);
 
-  Future<void> saveErrorMessage(String? message);
+  Future<void> saveActionResult(
+    String actionId,
+    AndroidWidgetActionResultDto result,
+  );
 
   Future<void> clear();
 

--- a/lib/application/usecases/android_widget/android_widget_interactivity_callback.dart
+++ b/lib/application/usecases/android_widget/android_widget_interactivity_callback.dart
@@ -4,6 +4,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/widgets.dart';
 import 'package:home_widget/home_widget.dart';
+import 'package:memora/application/dtos/android_widget/android_widget_action_result_dto.dart';
 import 'package:memora/application/usecases/android_widget/android_widget_itinerary_cache_usecases.dart';
 import 'package:memora/application/usecases/android_widget/get_android_widget_itinerary_cache_usecase.dart';
 import 'package:memora/core/time/app_clock.dart';
@@ -51,18 +52,30 @@ FutureOr<void> androidWidgetInteractivityCallback(Uri? uri) async {
     refreshCacheUsecase: refreshUsecase,
   );
 
+  final actionId = uri?.queryParameters['actionId'];
+
   switch (uri?.host) {
     case 'previous':
       await moveUsecase.execute(
         AndroidWidgetItineraryDateMoveDirection.previous,
+        actionId: actionId,
       );
       break;
     case 'next':
-      await moveUsecase.execute(AndroidWidgetItineraryDateMoveDirection.next);
+      await moveUsecase.execute(
+        AndroidWidgetItineraryDateMoveDirection.next,
+        actionId: actionId,
+      );
       break;
     case 'refresh':
       final groupId = await storage.getTargetGroupId();
       if (groupId == null) {
+        await _saveActionResult(
+          storage,
+          actionId,
+          AndroidWidgetActionResultStatus.failure,
+          '更新に失敗しました',
+        );
         await storage.updateWidget();
         return;
       }
@@ -71,9 +84,25 @@ FutureOr<void> androidWidgetInteractivityCallback(Uri? uri) async {
       await refreshUsecase.execute(
         groupId: groupId,
         selectedItineraryDateId: selectedItineraryDateId,
+        actionId: actionId,
       );
       break;
   }
+}
+
+Future<void> _saveActionResult(
+  HomeWidgetAndroidWidgetCacheStorage storage,
+  String? actionId,
+  AndroidWidgetActionResultStatus status,
+  String message,
+) async {
+  if (actionId == null || actionId.isEmpty) {
+    return;
+  }
+  await storage.saveActionResult(
+    actionId,
+    AndroidWidgetActionResultDto(status: status, message: message),
+  );
 }
 
 void registerAndroidWidgetInteractivityCallback() {

--- a/lib/application/usecases/android_widget/android_widget_itinerary_cache_usecases.dart
+++ b/lib/application/usecases/android_widget/android_widget_itinerary_cache_usecases.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:memora/application/dtos/android_widget/android_widget_action_result_dto.dart';
 import 'package:memora/application/dtos/android_widget/android_widget_itinerary_cache_dto.dart';
 import 'package:memora/application/dtos/trip/itinerary_item_dto.dart';
 import 'package:memora/application/dtos/trip/trip_entry_dto.dart';
@@ -64,6 +65,8 @@ class RefreshAndroidWidgetItineraryCacheUsecase {
   Future<void> execute({
     required String groupId,
     String? selectedItineraryDateId,
+    String? actionId,
+    String successMessage = '更新しました。',
   }) async {
     try {
       final cache = await _getCacheUsecase.execute(
@@ -72,13 +75,35 @@ class RefreshAndroidWidgetItineraryCacheUsecase {
       );
       await _cacheStorage.saveTargetGroupId(groupId);
       await _cacheStorage.saveItineraryCache(cache);
-      await _cacheStorage.saveErrorMessage(null);
+      await _saveActionResult(
+        actionId,
+        AndroidWidgetActionResultStatus.success,
+        successMessage,
+      );
     } catch (e) {
-      await _cacheStorage.saveErrorMessage('更新に失敗しました');
+      await _saveActionResult(
+        actionId,
+        AndroidWidgetActionResultStatus.failure,
+        '更新に失敗しました',
+      );
       rethrow;
     } finally {
       await _cacheStorage.updateWidget();
     }
+  }
+
+  Future<void> _saveActionResult(
+    String? actionId,
+    AndroidWidgetActionResultStatus status,
+    String message,
+  ) async {
+    if (actionId == null || actionId.isEmpty) {
+      return;
+    }
+    await _cacheStorage.saveActionResult(
+      actionId,
+      AndroidWidgetActionResultDto(status: status, message: message),
+    );
   }
 }
 
@@ -130,19 +155,25 @@ class MoveAndroidWidgetSelectedItineraryDateUsecase {
   static const _moveFailedMessage = '切り替えに失敗しました';
 
   Future<void> execute(
-    AndroidWidgetItineraryDateMoveDirection direction,
-  ) async {
+    AndroidWidgetItineraryDateMoveDirection direction, {
+    String? actionId,
+  }) async {
     try {
-      await _execute(direction);
+      await _execute(direction, actionId: actionId);
     } catch (_) {
-      await _cacheStorage.saveErrorMessage(_moveFailedMessage);
+      await _saveActionResult(
+        actionId,
+        AndroidWidgetActionResultStatus.failure,
+        _moveFailedMessage,
+      );
       await _cacheStorage.updateWidget();
     }
   }
 
   Future<void> _execute(
-    AndroidWidgetItineraryDateMoveDirection direction,
-  ) async {
+    AndroidWidgetItineraryDateMoveDirection direction, {
+    String? actionId,
+  }) async {
     final cache = await _cacheStorage.loadItineraryCache();
     if (cache == null || cache.selectedItineraryDateId == null) {
       await _cacheStorage.updateWidget();
@@ -160,7 +191,11 @@ class MoveAndroidWidgetSelectedItineraryDateUsecase {
           itineraryDates: cache.itineraryDates,
         ),
       );
-      await _cacheStorage.saveErrorMessage(null);
+      await _saveActionResult(
+        actionId,
+        AndroidWidgetActionResultStatus.success,
+        '',
+      );
       await _cacheStorage.updateWidget();
       return;
     }
@@ -177,6 +212,22 @@ class MoveAndroidWidgetSelectedItineraryDateUsecase {
     await _refreshCacheUsecase.execute(
       groupId: cache.groupId,
       selectedItineraryDateId: targetItineraryDateId,
+      actionId: actionId,
+      successMessage: '',
+    );
+  }
+
+  Future<void> _saveActionResult(
+    String? actionId,
+    AndroidWidgetActionResultStatus status,
+    String message,
+  ) async {
+    if (actionId == null || actionId.isEmpty) {
+      return;
+    }
+    await _cacheStorage.saveActionResult(
+      actionId,
+      AndroidWidgetActionResultDto(status: status, message: message),
     );
   }
 

--- a/lib/infrastructure/services/home_widget_android_widget_cache_storage.dart
+++ b/lib/infrastructure/services/home_widget_android_widget_cache_storage.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:home_widget/home_widget.dart';
+import 'package:memora/application/dtos/android_widget/android_widget_action_result_dto.dart';
 import 'package:memora/application/dtos/android_widget/android_widget_itinerary_cache_dto.dart';
 import 'package:memora/application/services/android_widget_cache_storage.dart';
 
@@ -13,7 +14,7 @@ class HomeWidgetAndroidWidgetCacheStorage implements AndroidWidgetCacheStorage {
   static const selectedItineraryDateIdKey =
       'memora_widget_selected_itinerary_date_id';
   static const lastUpdatedAtKey = 'memora_widget_last_updated_at';
-  static const errorMessageKey = 'memora_widget_error_message';
+  static const actionResultKeyPrefix = 'memora_widget_action_result_';
   static const cacheFileKey = 'memora_widget_itinerary_cache';
   static const qualifiedAndroidName =
       'com.example.memora.ItineraryWidgetReceiver';
@@ -86,8 +87,14 @@ class HomeWidgetAndroidWidgetCacheStorage implements AndroidWidgetCacheStorage {
   }
 
   @override
-  Future<void> saveErrorMessage(String? message) async {
-    await HomeWidget.saveWidgetData<String>(errorMessageKey, message ?? '');
+  Future<void> saveActionResult(
+    String actionId,
+    AndroidWidgetActionResultDto result,
+  ) async {
+    await HomeWidget.saveWidgetData<String>(
+      '$actionResultKeyPrefix$actionId',
+      jsonEncode(result.toJson()),
+    );
   }
 
   @override
@@ -96,7 +103,6 @@ class HomeWidgetAndroidWidgetCacheStorage implements AndroidWidgetCacheStorage {
       clearTargetGroupId(),
       saveSelectedItineraryDateId(null),
       HomeWidget.saveWidgetData<String>(lastUpdatedAtKey, ''),
-      HomeWidget.saveWidgetData<String>(errorMessageKey, ''),
       HomeWidget.saveWidgetData<String>(cacheFileKey, ''),
     ]);
   }

--- a/test/unit/application/usecases/android_widget/android_widget_itinerary_cache_usecases_test.dart
+++ b/test/unit/application/usecases/android_widget/android_widget_itinerary_cache_usecases_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:memora/application/dtos/android_widget/android_widget_action_result_dto.dart';
 import 'package:memora/application/dtos/android_widget/android_widget_itinerary_cache_dto.dart';
 import 'package:memora/application/dtos/trip/itinerary_item_dto.dart';
 import 'package:memora/application/dtos/trip/trip_entry_dto.dart';
@@ -13,8 +14,49 @@ import 'package:memora/core/time/app_clock.dart';
 import '../../../../helpers/test_exception.dart';
 
 void main() {
+  group('RefreshAndroidWidgetItineraryCacheUsecase', () {
+    test('更新に成功した場合はアクション結果に成功Toastを保存する', () async {
+      final storage = _FakeAndroidWidgetCacheStorage();
+      final usecase = _buildRefreshUsecase(
+        storage,
+        _FakeTripEntryQueryService(),
+        _FakeItineraryItemQueryService(),
+      );
+
+      await usecase.execute(groupId: 'group-1', actionId: 'action-1');
+
+      expect(storage.actionResults['action-1'], {
+        'status': 'success',
+        'message': '更新しました。',
+      });
+      expect(storage.errorMessage, isNull);
+    });
+
+    test('更新に失敗した場合はアクション結果に失敗Toastを保存する', () async {
+      final storage = _FakeAndroidWidgetCacheStorage();
+      final tripEntryQueryService = _FakeTripEntryQueryService()
+        ..exception = TestException('取得失敗');
+      final usecase = _buildRefreshUsecase(
+        storage,
+        tripEntryQueryService,
+        _FakeItineraryItemQueryService(),
+      );
+
+      await expectLater(
+        usecase.execute(groupId: 'group-1', actionId: 'action-1'),
+        throwsA(isA<TestException>()),
+      );
+
+      expect(storage.actionResults['action-1'], {
+        'status': 'failure',
+        'message': '更新に失敗しました',
+      });
+      expect(storage.errorMessage, isNull);
+    });
+  });
+
   group('MoveAndroidWidgetSelectedItineraryDateUsecase', () {
-    test('リモート探索で失敗した場合はエラーを保存してウィジェットを更新する', () async {
+    test('リモート探索で失敗した場合はアクション結果に失敗Toastを保存してウィジェットを更新する', () async {
       final storage = _FakeAndroidWidgetCacheStorage(
         cache: AndroidWidgetItineraryCacheDto(
           version: 1,
@@ -49,11 +91,18 @@ void main() {
       );
 
       await expectLater(
-        usecase.execute(AndroidWidgetItineraryDateMoveDirection.next),
+        usecase.execute(
+          AndroidWidgetItineraryDateMoveDirection.next,
+          actionId: 'action-1',
+        ),
         completes,
       );
 
-      expect(storage.errorMessage, '切り替えに失敗しました');
+      expect(storage.actionResults['action-1'], {
+        'status': 'failure',
+        'message': '切り替えに失敗しました',
+      });
+      expect(storage.errorMessage, isNull);
       expect(storage.updateWidgetCount, 1);
     });
   });
@@ -81,6 +130,7 @@ class _FakeAndroidWidgetCacheStorage implements AndroidWidgetCacheStorage {
   String? targetGroupId;
   String? selectedItineraryDateId;
   String? errorMessage;
+  final actionResults = <String, Map<String, String>>{};
   int updateWidgetCount = 0;
 
   @override
@@ -112,8 +162,14 @@ class _FakeAndroidWidgetCacheStorage implements AndroidWidgetCacheStorage {
   }
 
   @override
-  Future<void> saveErrorMessage(String? message) async {
-    errorMessage = message;
+  Future<void> saveActionResult(
+    String actionId,
+    AndroidWidgetActionResultDto result,
+  ) async {
+    actionResults[actionId] = {
+      'status': result.status.name,
+      'message': result.message,
+    };
   }
 
   @override

--- a/test/unit/presentation/app/top_page_test.dart
+++ b/test/unit/presentation/app/top_page_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:memora/application/dtos/android_widget/android_widget_action_result_dto.dart';
 import 'package:memora/application/dtos/android_widget/android_widget_itinerary_cache_dto.dart';
 import 'package:memora/application/dtos/group/group_member_dto.dart';
 import 'package:memora/application/dtos/account/user_dto.dart';
@@ -100,7 +101,10 @@ class _FakeAndroidWidgetCacheStorage implements AndroidWidgetCacheStorage {
   }
 
   @override
-  Future<void> saveErrorMessage(String? message) async {}
+  Future<void> saveActionResult(
+    String actionId,
+    AndroidWidgetActionResultDto result,
+  ) async {}
 
   @override
   Future<void> saveItineraryCache(AndroidWidgetItineraryCacheDto cache) async {}

--- a/test/unit/presentation/features/setting/settings_test.dart
+++ b/test/unit/presentation/features/setting/settings_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:memora/application/dtos/android_widget/android_widget_action_result_dto.dart';
 import 'package:memora/application/dtos/android_widget/android_widget_itinerary_cache_dto.dart';
 import 'package:memora/application/dtos/group/group_dto.dart';
 import 'package:memora/application/dtos/member/member_dto.dart';
@@ -228,7 +229,10 @@ class _FakeAndroidWidgetCacheStorage implements AndroidWidgetCacheStorage {
   }
 
   @override
-  Future<void> saveErrorMessage(String? message) async {}
+  Future<void> saveActionResult(
+    String actionId,
+    AndroidWidgetActionResultDto result,
+  ) async {}
 
   @override
   Future<void> saveItineraryCache(AndroidWidgetItineraryCacheDto cache) async {


### PR DESCRIPTION
### Motivation
- Androidウィジェットの操作結果通知をウィジェットUI内に残す方式から、Android標準のToastで表示する方式へ切替して誤表示を防ぎユーザー体験を改善するため。
- 各操作を一意に追跡する`actionId`を導入し、Dart側の背景コールバック完了後に結果を保存してからAndroid側でToast表示する設計にするため。

### Description
- Android側に独自Worker `MemoraWidgetActionWorker.kt` を追加し、操作ごとに生成した`actionId`を含むURIでDart背景コールバックを起動して完了待ちし、結果を読み取ってToast表示・削除する実装を追加した。 
- 既存のKotlin側呼び出しをBroadcast経由からWorker起動へ置換し、ウィジェット内のFooter表示（`FooterRow` / `ERROR_MESSAGE_KEY`）とそれに紐づく保存ロジックを廃止した。 
- Dart側に`AndroidWidgetActionResultDto`を追加し、`AndroidWidgetCacheStorage`インターフェースに`saveActionResult`を追加、`HomeWidgetAndroidWidgetCacheStorage`でactionIdごとにJSON保存するよう変更した。 
- `RefreshAndroidWidgetItineraryCacheUsecase`と`MoveAndroidWidgetSelectedItineraryDateUsecase`を`actionId`対応へ拡張し、成功/失敗の結果をHomeWidget共有データへ保存する処理を追加した。 
- `androidWidgetInteractivityCallback`でURIの`actionId`を受け取り各ユースケースへ伝搬し、対象グループ未設定時などの早期失敗でも結果を保存するようにした。 
- 単体テストを修正／追加して、actionIdに対する結果保存（成功／失敗）が行われることを検証するようにした。 
- 対応済みのToDo項目（docs/todo.md）の該当ブロックを削除した。 

### Testing
- 単体テスト `flutter test test/unit/application/usecases/android_widget/android_widget_itinerary_cache_usecases_test.dart` を実行し全テストが成功した（成功）。
- `dart format --set-exit-if-changed .` と `flutter analyze` を実行し問題なし（成功）。
- リポジトリの総合チェック `./check.sh` を実行し、ビルド生成・解析・テストを含む全チェックが通過した（成功）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a1d04493c8332ab51aafda4ac09d4)