### PR TITLE
fix(android-widget): WorkManagerへ失敗を返すように変更

### DIFF
--- a/lib/application/usecases/android_widget/android_widget_background_update.dart
+++ b/lib/application/usecases/android_widget/android_widget_background_update.dart
@@ -45,12 +45,11 @@ void androidWidgetBackgroundUpdateDispatcher() {
       return true;
     }
     WidgetsFlutterBinding.ensureInitialized();
-    await _refreshAndroidWidgetFromBackground();
-    return true;
+    return await _refreshAndroidWidgetFromBackground();
   });
 }
 
-Future<void> _refreshAndroidWidgetFromBackground() async {
+Future<bool> _refreshAndroidWidgetFromBackground() async {
   if (Firebase.apps.isEmpty) {
     await Firebase.initializeApp(
       options: DefaultFirebaseOptions.currentPlatform,
@@ -64,7 +63,7 @@ Future<void> _refreshAndroidWidgetFromBackground() async {
   final groupId = await storage.getTargetGroupId();
   if (groupId == null) {
     await storage.updateWidget();
-    return;
+    return true;
   }
 
   final clock = NtpSynchronizedAppClock();
@@ -90,7 +89,9 @@ Future<void> _refreshAndroidWidgetFromBackground() async {
   } catch (_) {
     await storage.updateWidget();
     await _showUpdateFailedToast();
+    return false;
   }
+  return true;
 }
 
 Future<void> _showUpdateFailedToast() async {

--- a/test/unit/android/android_widget_periodic_update_test.dart
+++ b/test/unit/android/android_widget_periodic_update_test.dart
@@ -29,6 +29,20 @@ void main() {
       expect(source, contains('memora_android_widget_periodic_update'));
     });
 
+    test('バックグラウンド更新失敗時はWorkManagerへ失敗を返す', () {
+      final source = File(_backgroundUpdatePath).readAsStringSync();
+
+      expect(
+        source,
+        contains('Future<bool> _refreshAndroidWidgetFromBackground()'),
+      );
+      expect(
+        source,
+        contains('return await _refreshAndroidWidgetFromBackground();'),
+      );
+      expect(source, contains('return false;'));
+    });
+
     test('アプリ起動時に定期更新を初期化する', () {
       final source = File(_mainPath).readAsStringSync();
 


### PR DESCRIPTION
### Motivation
- バックグラウンドでのウィジェット更新が例外時に常に成功扱いになっており、WorkManagerの再試行が発生しないため修正する目的です。 

### Description
- `androidWidgetBackgroundUpdateDispatcher` が `_refreshAndroidWidgetFromBackground()` の戻り値をそのまま返すように変更しました（`return await _refreshAndroidWidgetFromBackground();`）。
- `_refreshAndroidWidgetFromBackground()` のシグネチャを `Future<void>` から `Future<bool>` に変更し、成功時に `true`、例外発生時はウィジェット更新と失敗トースト表示の後に `false` を返すようにしました。 
- 上記仕様を検証するユニットテストを `test/unit/android/android_widget_periodic_update_test.dart` に追加しました（更新失敗時に `false` を返すことを検証）。

### Testing
- `flutter test test/unit/android/android_widget_periodic_update_test.dart` を実行し、追加したテストを含めてテストは通過しました。 
- `./check.sh` のフォーマット段階は成功しましたが、`./check.sh` に含まれる `build_runner` 実行が長時間を要したためフル実行はセッション内で完了できませんでした。 
- 追加した単体テストはローカル実行で合格しており、CI上でも同様に通ることを想定しています。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32987d7d288332b45376806a645978)