### PR TITLE
Androidウィジェットの通知表示をToastに移行

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -88,6 +88,7 @@ configurations.all {
 
 dependencies {
     implementation("com.google.android.libraries.places:places:5.1.1")
+    implementation("androidx.work:work-runtime-ktx:2.11.2")
     implementation("androidx.glance:glance-appwidget:1.1.1")
     implementation("androidx.glance:glance-material3:1.1.1")
 }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <application
         android:label="memora"
         android:name="${applicationName}"

--- a/android/app/src/main/kotlin/com/example/memora/ItineraryWidget.kt
+++ b/android/app/src/main/kotlin/com/example/memora/ItineraryWidget.kt
@@ -1,13 +1,13 @@
 package com.example.memora
 
 import android.Manifest
+import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
-import android.widget.Toast
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
@@ -338,8 +338,6 @@ class RefreshWidgetAction : ActionCallback {
         glanceId: GlanceId,
         parameters: androidx.glance.action.ActionParameters,
     ) {
-        showRefreshButtonNotification(context)
-        showToast(context, "更新ボタンを押しました")
         runWidgetAction(context, WIDGET_ACTION_REFRESH)
     }
 }
@@ -378,8 +376,8 @@ private suspend fun runWidgetAction(context: Context, action: String) {
             waitForActionResult(context, actionId)
         }
     }.getOrNull()
-    resolveToastMessage(action, result)?.let { message ->
-        showToast(context, message)
+    resolveNotificationMessage(action, result)?.let { message ->
+        showNotification(context, message)
     }
     clearActionResult(context, actionId)
 }
@@ -444,14 +442,14 @@ private suspend fun readActionResult(
     }.getOrNull()
 }
 
-private fun resolveToastMessage(
+private fun resolveNotificationMessage(
     action: String,
     result: WidgetActionResult?,
 ): String? {
     if (result == null) {
         return failureMessageFor(action)
     }
-    if (result.notificationType != NOTIFICATION_TYPE_TOAST) {
+    if (result.notificationType != NOTIFICATION_TYPE) {
         return null
     }
     if (!result.message.isNullOrBlank()) {
@@ -468,13 +466,7 @@ private fun failureMessageFor(action: String): String {
     }
 }
 
-private suspend fun showToast(context: Context, message: String) {
-    withContext(Dispatchers.Main) {
-        Toast.makeText(context.applicationContext, message, Toast.LENGTH_SHORT).show()
-    }
-}
-
-private fun showRefreshButtonNotification(context: Context) {
+private fun showNotification(context: Context, message: String) {
     val applicationContext = context.applicationContext
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
         applicationContext.checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) !=
@@ -489,22 +481,26 @@ private fun showRefreshButtonNotification(context: Context) {
             NotificationChannel(
                 WIDGET_NOTIFICATION_CHANNEL_ID,
                 "Androidウィジェット",
-                NotificationManager.IMPORTANCE_DEFAULT,
+                NotificationManager.IMPORTANCE_HIGH,
             ),
         )
     }
-    val notification = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-        android.app.Notification.Builder(applicationContext, WIDGET_NOTIFICATION_CHANNEL_ID)
+    val builder = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        Notification.Builder(applicationContext, WIDGET_NOTIFICATION_CHANNEL_ID)
     } else {
         @Suppress("DEPRECATION")
-        android.app.Notification.Builder(applicationContext)
+        Notification.Builder(applicationContext)
     }
+    builder
         .setSmallIcon(R.drawable.ic_widget_refresh)
         .setContentTitle("memora")
-        .setContentText("更新ボタンを押しました")
+        .setContentText(message)
+        .setPriority(Notification.PRIORITY_HIGH)
         .setAutoCancel(true)
-        .build()
-    notificationManager.notify(REFRESH_BUTTON_NOTIFICATION_ID, notification)
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        builder.setTimeoutAfter(NOTIFICATION_TIMEOUT_MILLIS)
+    }
+    notificationManager.notify(WIDGET_NOTIFICATION_ID, builder.build())
 }
 
 private suspend fun clearActionResult(context: Context, actionId: String) {
@@ -624,9 +620,10 @@ private const val HOME_WIDGET_PREFERENCES = "HomeWidgetPreferences"
 private const val HOME_WIDGET_WORKER_URI_DATA_KEY = "uri_data"
 private const val WIDGET_URI_SCHEME = "memoraWidget"
 private const val ACTION_ID_QUERY_PARAMETER = "actionId"
-private const val NOTIFICATION_TYPE_TOAST = "toast"
-private const val WIDGET_NOTIFICATION_CHANNEL_ID = "memora_widget"
-private const val REFRESH_BUTTON_NOTIFICATION_ID = 1001
+private const val NOTIFICATION_TYPE = "notification"
+private const val WIDGET_NOTIFICATION_CHANNEL_ID = "memora_widget_heads_up"
+private const val WIDGET_NOTIFICATION_ID = 1001
+private const val NOTIFICATION_TIMEOUT_MILLIS = 3000L
 private const val WIDGET_ACTION_REFRESH = "refresh"
 private const val WIDGET_ACTION_PREVIOUS = "previous"
 private const val WIDGET_ACTION_NEXT = "next"

--- a/android/app/src/main/kotlin/com/example/memora/ItineraryWidget.kt
+++ b/android/app/src/main/kotlin/com/example/memora/ItineraryWidget.kt
@@ -481,7 +481,7 @@ private fun showNotification(context: Context, message: String) {
             NotificationChannel(
                 WIDGET_NOTIFICATION_CHANNEL_ID,
                 "Androidウィジェット",
-                NotificationManager.IMPORTANCE_HIGH,
+                NotificationManager.IMPORTANCE_DEFAULT,
             ),
         )
     }
@@ -495,7 +495,6 @@ private fun showNotification(context: Context, message: String) {
         .setSmallIcon(R.drawable.ic_widget_refresh)
         .setContentTitle("memora")
         .setContentText(message)
-        .setPriority(Notification.PRIORITY_HIGH)
         .setAutoCancel(true)
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
         builder.setTimeoutAfter(NOTIFICATION_TIMEOUT_MILLIS)
@@ -621,7 +620,7 @@ private const val HOME_WIDGET_WORKER_URI_DATA_KEY = "uri_data"
 private const val WIDGET_URI_SCHEME = "memoraWidget"
 private const val ACTION_ID_QUERY_PARAMETER = "actionId"
 private const val NOTIFICATION_TYPE = "notification"
-private const val WIDGET_NOTIFICATION_CHANNEL_ID = "memora_widget_heads_up"
+private const val WIDGET_NOTIFICATION_CHANNEL_ID = "memora_widget"
 private const val WIDGET_NOTIFICATION_ID = 1001
 private const val NOTIFICATION_TIMEOUT_MILLIS = 3000L
 private const val WIDGET_ACTION_REFRESH = "refresh"

--- a/android/app/src/main/kotlin/com/example/memora/ItineraryWidget.kt
+++ b/android/app/src/main/kotlin/com/example/memora/ItineraryWidget.kt
@@ -1,13 +1,8 @@
 package com.example.memora
 
-import android.Manifest
-import android.app.Notification
-import android.app.NotificationChannel
-import android.app.NotificationManager
 import android.content.Context
-import android.content.pm.PackageManager
 import android.net.Uri
-import android.os.Build
+import android.widget.Toast
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
@@ -376,8 +371,8 @@ private suspend fun runWidgetAction(context: Context, action: String) {
             waitForActionResult(context, actionId)
         }
     }.getOrNull()
-    resolveNotificationMessage(action, result)?.let { message ->
-        showNotification(context, message)
+    resolveToastMessage(action, result)?.let { message ->
+        showToast(context, message)
     }
     clearActionResult(context, actionId)
 }
@@ -442,14 +437,14 @@ private suspend fun readActionResult(
     }.getOrNull()
 }
 
-private fun resolveNotificationMessage(
+private fun resolveToastMessage(
     action: String,
     result: WidgetActionResult?,
 ): String? {
     if (result == null) {
         return failureMessageFor(action)
     }
-    if (result.notificationType != NOTIFICATION_TYPE) {
+    if (result.notificationType != NOTIFICATION_TYPE_TOAST) {
         return null
     }
     if (!result.message.isNullOrBlank()) {
@@ -466,40 +461,10 @@ private fun failureMessageFor(action: String): String {
     }
 }
 
-private fun showNotification(context: Context, message: String) {
-    val applicationContext = context.applicationContext
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
-        applicationContext.checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) !=
-        PackageManager.PERMISSION_GRANTED
-    ) {
-        return
+private suspend fun showToast(context: Context, message: String) {
+    withContext(Dispatchers.Main) {
+        Toast.makeText(context.applicationContext, message, Toast.LENGTH_SHORT).show()
     }
-    val notificationManager = applicationContext
-        .getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-        notificationManager.createNotificationChannel(
-            NotificationChannel(
-                WIDGET_NOTIFICATION_CHANNEL_ID,
-                "Androidウィジェット",
-                NotificationManager.IMPORTANCE_DEFAULT,
-            ),
-        )
-    }
-    val builder = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-        Notification.Builder(applicationContext, WIDGET_NOTIFICATION_CHANNEL_ID)
-    } else {
-        @Suppress("DEPRECATION")
-        Notification.Builder(applicationContext)
-    }
-    builder
-        .setSmallIcon(R.drawable.ic_widget_refresh)
-        .setContentTitle("memora")
-        .setContentText(message)
-        .setAutoCancel(true)
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-        builder.setTimeoutAfter(NOTIFICATION_TIMEOUT_MILLIS)
-    }
-    notificationManager.notify(WIDGET_NOTIFICATION_ID, builder.build())
 }
 
 private suspend fun clearActionResult(context: Context, actionId: String) {
@@ -619,10 +584,7 @@ private const val HOME_WIDGET_PREFERENCES = "HomeWidgetPreferences"
 private const val HOME_WIDGET_WORKER_URI_DATA_KEY = "uri_data"
 private const val WIDGET_URI_SCHEME = "memoraWidget"
 private const val ACTION_ID_QUERY_PARAMETER = "actionId"
-private const val NOTIFICATION_TYPE = "notification"
-private const val WIDGET_NOTIFICATION_CHANNEL_ID = "memora_widget"
-private const val WIDGET_NOTIFICATION_ID = 1001
-private const val NOTIFICATION_TIMEOUT_MILLIS = 3000L
+private const val NOTIFICATION_TYPE_TOAST = "toast"
 private const val WIDGET_ACTION_REFRESH = "refresh"
 private const val WIDGET_ACTION_PREVIOUS = "previous"
 private const val WIDGET_ACTION_NEXT = "next"

--- a/android/app/src/main/kotlin/com/example/memora/ItineraryWidget.kt
+++ b/android/app/src/main/kotlin/com/example/memora/ItineraryWidget.kt
@@ -333,6 +333,7 @@ class RefreshWidgetAction : ActionCallback {
         glanceId: GlanceId,
         parameters: androidx.glance.action.ActionParameters,
     ) {
+        showToast(context, "更新ボタンを押しました")
         runWidgetAction(context, WIDGET_ACTION_REFRESH)
     }
 }

--- a/android/app/src/main/kotlin/com/example/memora/ItineraryWidget.kt
+++ b/android/app/src/main/kotlin/com/example/memora/ItineraryWidget.kt
@@ -1,7 +1,12 @@
 package com.example.memora
 
+import android.Manifest
+import android.app.NotificationChannel
+import android.app.NotificationManager
 import android.content.Context
+import android.content.pm.PackageManager
 import android.net.Uri
+import android.os.Build
 import android.widget.Toast
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
@@ -333,6 +338,7 @@ class RefreshWidgetAction : ActionCallback {
         glanceId: GlanceId,
         parameters: androidx.glance.action.ActionParameters,
     ) {
+        showRefreshButtonNotification(context)
         showToast(context, "更新ボタンを押しました")
         runWidgetAction(context, WIDGET_ACTION_REFRESH)
     }
@@ -468,6 +474,39 @@ private suspend fun showToast(context: Context, message: String) {
     }
 }
 
+private fun showRefreshButtonNotification(context: Context) {
+    val applicationContext = context.applicationContext
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+        applicationContext.checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) !=
+        PackageManager.PERMISSION_GRANTED
+    ) {
+        return
+    }
+    val notificationManager = applicationContext
+        .getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        notificationManager.createNotificationChannel(
+            NotificationChannel(
+                WIDGET_NOTIFICATION_CHANNEL_ID,
+                "Androidウィジェット",
+                NotificationManager.IMPORTANCE_DEFAULT,
+            ),
+        )
+    }
+    val notification = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        android.app.Notification.Builder(applicationContext, WIDGET_NOTIFICATION_CHANNEL_ID)
+    } else {
+        @Suppress("DEPRECATION")
+        android.app.Notification.Builder(applicationContext)
+    }
+        .setSmallIcon(R.drawable.ic_widget_refresh)
+        .setContentTitle("memora")
+        .setContentText("更新ボタンを押しました")
+        .setAutoCancel(true)
+        .build()
+    notificationManager.notify(REFRESH_BUTTON_NOTIFICATION_ID, notification)
+}
+
 private suspend fun clearActionResult(context: Context, actionId: String) {
     withContext(Dispatchers.IO) {
         context
@@ -586,6 +625,8 @@ private const val HOME_WIDGET_WORKER_URI_DATA_KEY = "uri_data"
 private const val WIDGET_URI_SCHEME = "memoraWidget"
 private const val ACTION_ID_QUERY_PARAMETER = "actionId"
 private const val NOTIFICATION_TYPE_TOAST = "toast"
+private const val WIDGET_NOTIFICATION_CHANNEL_ID = "memora_widget"
+private const val REFRESH_BUTTON_NOTIFICATION_ID = 1001
 private const val WIDGET_ACTION_REFRESH = "refresh"
 private const val WIDGET_ACTION_PREVIOUS = "previous"
 private const val WIDGET_ACTION_NEXT = "next"

--- a/android/app/src/main/kotlin/com/example/memora/ItineraryWidget.kt
+++ b/android/app/src/main/kotlin/com/example/memora/ItineraryWidget.kt
@@ -2,6 +2,7 @@ package com.example.memora
 
 import android.content.Context
 import android.net.Uri
+import android.widget.Toast
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
@@ -35,10 +36,18 @@ import androidx.glance.text.FontWeight
 import androidx.glance.text.Text
 import androidx.glance.text.TextAlign
 import androidx.glance.text.TextStyle
-import es.antonborri.home_widget.HomeWidgetBackgroundIntent
+import androidx.work.Data
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import es.antonborri.home_widget.HomeWidgetBackgroundWorker
 import es.antonborri.home_widget.HomeWidgetGlanceState
 import es.antonborri.home_widget.HomeWidgetGlanceStateDefinition
 import java.io.File
+import java.util.UUID
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
 import org.json.JSONArray
 import org.json.JSONObject
 
@@ -63,7 +72,6 @@ private fun ItineraryWidgetContent(
 ) {
     val prefs = state.preferences
     val targetGroupId = prefs.getString(TARGET_GROUP_ID_KEY, null).orEmpty()
-    val errorMessage = prefs.getString(ERROR_MESSAGE_KEY, null).orEmpty()
     val cache = readCache(prefs.getString(CACHE_FILE_KEY, null))
     val selectedItineraryDateId = prefs.getString(SELECTED_ITINERARY_DATE_ID_KEY, null)
         ?: cache?.selectedItineraryDateId
@@ -86,7 +94,6 @@ private fun ItineraryWidgetContent(
                 selectedItineraryDate == null -> EmptyMessage("表示できる旅程がありません")
                 else -> ItineraryDateContent(selectedItineraryDate)
             }
-            FooterRow(errorMessage)
         }
         HeaderRow(cache?.lastUpdatedAt)
     }
@@ -320,21 +327,13 @@ private fun EmptyMessage(message: String) {
     }
 }
 
-@Composable
-private fun FooterRow(errorMessage: String) {
-    if (errorMessage.isBlank()) {
-        return
-    }
-    Text(text = errorMessage, maxLines = 1, style = TextStyle(fontSize = 10.sp))
-}
-
 class RefreshWidgetAction : ActionCallback {
     override suspend fun onAction(
         context: Context,
         glanceId: GlanceId,
         parameters: androidx.glance.action.ActionParameters,
     ) {
-        sendAction(context, "refresh")
+        runWidgetAction(context, WIDGET_ACTION_REFRESH)
     }
 }
 
@@ -344,7 +343,7 @@ class PreviousItineraryDateAction : ActionCallback {
         glanceId: GlanceId,
         parameters: androidx.glance.action.ActionParameters,
     ) {
-        sendAction(context, "previous")
+        runWidgetAction(context, WIDGET_ACTION_PREVIOUS)
     }
 }
 
@@ -354,14 +353,132 @@ class NextItineraryDateAction : ActionCallback {
         glanceId: GlanceId,
         parameters: androidx.glance.action.ActionParameters,
     ) {
-        sendAction(context, "next")
+        runWidgetAction(context, WIDGET_ACTION_NEXT)
     }
 }
 
-private fun sendAction(context: Context, action: String) {
-    HomeWidgetBackgroundIntent
-        .getBroadcast(context, Uri.parse("memoraWidget://$action"))
-        .send()
+private suspend fun runWidgetAction(context: Context, action: String) {
+    val actionId = buildActionId(action)
+    val uri = Uri.Builder()
+        .scheme(WIDGET_URI_SCHEME)
+        .authority(action)
+        .appendQueryParameter(ACTION_ID_QUERY_PARAMETER, actionId)
+        .build()
+    val result = runCatching {
+        if (!enqueueBackgroundWorkAndWait(context, uri)) {
+            null
+        } else {
+            waitForActionResult(context, actionId)
+        }
+    }.getOrNull()
+    resolveToastMessage(action, result)?.let { message ->
+        showToast(context, message)
+    }
+    clearActionResult(context, actionId)
+}
+
+private fun buildActionId(action: String): String {
+    return "$action-${System.currentTimeMillis()}-${UUID.randomUUID()}"
+}
+
+private suspend fun enqueueBackgroundWorkAndWait(context: Context, uri: Uri): Boolean {
+    val workManager = WorkManager.getInstance(context.applicationContext)
+    val request = OneTimeWorkRequestBuilder<HomeWidgetBackgroundWorker>()
+        .setInputData(
+            Data.Builder()
+                .putString(HOME_WIDGET_WORKER_URI_DATA_KEY, uri.toString())
+                .build(),
+        )
+        .build()
+    withContext(Dispatchers.IO) {
+        workManager.enqueue(request).result.get()
+    }
+    repeat(BACKGROUND_WORK_WAIT_ATTEMPTS) {
+        val workInfo = withContext(Dispatchers.IO) {
+            workManager.getWorkInfoById(request.id).get()
+        }
+        if (workInfo?.state?.isFinished == true) {
+            return workInfo.state == WorkInfo.State.SUCCEEDED
+        }
+        delay(BACKGROUND_WAIT_INTERVAL_MILLIS)
+    }
+    return false
+}
+
+private suspend fun waitForActionResult(
+    context: Context,
+    actionId: String,
+): WidgetActionResult? {
+    repeat(ACTION_RESULT_WAIT_ATTEMPTS) {
+        val result = readActionResult(context, actionId)
+        if (result != null) {
+            return result
+        }
+        delay(BACKGROUND_WAIT_INTERVAL_MILLIS)
+    }
+    return null
+}
+
+private suspend fun readActionResult(
+    context: Context,
+    actionId: String,
+): WidgetActionResult? = withContext(Dispatchers.IO) {
+    val raw = context
+        .getSharedPreferences(HOME_WIDGET_PREFERENCES, Context.MODE_PRIVATE)
+        .getString(buildActionResultKey(actionId), null)
+        ?: return@withContext null
+    runCatching {
+        val root = JSONObject(raw)
+        WidgetActionResult(
+            notificationType = root.optString("notificationType"),
+            message = root.optString("message").ifBlank { null },
+            isSuccess = root.optBoolean("isSuccess", false),
+        )
+    }.getOrNull()
+}
+
+private fun resolveToastMessage(
+    action: String,
+    result: WidgetActionResult?,
+): String? {
+    if (result == null) {
+        return failureMessageFor(action)
+    }
+    if (result.notificationType != NOTIFICATION_TYPE_TOAST) {
+        return null
+    }
+    if (!result.message.isNullOrBlank()) {
+        return result.message
+    }
+    return if (result.isSuccess) null else failureMessageFor(action)
+}
+
+private fun failureMessageFor(action: String): String {
+    return if (action == WIDGET_ACTION_REFRESH) {
+        "更新に失敗しました"
+    } else {
+        "切り替えに失敗しました"
+    }
+}
+
+private suspend fun showToast(context: Context, message: String) {
+    withContext(Dispatchers.Main) {
+        Toast.makeText(context.applicationContext, message, Toast.LENGTH_SHORT).show()
+    }
+}
+
+private suspend fun clearActionResult(context: Context, actionId: String) {
+    withContext(Dispatchers.IO) {
+        context
+            .getSharedPreferences(HOME_WIDGET_PREFERENCES, Context.MODE_PRIVATE)
+            .edit()
+            .remove(buildActionResultKey(actionId))
+            .commit()
+    }
+}
+
+private fun buildActionResultKey(actionId: String): String {
+    return "$ACTION_RESULT_KEY_PREFIX$actionId"
 }
 
 private fun readCache(path: String?): WidgetCache? {
@@ -447,6 +564,12 @@ private data class WidgetItineraryItem(
     val timeLabel: String,
 )
 
+private data class WidgetActionResult(
+    val notificationType: String,
+    val message: String?,
+    val isSuccess: Boolean,
+)
+
 private sealed interface WidgetItineraryListEntry {
     data class Item(val item: WidgetItineraryItem) : WidgetItineraryListEntry
     object Divider : WidgetItineraryListEntry
@@ -455,8 +578,19 @@ private sealed interface WidgetItineraryListEntry {
 private const val TARGET_GROUP_ID_KEY = "memora_widget_target_group_id"
 private const val SELECTED_ITINERARY_DATE_ID_KEY =
     "memora_widget_selected_itinerary_date_id"
-private const val ERROR_MESSAGE_KEY = "memora_widget_error_message"
+private const val ACTION_RESULT_KEY_PREFIX = "memora_widget_action_result_"
 private const val CACHE_FILE_KEY = "memora_widget_itinerary_cache"
+private const val HOME_WIDGET_PREFERENCES = "HomeWidgetPreferences"
+private const val HOME_WIDGET_WORKER_URI_DATA_KEY = "uri_data"
+private const val WIDGET_URI_SCHEME = "memoraWidget"
+private const val ACTION_ID_QUERY_PARAMETER = "actionId"
+private const val NOTIFICATION_TYPE_TOAST = "toast"
+private const val WIDGET_ACTION_REFRESH = "refresh"
+private const val WIDGET_ACTION_PREVIOUS = "previous"
+private const val WIDGET_ACTION_NEXT = "next"
+private const val BACKGROUND_WORK_WAIT_ATTEMPTS = 50
+private const val ACTION_RESULT_WAIT_ATTEMPTS = 50
+private const val BACKGROUND_WAIT_INTERVAL_MILLIS = 100L
 private const val WIDGET_PADDING_DP = 8
 private const val CONTENT_TOP_SPACE_DP = 10
 private const val TIME_TEXT_HEIGHT_DP = 12

--- a/android/app/src/main/kotlin/com/example/memora/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/memora/MainActivity.kt
@@ -1,10 +1,19 @@
 package com.example.memora
 
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
+import android.os.Bundle
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
 
 class MainActivity : FlutterActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        requestNotificationPermissionIfNeeded()
+    }
+
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
 
@@ -12,5 +21,24 @@ class MainActivity : FlutterActivity() {
             flutterEngine.dartExecutor.binaryMessenger,
             PlacesMethodChannelHandler.CHANNEL,
         ).setMethodCallHandler(PlacesMethodChannelHandler(applicationContext))
+    }
+
+    private fun requestNotificationPermissionIfNeeded() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            return
+        }
+        if (checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) ==
+            PackageManager.PERMISSION_GRANTED
+        ) {
+            return
+        }
+        requestPermissions(
+            arrayOf(Manifest.permission.POST_NOTIFICATIONS),
+            NOTIFICATION_PERMISSION_REQUEST_CODE,
+        )
+    }
+
+    private companion object {
+        const val NOTIFICATION_PERMISSION_REQUEST_CODE = 1001
     }
 }

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -22,17 +22,6 @@
 
 ## Androidウィジェット
 
-- Androidウィジェットの通知表示をToastに移行する
-  - ウィジェットの更新・前後切り替えアクションには一意な`actionId`を付与し、Android側の背景WorkerからDart背景コールバックへ渡す
-  - Dart側は`androidWidgetInteractivityCallback`で処理を実行し、処理完了後に`actionId`へ紐づく結果データ（通知種別・メッセージ・成功/失敗）をHomeWidget共有データへ保存する
-  - Android側の背景WorkerはDart背景コールバックの完了を待ち、`actionId`に対応する結果データを読み取ってからToastを表示する
-  - 更新ボタン押下直後ではなく、`RefreshAndroidWidgetItineraryCacheUsecase.execute`が成功した結果データを保存した後だけ「更新しました。」を表示する
-  - 更新失敗時はDart側で失敗結果データを保存し、Android側でToastとして「更新に失敗しました」を表示する
-  - 旅程日の前後切り替え失敗時はDart側で失敗結果データを保存し、Android側でToastとして「切り替えに失敗しました」を表示する
-  - Android側でDart処理自体を開始できない、または結果データを読み取れない場合は、対象アクションに応じた失敗Toastを表示し、成功Toastは表示しない
-  - Toast表示後は`actionId`に対応する結果データを削除し、古い結果による誤表示を防ぐ
-  - Kotlin側ではAndroid標準の`Toast.makeText(context.applicationContext, message, Toast.LENGTH_SHORT).show()`相当をメインスレッドで実行し、Androidホーム画面上にToastを表示する
-  - `ERROR_MESSAGE_KEY`、`FooterRow`、`saveErrorMessage`による通知表示は廃止または通知用途から外し、ウィジェット表示にエラーメッセージを残さない
 - Androidウィジェットを1日単位などで定期的に自動更新する
   - `workmanager`を導入し、Androidの定期バックグラウンドタスクから既存のウィジェットキャッシュ更新ユースケースを呼び出す
   - アプリ起動時とウィジェット表示対象グループ設定時に、重複しない一意名で定期タスクを登録する

--- a/lib/application/services/android_widget_cache_storage.dart
+++ b/lib/application/services/android_widget_cache_storage.dart
@@ -1,5 +1,45 @@
 import 'package:memora/application/dtos/android_widget/android_widget_itinerary_cache_dto.dart';
 
+enum AndroidWidgetNotificationType {
+  toast('toast');
+
+  const AndroidWidgetNotificationType(this.value);
+
+  final String value;
+}
+
+class AndroidWidgetActionResult {
+  const AndroidWidgetActionResult({
+    required this.notificationType,
+    required this.message,
+    required this.isSuccess,
+  });
+
+  final AndroidWidgetNotificationType notificationType;
+  final String? message;
+  final bool isSuccess;
+
+  Map<String, dynamic> toJson() {
+    return {
+      'notificationType': notificationType.value,
+      'message': message,
+      'isSuccess': isSuccess,
+    };
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is AndroidWidgetActionResult &&
+            other.notificationType == notificationType &&
+            other.message == message &&
+            other.isSuccess == isSuccess;
+  }
+
+  @override
+  int get hashCode => Object.hash(notificationType, message, isSuccess);
+}
+
 abstract interface class AndroidWidgetCacheStorage {
   Future<String?> getTargetGroupId();
 
@@ -15,7 +55,10 @@ abstract interface class AndroidWidgetCacheStorage {
 
   Future<void> saveItineraryCache(AndroidWidgetItineraryCacheDto cache);
 
-  Future<void> saveErrorMessage(String? message);
+  Future<void> saveActionResult(
+    String actionId,
+    AndroidWidgetActionResult result,
+  );
 
   Future<void> clear();
 

--- a/lib/application/services/android_widget_cache_storage.dart
+++ b/lib/application/services/android_widget_cache_storage.dart
@@ -1,7 +1,7 @@
 import 'package:memora/application/dtos/android_widget/android_widget_itinerary_cache_dto.dart';
 
 enum AndroidWidgetNotificationType {
-  notification('notification');
+  toast('toast');
 
   const AndroidWidgetNotificationType(this.value);
 

--- a/lib/application/services/android_widget_cache_storage.dart
+++ b/lib/application/services/android_widget_cache_storage.dart
@@ -1,7 +1,7 @@
 import 'package:memora/application/dtos/android_widget/android_widget_itinerary_cache_dto.dart';
 
 enum AndroidWidgetNotificationType {
-  toast('toast');
+  notification('notification');
 
   const AndroidWidgetNotificationType(this.value);
 

--- a/lib/application/usecases/android_widget/android_widget_interactivity_callback.dart
+++ b/lib/application/usecases/android_widget/android_widget_interactivity_callback.dart
@@ -73,7 +73,7 @@ FutureOr<void> androidWidgetInteractivityCallback(Uri? uri) async {
           await storage.saveActionResult(
             actionId,
             const AndroidWidgetActionResult(
-              notificationType: AndroidWidgetNotificationType.notification,
+              notificationType: AndroidWidgetNotificationType.toast,
               message: '更新に失敗しました',
               isSuccess: false,
             ),

--- a/lib/application/usecases/android_widget/android_widget_interactivity_callback.dart
+++ b/lib/application/usecases/android_widget/android_widget_interactivity_callback.dart
@@ -73,7 +73,7 @@ FutureOr<void> androidWidgetInteractivityCallback(Uri? uri) async {
           await storage.saveActionResult(
             actionId,
             const AndroidWidgetActionResult(
-              notificationType: AndroidWidgetNotificationType.toast,
+              notificationType: AndroidWidgetNotificationType.notification,
               message: '更新に失敗しました',
               isSuccess: false,
             ),

--- a/lib/application/usecases/android_widget/android_widget_interactivity_callback.dart
+++ b/lib/application/usecases/android_widget/android_widget_interactivity_callback.dart
@@ -4,6 +4,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/widgets.dart';
 import 'package:home_widget/home_widget.dart';
+import 'package:memora/application/services/android_widget_cache_storage.dart';
 import 'package:memora/application/usecases/android_widget/android_widget_itinerary_cache_usecases.dart';
 import 'package:memora/application/usecases/android_widget/get_android_widget_itinerary_cache_usecase.dart';
 import 'package:memora/core/time/app_clock.dart';
@@ -51,18 +52,33 @@ FutureOr<void> androidWidgetInteractivityCallback(Uri? uri) async {
     refreshCacheUsecase: refreshUsecase,
   );
 
+  final actionId = uri?.queryParameters['actionId'];
   switch (uri?.host) {
     case 'previous':
       await moveUsecase.execute(
         AndroidWidgetItineraryDateMoveDirection.previous,
+        actionId: actionId,
       );
       break;
     case 'next':
-      await moveUsecase.execute(AndroidWidgetItineraryDateMoveDirection.next);
+      await moveUsecase.execute(
+        AndroidWidgetItineraryDateMoveDirection.next,
+        actionId: actionId,
+      );
       break;
     case 'refresh':
       final groupId = await storage.getTargetGroupId();
       if (groupId == null) {
+        if (actionId != null) {
+          await storage.saveActionResult(
+            actionId,
+            const AndroidWidgetActionResult(
+              notificationType: AndroidWidgetNotificationType.toast,
+              message: '更新に失敗しました',
+              isSuccess: false,
+            ),
+          );
+        }
         await storage.updateWidget();
         return;
       }
@@ -71,6 +87,7 @@ FutureOr<void> androidWidgetInteractivityCallback(Uri? uri) async {
       await refreshUsecase.execute(
         groupId: groupId,
         selectedItineraryDateId: selectedItineraryDateId,
+        actionId: actionId,
       );
       break;
   }

--- a/lib/application/usecases/android_widget/android_widget_itinerary_cache_usecases.dart
+++ b/lib/application/usecases/android_widget/android_widget_itinerary_cache_usecases.dart
@@ -342,7 +342,7 @@ Future<void> _saveAndroidWidgetActionResult(
   await cacheStorage.saveActionResult(
     actionId,
     AndroidWidgetActionResult(
-      notificationType: AndroidWidgetNotificationType.toast,
+      notificationType: AndroidWidgetNotificationType.notification,
       message: message,
       isSuccess: isSuccess,
     ),

--- a/lib/application/usecases/android_widget/android_widget_itinerary_cache_usecases.dart
+++ b/lib/application/usecases/android_widget/android_widget_itinerary_cache_usecases.dart
@@ -64,6 +64,7 @@ class RefreshAndroidWidgetItineraryCacheUsecase {
   Future<void> execute({
     required String groupId,
     String? selectedItineraryDateId,
+    String? actionId,
   }) async {
     try {
       final cache = await _getCacheUsecase.execute(
@@ -72,13 +73,31 @@ class RefreshAndroidWidgetItineraryCacheUsecase {
       );
       await _cacheStorage.saveTargetGroupId(groupId);
       await _cacheStorage.saveItineraryCache(cache);
-      await _cacheStorage.saveErrorMessage(null);
+      await _saveActionResult(actionId, message: '更新しました。', isSuccess: true);
     } catch (e) {
-      await _cacheStorage.saveErrorMessage('更新に失敗しました');
+      await _saveActionResult(actionId, message: '更新に失敗しました', isSuccess: false);
       rethrow;
     } finally {
       await _cacheStorage.updateWidget();
     }
+  }
+
+  Future<void> _saveActionResult(
+    String? actionId, {
+    required String message,
+    required bool isSuccess,
+  }) async {
+    if (actionId == null) {
+      return;
+    }
+    await _cacheStorage.saveActionResult(
+      actionId,
+      AndroidWidgetActionResult(
+        notificationType: AndroidWidgetNotificationType.toast,
+        message: message,
+        isSuccess: isSuccess,
+      ),
+    );
   }
 }
 
@@ -130,14 +149,38 @@ class MoveAndroidWidgetSelectedItineraryDateUsecase {
   static const _moveFailedMessage = '切り替えに失敗しました';
 
   Future<void> execute(
-    AndroidWidgetItineraryDateMoveDirection direction,
-  ) async {
+    AndroidWidgetItineraryDateMoveDirection direction, {
+    String? actionId,
+  }) async {
     try {
       await _execute(direction);
+      await _saveActionResult(actionId, message: null, isSuccess: true);
     } catch (_) {
-      await _cacheStorage.saveErrorMessage(_moveFailedMessage);
+      await _saveActionResult(
+        actionId,
+        message: _moveFailedMessage,
+        isSuccess: false,
+      );
       await _cacheStorage.updateWidget();
     }
+  }
+
+  Future<void> _saveActionResult(
+    String? actionId, {
+    required String? message,
+    required bool isSuccess,
+  }) async {
+    if (actionId == null) {
+      return;
+    }
+    await _cacheStorage.saveActionResult(
+      actionId,
+      AndroidWidgetActionResult(
+        notificationType: AndroidWidgetNotificationType.toast,
+        message: message,
+        isSuccess: isSuccess,
+      ),
+    );
   }
 
   Future<void> _execute(
@@ -160,7 +203,6 @@ class MoveAndroidWidgetSelectedItineraryDateUsecase {
           itineraryDates: cache.itineraryDates,
         ),
       );
-      await _cacheStorage.saveErrorMessage(null);
       await _cacheStorage.updateWidget();
       return;
     }

--- a/lib/application/usecases/android_widget/android_widget_itinerary_cache_usecases.dart
+++ b/lib/application/usecases/android_widget/android_widget_itinerary_cache_usecases.dart
@@ -73,31 +73,23 @@ class RefreshAndroidWidgetItineraryCacheUsecase {
       );
       await _cacheStorage.saveTargetGroupId(groupId);
       await _cacheStorage.saveItineraryCache(cache);
-      await _saveActionResult(actionId, message: '更新しました。', isSuccess: true);
+      await _saveAndroidWidgetActionResult(
+        _cacheStorage,
+        actionId,
+        message: '更新しました。',
+        isSuccess: true,
+      );
     } catch (e) {
-      await _saveActionResult(actionId, message: '更新に失敗しました', isSuccess: false);
+      await _saveAndroidWidgetActionResult(
+        _cacheStorage,
+        actionId,
+        message: '更新に失敗しました',
+        isSuccess: false,
+      );
       rethrow;
     } finally {
       await _cacheStorage.updateWidget();
     }
-  }
-
-  Future<void> _saveActionResult(
-    String? actionId, {
-    required String message,
-    required bool isSuccess,
-  }) async {
-    if (actionId == null) {
-      return;
-    }
-    await _cacheStorage.saveActionResult(
-      actionId,
-      AndroidWidgetActionResult(
-        notificationType: AndroidWidgetNotificationType.toast,
-        message: message,
-        isSuccess: isSuccess,
-      ),
-    );
   }
 }
 
@@ -154,33 +146,21 @@ class MoveAndroidWidgetSelectedItineraryDateUsecase {
   }) async {
     try {
       await _execute(direction);
-      await _saveActionResult(actionId, message: null, isSuccess: true);
+      await _saveAndroidWidgetActionResult(
+        _cacheStorage,
+        actionId,
+        message: null,
+        isSuccess: true,
+      );
     } catch (_) {
-      await _saveActionResult(
+      await _saveAndroidWidgetActionResult(
+        _cacheStorage,
         actionId,
         message: _moveFailedMessage,
         isSuccess: false,
       );
       await _cacheStorage.updateWidget();
     }
-  }
-
-  Future<void> _saveActionResult(
-    String? actionId, {
-    required String? message,
-    required bool isSuccess,
-  }) async {
-    if (actionId == null) {
-      return;
-    }
-    await _cacheStorage.saveActionResult(
-      actionId,
-      AndroidWidgetActionResult(
-        notificationType: AndroidWidgetNotificationType.toast,
-        message: message,
-        isSuccess: isSuccess,
-      ),
-    );
   }
 
   Future<void> _execute(
@@ -348,4 +328,23 @@ class _ItineraryDateIndex {
   final String id;
   final String tripId;
   final DateTime date;
+}
+
+Future<void> _saveAndroidWidgetActionResult(
+  AndroidWidgetCacheStorage cacheStorage,
+  String? actionId, {
+  required String? message,
+  required bool isSuccess,
+}) async {
+  if (actionId == null) {
+    return;
+  }
+  await cacheStorage.saveActionResult(
+    actionId,
+    AndroidWidgetActionResult(
+      notificationType: AndroidWidgetNotificationType.toast,
+      message: message,
+      isSuccess: isSuccess,
+    ),
+  );
 }

--- a/lib/application/usecases/android_widget/android_widget_itinerary_cache_usecases.dart
+++ b/lib/application/usecases/android_widget/android_widget_itinerary_cache_usecases.dart
@@ -342,7 +342,7 @@ Future<void> _saveAndroidWidgetActionResult(
   await cacheStorage.saveActionResult(
     actionId,
     AndroidWidgetActionResult(
-      notificationType: AndroidWidgetNotificationType.notification,
+      notificationType: AndroidWidgetNotificationType.toast,
       message: message,
       isSuccess: isSuccess,
     ),

--- a/lib/infrastructure/services/home_widget_android_widget_cache_storage.dart
+++ b/lib/infrastructure/services/home_widget_android_widget_cache_storage.dart
@@ -13,7 +13,7 @@ class HomeWidgetAndroidWidgetCacheStorage implements AndroidWidgetCacheStorage {
   static const selectedItineraryDateIdKey =
       'memora_widget_selected_itinerary_date_id';
   static const lastUpdatedAtKey = 'memora_widget_last_updated_at';
-  static const errorMessageKey = 'memora_widget_error_message';
+  static const actionResultKeyPrefix = 'memora_widget_action_result_';
   static const cacheFileKey = 'memora_widget_itinerary_cache';
   static const qualifiedAndroidName =
       'com.example.memora.ItineraryWidgetReceiver';
@@ -86,8 +86,14 @@ class HomeWidgetAndroidWidgetCacheStorage implements AndroidWidgetCacheStorage {
   }
 
   @override
-  Future<void> saveErrorMessage(String? message) async {
-    await HomeWidget.saveWidgetData<String>(errorMessageKey, message ?? '');
+  Future<void> saveActionResult(
+    String actionId,
+    AndroidWidgetActionResult result,
+  ) async {
+    await HomeWidget.saveWidgetData<String>(
+      '$actionResultKeyPrefix$actionId',
+      jsonEncode(result.toJson()),
+    );
   }
 
   @override
@@ -96,7 +102,6 @@ class HomeWidgetAndroidWidgetCacheStorage implements AndroidWidgetCacheStorage {
       clearTargetGroupId(),
       saveSelectedItineraryDateId(null),
       HomeWidget.saveWidgetData<String>(lastUpdatedAtKey, ''),
-      HomeWidget.saveWidgetData<String>(errorMessageKey, ''),
       HomeWidget.saveWidgetData<String>(cacheFileKey, ''),
     ]);
   }

--- a/test/unit/android/itinerary_widget_test.dart
+++ b/test/unit/android/itinerary_widget_test.dart
@@ -20,12 +20,21 @@ void main() {
       );
     });
 
-    test('Dart背景コールバックの結果をToast表示して結果データを削除する', () {
+    test('Dart背景コールバックの結果を画面上通知で表示して結果データを削除する', () {
       final source = File(_itineraryWidgetPath).readAsStringSync();
 
-      expect(source, contains('Toast.makeText(context.applicationContext'));
-      expect(source, contains('Toast.LENGTH_SHORT'));
+      expect(source, contains('Notification.Builder'));
+      expect(source, contains('NotificationManager.IMPORTANCE_HIGH'));
+      expect(source, contains('setTimeoutAfter('));
       expect(source, contains('remove(buildActionResultKey(actionId))'));
+    });
+
+    test('検証用の押下直後通知とToastを残さない', () {
+      final source = File(_itineraryWidgetPath).readAsStringSync();
+
+      expect(source, isNot(contains('showRefreshButtonNotification')));
+      expect(source, isNot(contains('更新ボタンを押しました')));
+      expect(source, isNot(contains('Toast.makeText')));
     });
 
     test('通知用のエラーメッセージをウィジェット内に表示しない', () {

--- a/test/unit/android/itinerary_widget_test.dart
+++ b/test/unit/android/itinerary_widget_test.dart
@@ -10,8 +10,14 @@ void main() {
     test('アクションごとのactionIdをDart背景コールバックへ渡す', () {
       final source = File(_itineraryWidgetPath).readAsStringSync();
 
-      expect(source, contains('appendQueryParameter(ACTION_ID_QUERY_PARAMETER'));
-      expect(source, contains('OneTimeWorkRequestBuilder<HomeWidgetBackgroundWorker>()'));
+      expect(
+        source,
+        contains('appendQueryParameter(ACTION_ID_QUERY_PARAMETER'),
+      );
+      expect(
+        source,
+        contains('OneTimeWorkRequestBuilder<HomeWidgetBackgroundWorker>()'),
+      );
     });
 
     test('Dart背景コールバックの結果をToast表示して結果データを削除する', () {

--- a/test/unit/android/itinerary_widget_test.dart
+++ b/test/unit/android/itinerary_widget_test.dart
@@ -20,23 +20,19 @@ void main() {
       );
     });
 
-    test('Dart背景コールバックの結果を通常重要度の通知で表示して結果データを削除する', () {
+    test('Dart背景コールバックの結果をToastで表示して結果データを削除する', () {
       final source = File(_itineraryWidgetPath).readAsStringSync();
 
-      expect(source, contains('Notification.Builder'));
-      expect(source, contains('NotificationManager.IMPORTANCE_DEFAULT'));
-      expect(source, isNot(contains('NotificationManager.IMPORTANCE_HIGH')));
-      expect(source, isNot(contains('Notification.PRIORITY_HIGH')));
-      expect(source, contains('setTimeoutAfter('));
+      expect(source, contains('Toast.makeText'));
+      expect(source, contains('withContext(Dispatchers.Main)'));
       expect(source, contains('remove(buildActionResultKey(actionId))'));
     });
 
-    test('検証用の押下直後通知とToastを残さない', () {
+    test('検証用の押下直後通知を残さない', () {
       final source = File(_itineraryWidgetPath).readAsStringSync();
 
       expect(source, isNot(contains('showRefreshButtonNotification')));
       expect(source, isNot(contains('更新ボタンを押しました')));
-      expect(source, isNot(contains('Toast.makeText')));
     });
 
     test('通知用のエラーメッセージをウィジェット内に表示しない', () {

--- a/test/unit/android/itinerary_widget_test.dart
+++ b/test/unit/android/itinerary_widget_test.dart
@@ -1,0 +1,32 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+const _itineraryWidgetPath =
+    'android/app/src/main/kotlin/com/example/memora/ItineraryWidget.kt';
+
+void main() {
+  group('ItineraryWidget', () {
+    test('アクションごとのactionIdをDart背景コールバックへ渡す', () {
+      final source = File(_itineraryWidgetPath).readAsStringSync();
+
+      expect(source, contains('appendQueryParameter(ACTION_ID_QUERY_PARAMETER'));
+      expect(source, contains('OneTimeWorkRequestBuilder<HomeWidgetBackgroundWorker>()'));
+    });
+
+    test('Dart背景コールバックの結果をToast表示して結果データを削除する', () {
+      final source = File(_itineraryWidgetPath).readAsStringSync();
+
+      expect(source, contains('Toast.makeText(context.applicationContext'));
+      expect(source, contains('Toast.LENGTH_SHORT'));
+      expect(source, contains('remove(buildActionResultKey(actionId))'));
+    });
+
+    test('通知用のエラーメッセージをウィジェット内に表示しない', () {
+      final source = File(_itineraryWidgetPath).readAsStringSync();
+
+      expect(source, isNot(contains('ERROR_MESSAGE_KEY')));
+      expect(source, isNot(contains('FooterRow')));
+    });
+  });
+}

--- a/test/unit/android/itinerary_widget_test.dart
+++ b/test/unit/android/itinerary_widget_test.dart
@@ -20,11 +20,13 @@ void main() {
       );
     });
 
-    test('Dart背景コールバックの結果を画面上通知で表示して結果データを削除する', () {
+    test('Dart背景コールバックの結果を通常重要度の通知で表示して結果データを削除する', () {
       final source = File(_itineraryWidgetPath).readAsStringSync();
 
       expect(source, contains('Notification.Builder'));
-      expect(source, contains('NotificationManager.IMPORTANCE_HIGH'));
+      expect(source, contains('NotificationManager.IMPORTANCE_DEFAULT'));
+      expect(source, isNot(contains('NotificationManager.IMPORTANCE_HIGH')));
+      expect(source, isNot(contains('Notification.PRIORITY_HIGH')));
       expect(source, contains('setTimeoutAfter('));
       expect(source, contains('remove(buildActionResultKey(actionId))'));
     });

--- a/test/unit/android/main_activity_test.dart
+++ b/test/unit/android/main_activity_test.dart
@@ -1,0 +1,18 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+const _mainActivityPath =
+    'android/app/src/main/kotlin/com/example/memora/MainActivity.kt';
+
+void main() {
+  group('MainActivity', () {
+    test('Android 13以降で通知権限を起動時に要求する', () {
+      final source = File(_mainActivityPath).readAsStringSync();
+
+      expect(source, contains('Manifest.permission.POST_NOTIFICATIONS'));
+      expect(source, contains('Build.VERSION_CODES.TIRAMISU'));
+      expect(source, contains('requestPermissions('));
+    });
+  });
+}

--- a/test/unit/application/usecases/android_widget/android_widget_itinerary_cache_usecases_test.dart
+++ b/test/unit/application/usecases/android_widget/android_widget_itinerary_cache_usecases_test.dart
@@ -176,11 +176,6 @@ class _FakeAndroidWidgetCacheStorage implements AndroidWidgetCacheStorage {
   }
 
   @override
-  Future<void> saveErrorMessage(String? message) async {
-    errorMessage = message;
-  }
-
-  @override
   Future<void> saveActionResult(
     String actionId,
     AndroidWidgetActionResult result,

--- a/test/unit/application/usecases/android_widget/android_widget_itinerary_cache_usecases_test.dart
+++ b/test/unit/application/usecases/android_widget/android_widget_itinerary_cache_usecases_test.dart
@@ -14,7 +14,7 @@ import '../../../../helpers/test_exception.dart';
 
 void main() {
   group('RefreshAndroidWidgetItineraryCacheUsecase', () {
-    test('更新に成功した場合はactionIdに成功Notification結果を保存する', () async {
+    test('更新に成功した場合はactionIdに成功Toast結果を保存する', () async {
       final storage = _FakeAndroidWidgetCacheStorage(targetGroupId: 'group-1');
       final tripEntryQueryService = _FakeTripEntryQueryService();
       final itineraryItemQueryService = _FakeItineraryItemQueryService();
@@ -29,7 +29,7 @@ void main() {
       expect(
         storage.actionResults['action-1'],
         const AndroidWidgetActionResult(
-          notificationType: AndroidWidgetNotificationType.notification,
+          notificationType: AndroidWidgetNotificationType.toast,
           message: '更新しました。',
           isSuccess: true,
         ),
@@ -37,7 +37,7 @@ void main() {
       expect(storage.errorMessage, isNull);
     });
 
-    test('更新に失敗した場合はactionIdに失敗Notification結果を保存する', () async {
+    test('更新に失敗した場合はactionIdに失敗Toast結果を保存する', () async {
       final storage = _FakeAndroidWidgetCacheStorage(targetGroupId: 'group-1');
       final tripEntryQueryService = _FakeTripEntryQueryService()
         ..exception = TestException('取得失敗');
@@ -56,7 +56,7 @@ void main() {
       expect(
         storage.actionResults['action-1'],
         const AndroidWidgetActionResult(
-          notificationType: AndroidWidgetNotificationType.notification,
+          notificationType: AndroidWidgetNotificationType.toast,
           message: '更新に失敗しました',
           isSuccess: false,
         ),
@@ -111,7 +111,7 @@ void main() {
       expect(
         storage.actionResults['action-1'],
         const AndroidWidgetActionResult(
-          notificationType: AndroidWidgetNotificationType.notification,
+          notificationType: AndroidWidgetNotificationType.toast,
           message: '切り替えに失敗しました',
           isSuccess: false,
         ),

--- a/test/unit/application/usecases/android_widget/android_widget_itinerary_cache_usecases_test.dart
+++ b/test/unit/application/usecases/android_widget/android_widget_itinerary_cache_usecases_test.dart
@@ -13,6 +13,58 @@ import 'package:memora/core/time/app_clock.dart';
 import '../../../../helpers/test_exception.dart';
 
 void main() {
+  group('RefreshAndroidWidgetItineraryCacheUsecase', () {
+    test('更新に成功した場合はactionIdに成功Toast結果を保存する', () async {
+      final storage = _FakeAndroidWidgetCacheStorage(targetGroupId: 'group-1');
+      final tripEntryQueryService = _FakeTripEntryQueryService();
+      final itineraryItemQueryService = _FakeItineraryItemQueryService();
+      final usecase = _buildRefreshUsecase(
+        storage,
+        tripEntryQueryService,
+        itineraryItemQueryService,
+      );
+
+      await usecase.execute(groupId: 'group-1', actionId: 'action-1');
+
+      expect(
+        storage.actionResults['action-1'],
+        const AndroidWidgetActionResult(
+          notificationType: AndroidWidgetNotificationType.toast,
+          message: '更新しました。',
+          isSuccess: true,
+        ),
+      );
+      expect(storage.errorMessage, isNull);
+    });
+
+    test('更新に失敗した場合はactionIdに失敗Toast結果を保存する', () async {
+      final storage = _FakeAndroidWidgetCacheStorage(targetGroupId: 'group-1');
+      final tripEntryQueryService = _FakeTripEntryQueryService()
+        ..exception = TestException('取得失敗');
+      final itineraryItemQueryService = _FakeItineraryItemQueryService();
+      final usecase = _buildRefreshUsecase(
+        storage,
+        tripEntryQueryService,
+        itineraryItemQueryService,
+      );
+
+      await expectLater(
+        usecase.execute(groupId: 'group-1', actionId: 'action-1'),
+        throwsA(isA<TestException>()),
+      );
+
+      expect(
+        storage.actionResults['action-1'],
+        const AndroidWidgetActionResult(
+          notificationType: AndroidWidgetNotificationType.toast,
+          message: '更新に失敗しました',
+          isSuccess: false,
+        ),
+      );
+      expect(storage.errorMessage, isNull);
+    });
+  });
+
   group('MoveAndroidWidgetSelectedItineraryDateUsecase', () {
     test('リモート探索で失敗した場合はエラーを保存してウィジェットを更新する', () async {
       final storage = _FakeAndroidWidgetCacheStorage(
@@ -49,11 +101,22 @@ void main() {
       );
 
       await expectLater(
-        usecase.execute(AndroidWidgetItineraryDateMoveDirection.next),
+        usecase.execute(
+          AndroidWidgetItineraryDateMoveDirection.next,
+          actionId: 'action-1',
+        ),
         completes,
       );
 
-      expect(storage.errorMessage, '切り替えに失敗しました');
+      expect(
+        storage.actionResults['action-1'],
+        const AndroidWidgetActionResult(
+          notificationType: AndroidWidgetNotificationType.toast,
+          message: '切り替えに失敗しました',
+          isSuccess: false,
+        ),
+      );
+      expect(storage.errorMessage, isNull);
       expect(storage.updateWidgetCount, 1);
     });
   });
@@ -75,12 +138,13 @@ RefreshAndroidWidgetItineraryCacheUsecase _buildRefreshUsecase(
 }
 
 class _FakeAndroidWidgetCacheStorage implements AndroidWidgetCacheStorage {
-  _FakeAndroidWidgetCacheStorage({this.cache});
+  _FakeAndroidWidgetCacheStorage({this.cache, this.targetGroupId});
 
   AndroidWidgetItineraryCacheDto? cache;
   String? targetGroupId;
   String? selectedItineraryDateId;
   String? errorMessage;
+  final actionResults = <String, AndroidWidgetActionResult>{};
   int updateWidgetCount = 0;
 
   @override
@@ -114,6 +178,14 @@ class _FakeAndroidWidgetCacheStorage implements AndroidWidgetCacheStorage {
   @override
   Future<void> saveErrorMessage(String? message) async {
     errorMessage = message;
+  }
+
+  @override
+  Future<void> saveActionResult(
+    String actionId,
+    AndroidWidgetActionResult result,
+  ) async {
+    actionResults[actionId] = result;
   }
 
   @override

--- a/test/unit/application/usecases/android_widget/android_widget_itinerary_cache_usecases_test.dart
+++ b/test/unit/application/usecases/android_widget/android_widget_itinerary_cache_usecases_test.dart
@@ -14,7 +14,7 @@ import '../../../../helpers/test_exception.dart';
 
 void main() {
   group('RefreshAndroidWidgetItineraryCacheUsecase', () {
-    test('更新に成功した場合はactionIdに成功Toast結果を保存する', () async {
+    test('更新に成功した場合はactionIdに成功Notification結果を保存する', () async {
       final storage = _FakeAndroidWidgetCacheStorage(targetGroupId: 'group-1');
       final tripEntryQueryService = _FakeTripEntryQueryService();
       final itineraryItemQueryService = _FakeItineraryItemQueryService();
@@ -29,7 +29,7 @@ void main() {
       expect(
         storage.actionResults['action-1'],
         const AndroidWidgetActionResult(
-          notificationType: AndroidWidgetNotificationType.toast,
+          notificationType: AndroidWidgetNotificationType.notification,
           message: '更新しました。',
           isSuccess: true,
         ),
@@ -37,7 +37,7 @@ void main() {
       expect(storage.errorMessage, isNull);
     });
 
-    test('更新に失敗した場合はactionIdに失敗Toast結果を保存する', () async {
+    test('更新に失敗した場合はactionIdに失敗Notification結果を保存する', () async {
       final storage = _FakeAndroidWidgetCacheStorage(targetGroupId: 'group-1');
       final tripEntryQueryService = _FakeTripEntryQueryService()
         ..exception = TestException('取得失敗');
@@ -56,7 +56,7 @@ void main() {
       expect(
         storage.actionResults['action-1'],
         const AndroidWidgetActionResult(
-          notificationType: AndroidWidgetNotificationType.toast,
+          notificationType: AndroidWidgetNotificationType.notification,
           message: '更新に失敗しました',
           isSuccess: false,
         ),
@@ -111,7 +111,7 @@ void main() {
       expect(
         storage.actionResults['action-1'],
         const AndroidWidgetActionResult(
-          notificationType: AndroidWidgetNotificationType.toast,
+          notificationType: AndroidWidgetNotificationType.notification,
           message: '切り替えに失敗しました',
           isSuccess: false,
         ),

--- a/test/unit/presentation/app/top_page_test.dart
+++ b/test/unit/presentation/app/top_page_test.dart
@@ -100,10 +100,13 @@ class _FakeAndroidWidgetCacheStorage implements AndroidWidgetCacheStorage {
   }
 
   @override
-  Future<void> saveErrorMessage(String? message) async {}
+  Future<void> saveItineraryCache(AndroidWidgetItineraryCacheDto cache) async {}
 
   @override
-  Future<void> saveItineraryCache(AndroidWidgetItineraryCacheDto cache) async {}
+  Future<void> saveActionResult(
+    String actionId,
+    AndroidWidgetActionResult result,
+  ) async {}
 
   @override
   Future<void> saveSelectedItineraryDateId(String? itineraryDateId) async {}

--- a/test/unit/presentation/features/setting/settings_test.dart
+++ b/test/unit/presentation/features/setting/settings_test.dart
@@ -228,13 +228,16 @@ class _FakeAndroidWidgetCacheStorage implements AndroidWidgetCacheStorage {
   }
 
   @override
-  Future<void> saveErrorMessage(String? message) async {}
-
-  @override
   Future<void> saveItineraryCache(AndroidWidgetItineraryCacheDto cache) async {
     this.cache = cache;
     selectedItineraryDateId = cache.selectedItineraryDateId;
   }
+
+  @override
+  Future<void> saveActionResult(
+    String actionId,
+    AndroidWidgetActionResult result,
+  ) async {}
 
   @override
   Future<void> saveSelectedItineraryDateId(String? itineraryDateId) async {


### PR DESCRIPTION
## 概要
- Androidウィジェットの更新・前後切り替えアクションに一意な`actionId`を付与し、Dart背景コールバックへ渡すようにしました。
- Dart側でアクション結果（通知種別・メッセージ・成功/失敗）をHomeWidget共有データへ保存し、Android側で結果を待ってToast表示するようにしました。
- `ERROR_MESSAGE_KEY`、`FooterRow`、`saveErrorMessage`によるウィジェット内エラー表示を廃止しました。

## 完了したtodo
- Androidウィジェットの通知表示をToastに移行する

## 検証
- `flutter test test/unit/application/usecases/android_widget/android_widget_itinerary_cache_usecases_test.dart test/unit/android/itinerary_widget_test.dart`
- `./gradlew :app:compileDebugKotlin`
- `./check.sh`