### PR TITLE
fix(android-widget): 初期サイズを4×3に変更

### DIFF
--- a/android/app/src/main/res/xml/itinerary_widget_info.xml
+++ b/android/app/src/main/res/xml/itinerary_widget_info.xml
@@ -3,7 +3,7 @@
     android:description="@string/itinerary_widget_description"
     android:initialLayout="@layout/itinerary_widget_loading"
     android:minWidth="250dp"
-    android:minHeight="140dp"
+    android:minHeight="180dp"
     android:previewLayout="@layout/itinerary_widget_loading"
     android:resizeMode="horizontal|vertical"
     android:targetCellWidth="4"

--- a/android/app/src/main/res/xml/itinerary_widget_info.xml
+++ b/android/app/src/main/res/xml/itinerary_widget_info.xml
@@ -7,6 +7,6 @@
     android:previewLayout="@layout/itinerary_widget_loading"
     android:resizeMode="horizontal|vertical"
     android:targetCellWidth="4"
-    android:targetCellHeight="2"
+    android:targetCellHeight="3"
     android:updatePeriodMillis="0"
     android:widgetCategory="home_screen" />

--- a/test/unit/android/android_widget_size_test.dart
+++ b/test/unit/android/android_widget_size_test.dart
@@ -1,0 +1,15 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+const _widgetInfoPath =
+    'android/app/src/main/res/xml/itinerary_widget_info.xml';
+
+void main() {
+  test('Androidウィジェットの初期サイズを4×3にする', () {
+    final source = File(_widgetInfoPath).readAsStringSync();
+
+    expect(source, contains('android:targetCellWidth="4"'));
+    expect(source, contains('android:targetCellHeight="3"'));
+  });
+}

--- a/test/unit/android/android_widget_size_test.dart
+++ b/test/unit/android/android_widget_size_test.dart
@@ -16,5 +16,6 @@ void main() {
     final source = File(_widgetInfoPath).readAsStringSync();
 
     expect(source, contains('android:targetCellHeight="3"'));
+    expect(source, contains('android:minHeight="180dp"'));
   });
 }

--- a/test/unit/android/android_widget_size_test.dart
+++ b/test/unit/android/android_widget_size_test.dart
@@ -6,10 +6,15 @@ const _widgetInfoPath =
     'android/app/src/main/res/xml/itinerary_widget_info.xml';
 
 void main() {
-  test('Androidウィジェットの初期サイズを4×3にする', () {
+  test('Androidウィジェットの初期幅を4セルにする', () {
     final source = File(_widgetInfoPath).readAsStringSync();
 
     expect(source, contains('android:targetCellWidth="4"'));
+  });
+
+  test('Androidウィジェットの初期高さを3セルにする', () {
+    final source = File(_widgetInfoPath).readAsStringSync();
+
     expect(source, contains('android:targetCellHeight="3"'));
   });
 }

--- a/test/unit/android/android_widget_size_test.dart
+++ b/test/unit/android/android_widget_size_test.dart
@@ -6,15 +6,13 @@ const _widgetInfoPath =
     'android/app/src/main/res/xml/itinerary_widget_info.xml';
 
 void main() {
-  test('Androidウィジェットの初期幅を4セルにする', () {
-    final source = File(_widgetInfoPath).readAsStringSync();
+  final source = File(_widgetInfoPath).readAsStringSync();
 
+  test('Androidウィジェットの初期幅を4セルにする', () {
     expect(source, contains('android:targetCellWidth="4"'));
   });
 
   test('Androidウィジェットの初期高さを3セルにする', () {
-    final source = File(_widgetInfoPath).readAsStringSync();
-
     expect(source, contains('android:targetCellHeight="3"'));
     expect(source, contains('android:minHeight="180dp"'));
   });


### PR DESCRIPTION
## 概要

Androidホーム画面ウィジェットの初期サイズを4×3セルへ変更します。

## 変更内容

- `targetCellHeight`を2から3へ変更
- 初期幅4セル・初期高さ3セルを検証する回帰テストを追加

## 変更理由

Androidウィジェット追加時の初期表示領域を4×3セルにするためです。

## 検証

- `./check.sh`