### PR TITLE
feat(android-widget): ウィジェットタップで旅行編集を開く

### DIFF
--- a/android/app/src/main/kotlin/com/example/memora/ItineraryWidget.kt
+++ b/android/app/src/main/kotlin/com/example/memora/ItineraryWidget.kt
@@ -41,6 +41,7 @@ import es.antonborri.home_widget.HomeWidgetGlanceWidgetReceiver
 import es.antonborri.home_widget.HomeWidgetGlanceState
 import es.antonborri.home_widget.HomeWidgetGlanceStateDefinition
 import es.antonborri.home_widget.HomeWidgetPlugin
+import es.antonborri.home_widget.actionStartActivity
 import java.io.File
 import org.json.JSONArray
 import org.json.JSONObject
@@ -98,7 +99,7 @@ private fun ItineraryWidgetContent(
             when {
                 targetGroupId.isEmpty() -> EmptyMessage("表示対象グループが未設定です")
                 selectedItineraryDate == null -> EmptyMessage("表示できる旅程がありません")
-                else -> ItineraryDateContent(selectedItineraryDate)
+                else -> ItineraryDateContent(context, selectedItineraryDate)
             }
         }
         HeaderRow(cache?.lastUpdatedAt)
@@ -156,7 +157,10 @@ private fun RefreshIcon() {
 }
 
 @Composable
-private fun ItineraryDateContent(itineraryDate: WidgetItineraryDate) {
+private fun ItineraryDateContent(
+    context: Context,
+    itineraryDate: WidgetItineraryDate,
+) {
     Box(
         modifier = GlanceModifier
             .fillMaxWidth()
@@ -172,7 +176,7 @@ private fun ItineraryDateContent(itineraryDate: WidgetItineraryDate) {
             modifier = GlanceModifier.fillMaxSize(),
             contentAlignment = Alignment.Center,
         ) {
-            TripHeader(itineraryDate)
+            TripHeader(context, itineraryDate)
         }
         Box(
             modifier = GlanceModifier.fillMaxSize(),
@@ -209,9 +213,21 @@ private fun ItineraryList(items: List<WidgetItineraryItem>) {
 }
 
 @Composable
-private fun TripHeader(itineraryDate: WidgetItineraryDate) {
+private fun TripHeader(
+    context: Context,
+    itineraryDate: WidgetItineraryDate,
+) {
     Column(
-        modifier = GlanceModifier.width(180.dp),
+        modifier = GlanceModifier
+            .width(180.dp)
+            .clickable(
+                actionStartActivity<MainActivity>(
+                    context,
+                    Uri.parse(
+                        "memoraWidget://openTrip?tripId=${Uri.encode(itineraryDate.tripId)}",
+                    ),
+                ),
+            ),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Text(
@@ -399,6 +415,7 @@ private fun JSONArray?.toItineraryDates(): List<WidgetItineraryDate> {
             add(
                 WidgetItineraryDate(
                     id = itineraryDate.optString("id"),
+                    tripId = itineraryDate.optString("tripId"),
                     tripName = itineraryDate.optString("tripName"),
                     tripPeriodLabel = itineraryDate.optString("tripPeriodLabel"),
                     dateLabel = itineraryDate.optString("dateLabel"),
@@ -441,6 +458,7 @@ private data class WidgetCache(
 
 private data class WidgetItineraryDate(
     val id: String,
+    val tripId: String,
     val tripName: String,
     val tripPeriodLabel: String,
     val dateLabel: String,

--- a/android/app/src/main/kotlin/com/example/memora/ItineraryWidget.kt
+++ b/android/app/src/main/kotlin/com/example/memora/ItineraryWidget.kt
@@ -196,13 +196,18 @@ private fun ItineraryDateContent(
         return
     }
 
-    ItineraryList(itineraryDate.items)
+    ItineraryList(context, itineraryDate)
 }
 
 @Composable
-private fun ItineraryList(items: List<WidgetItineraryItem>) {
+private fun ItineraryList(
+    context: Context,
+    itineraryDate: WidgetItineraryDate,
+) {
+    val tripId = itineraryDate.tripId
+    val items = itineraryDate.items
     val listEntries = buildItineraryListEntries(items)
-    LazyColumn(modifier = GlanceModifier.fillMaxWidth()) {
+    LazyColumn(modifier = openTripModifier(context, tripId)) {
         items(listEntries) { entry ->
             when (entry) {
                 is WidgetItineraryListEntry.Item -> ItineraryItemRow(entry.item)
@@ -220,14 +225,7 @@ private fun TripHeader(
     Column(
         modifier = GlanceModifier
             .width(180.dp)
-            .clickable(
-                actionStartActivity<MainActivity>(
-                    context,
-                    Uri.parse(
-                        "memoraWidget://openTrip?tripId=${Uri.encode(itineraryDate.tripId)}",
-                    ),
-                ),
-            ),
+            .clickable(openTripAction(context, itineraryDate.tripId)),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Text(
@@ -242,6 +240,21 @@ private fun TripHeader(
         )
     }
 }
+
+private fun openTripModifier(
+    context: Context,
+    tripId: String,
+) = GlanceModifier
+    .fillMaxWidth()
+    .clickable(openTripAction(context, tripId))
+
+private fun openTripAction(
+    context: Context,
+    tripId: String,
+) = actionStartActivity<MainActivity>(
+    context,
+    Uri.parse("memoraWidget://openTrip?tripId=${Uri.encode(tripId)}"),
+)
 
 @Composable
 private fun ItineraryItemRow(item: WidgetItineraryItem) {

--- a/android/app/src/main/kotlin/com/example/memora/ItineraryWidget.kt
+++ b/android/app/src/main/kotlin/com/example/memora/ItineraryWidget.kt
@@ -207,11 +207,13 @@ private fun ItineraryList(
     val tripId = itineraryDate.tripId
     val items = itineraryDate.items
     val listEntries = buildItineraryListEntries(items)
-    LazyColumn(modifier = openTripModifier(context, tripId)) {
+    LazyColumn(modifier = GlanceModifier.fillMaxWidth()) {
         items(listEntries) { entry ->
-            when (entry) {
-                is WidgetItineraryListEntry.Item -> ItineraryItemRow(entry.item)
-                WidgetItineraryListEntry.Divider -> ItineraryDivider()
+            Box(modifier = openTripModifier(context, tripId)) {
+                when (entry) {
+                    is WidgetItineraryListEntry.Item -> ItineraryItemRow(entry.item)
+                    WidgetItineraryListEntry.Divider -> ItineraryDivider()
+                }
             }
         }
     }

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -22,19 +22,6 @@
 
 ## Androidウィジェット
 
-- ウィジェットタップでアプリを開くようにする
-  - Kotlin側の`WidgetItineraryDate`でキャッシュJSONの`tripId`を読み込む
-  - Glanceの旅程ヘッダーまたは旅程表示領域に`actionStartActivity<MainActivity>`を設定し、`memoraWidget://openTrip?tripId=...`形式のURIを渡す
-  - Flutter側で`HomeWidget.initiallyLaunchedFromHomeWidget()`と`HomeWidget.widgetClicked`を購読し、起動時と起動済みの両方でURIを受け取る
-  - 受け取ったURIは専用Notifierに保留し、認証完了と`currentMember`読み込み完了後に処理する
-  - `tripId`から`GetTripEntryByIdUsecase`で旅行詳細を取得し、取得できた`groupId`と`year`でグループ年表の旅行管理画面へ遷移する
-  - `GroupTimelineTripManagementDestination`または`TripManagement`に初期編集対象`tripId`を渡せる口を追加する
-  - `TripManagement`は旅行一覧とグループメンバー読み込み後、初期編集対象`tripId`の詳細を取得して`TripEditModal`を一度だけ開く
-  - ウィジェット経由で開いた場合も、編集モーダルの親画面は対象旅行を含む年の旅行管理画面にする
-  - 編集モーダルで保存、キャンセル、または破棄確認後に閉じた場合は、対象年の旅行管理画面に戻る
-  - 旅行管理画面の戻る操作では対象グループの年表画面に戻り、以降は通常の年表ナビゲーションに従う
-  - 未ログイン時はログイン後に保留URIを再処理し、対象旅行が取得できない場合はSnackBarで通知して通常のグループ年表へ戻す
-  - 同じURIを複数回処理しないよう、処理済み`tripId`またはURIをNotifier側でクリアする
 
 ## グループ年表画面
 

--- a/lib/application/services/android_widget_launch_uri_source.dart
+++ b/lib/application/services/android_widget_launch_uri_source.dart
@@ -1,0 +1,5 @@
+abstract interface class AndroidWidgetLaunchUriSource {
+  Future<Uri?> getInitialUri();
+
+  Stream<Uri?> get clickedUris;
+}

--- a/lib/application/usecases/android_widget/watch_android_widget_launch_uri_usecase.dart
+++ b/lib/application/usecases/android_widget/watch_android_widget_launch_uri_usecase.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:memora/application/services/android_widget_launch_uri_source.dart';
+import 'package:memora/infrastructure/services/home_widget_android_widget_launch_uri_source.dart';
+
+final watchAndroidWidgetLaunchUriUsecaseProvider =
+    Provider<WatchAndroidWidgetLaunchUriUsecase>((ref) {
+      return const WatchAndroidWidgetLaunchUriUsecase(
+        HomeWidgetAndroidWidgetLaunchUriSource(),
+      );
+    });
+
+class WatchAndroidWidgetLaunchUriUsecase {
+  const WatchAndroidWidgetLaunchUriUsecase(this._source);
+
+  final AndroidWidgetLaunchUriSource _source;
+
+  Future<Uri?> getInitialUri() {
+    return _source.getInitialUri();
+  }
+
+  Stream<Uri?> get clickedUris => _source.clickedUris;
+}

--- a/lib/infrastructure/services/home_widget_android_widget_launch_uri_source.dart
+++ b/lib/infrastructure/services/home_widget_android_widget_launch_uri_source.dart
@@ -1,0 +1,15 @@
+import 'package:home_widget/home_widget.dart';
+import 'package:memora/application/services/android_widget_launch_uri_source.dart';
+
+class HomeWidgetAndroidWidgetLaunchUriSource
+    implements AndroidWidgetLaunchUriSource {
+  const HomeWidgetAndroidWidgetLaunchUriSource();
+
+  @override
+  Stream<Uri?> get clickedUris => HomeWidget.widgetClicked;
+
+  @override
+  Future<Uri?> getInitialUri() {
+    return HomeWidget.initiallyLaunchedFromHomeWidget();
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,6 +11,7 @@ import 'package:memora/infrastructure/services/shared_preferences_android_widget
 import 'package:logger/logger.dart';
 import 'package:memora/core/app_logger.dart';
 import 'package:memora/core/time/app_clock.dart';
+import 'package:memora/presentation/notifiers/android_widget_launch_notifier.dart';
 import 'firebase_options.dart';
 import 'presentation/app/top_page.dart';
 import 'presentation/features/auth/auth_guard.dart';
@@ -106,11 +107,12 @@ class _AppClockLifecycleSyncState extends ConsumerState<AppClockLifecycleSync>
   }
 }
 
-class MyApp extends StatelessWidget {
+class MyApp extends ConsumerWidget {
   const MyApp({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.watch(androidWidgetLaunchNotifierProvider);
     return MaterialApp(
       title: 'memora',
       theme: ThemeData(

--- a/lib/presentation/app/top_page.dart
+++ b/lib/presentation/app/top_page.dart
@@ -190,7 +190,10 @@ class TopPage extends HookConsumerWidget {
       final timelineNotifier = ref.read(
         groupTimelineNavigationNotifierProvider.notifier,
       );
-      timelineNotifier.showGroupTimeline(group);
+      timelineNotifier.showGroupTimeline(
+        group,
+        clearGroupSelectionLoadFuture: true,
+      );
       timelineNotifier.showTripManagement(
         trip.groupId,
         trip.year,

--- a/lib/presentation/app/top_page.dart
+++ b/lib/presentation/app/top_page.dart
@@ -29,6 +29,7 @@ class TopPage extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final scaffoldKey = useMemoized(GlobalKey<ScaffoldState>.new);
     final isDrawerOpen = useState(false);
+    final isHandlingAndroidWidgetLaunch = useState(false);
 
     useEffect(() {
       WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -46,11 +47,25 @@ class TopPage extends HookConsumerWidget {
 
     final currentMemberState = ref.watch(currentMemberNotifierProvider);
     final currentMember = currentMemberState.member;
-    final pendingAndroidWidgetTripId = ref.watch(
-      androidWidgetLaunchNotifierProvider.select(
-        (state) => state.pendingTripId,
-      ),
+    final androidWidgetLaunchState = ref.watch(
+      androidWidgetLaunchNotifierProvider,
     );
+    final pendingAndroidWidgetTripId = androidWidgetLaunchState.pendingTripId;
+    final shouldHideForAndroidWidgetLaunch =
+        androidWidgetLaunchState.isInitialUriLoading ||
+        pendingAndroidWidgetTripId != null ||
+        isHandlingAndroidWidgetLaunch.value;
+
+    Future<void> handleAndroidWidgetLaunch(MemberDto member) async {
+      isHandlingAndroidWidgetLaunch.value = true;
+      try {
+        await _handleAndroidWidgetLaunch(context, ref, member);
+      } finally {
+        if (context.mounted) {
+          isHandlingAndroidWidgetLaunch.value = false;
+        }
+      }
+    }
 
     useEffect(() {
       if (currentMemberState.status != CurrentMemberStatus.error) {
@@ -77,7 +92,7 @@ class TopPage extends HookConsumerWidget {
         if (!context.mounted) {
           return;
         }
-        unawaited(_handleAndroidWidgetLaunch(context, ref, currentMember));
+        unawaited(handleAndroidWidgetLaunch(currentMember));
       });
       return null;
     }, [pendingAndroidWidgetTripId, currentMember?.id]);
@@ -95,7 +110,8 @@ class TopPage extends HookConsumerWidget {
     useEffect(
       () {
         if (selectedItem != NavigationItem.groupTimeline ||
-            currentMember == null) {
+            currentMember == null ||
+            shouldHideForAndroidWidgetLaunch) {
           return null;
         }
         if (timelineEntryState.groupSelectionLoadFuture != null ||
@@ -118,6 +134,7 @@ class TopPage extends HookConsumerWidget {
       [
         selectedItem,
         currentMember?.id,
+        shouldHideForAndroidWidgetLaunch,
         timelineEntryState.groupSelectionLoadFuture,
         timelineEntryState.groupTimelineInstance,
       ],
@@ -141,7 +158,9 @@ class TopPage extends HookConsumerWidget {
         },
         appBar: _buildAppBar(context),
         drawer: _buildDrawer(context, ref),
-        body: _buildBody(context, ref, currentMember, selectedItem),
+        body: shouldHideForAndroidWidgetLaunch
+            ? const Center(child: CircularProgressIndicator())
+            : _buildBody(context, ref, currentMember, selectedItem),
       ),
     );
   }

--- a/lib/presentation/app/top_page.dart
+++ b/lib/presentation/app/top_page.dart
@@ -4,6 +4,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:memora/application/dtos/member/member_dto.dart';
+import 'package:memora/application/usecases/group/get_groups_with_members_usecase.dart';
+import 'package:memora/application/usecases/trip/get_trip_entry_by_id_usecase.dart';
+import 'package:memora/core/app_logger.dart';
 import 'package:memora/presentation/notifiers/auth_notifier.dart';
 import 'package:memora/presentation/notifiers/navigation_notifier.dart';
 import 'package:memora/presentation/notifiers/group_timeline_navigation_notifier.dart';
@@ -14,6 +17,7 @@ import 'package:memora/presentation/features/member/member_management.dart';
 import 'package:memora/presentation/features/setting/settings.dart';
 import 'package:memora/presentation/features/account_setting/account_settings.dart';
 import 'package:memora/presentation/notifiers/current_member_notifier.dart';
+import 'package:memora/presentation/notifiers/android_widget_launch_notifier.dart';
 import 'package:memora/presentation/shared/group_selection/group_selection_list.dart';
 
 class TopPage extends HookConsumerWidget {
@@ -42,6 +46,11 @@ class TopPage extends HookConsumerWidget {
 
     final currentMemberState = ref.watch(currentMemberNotifierProvider);
     final currentMember = currentMemberState.member;
+    final pendingAndroidWidgetTripId = ref.watch(
+      androidWidgetLaunchNotifierProvider.select(
+        (state) => state.pendingTripId,
+      ),
+    );
 
     useEffect(() {
       if (currentMemberState.status != CurrentMemberStatus.error) {
@@ -59,6 +68,19 @@ class TopPage extends HookConsumerWidget {
       });
       return null;
     }, [currentMemberState.status, currentMemberState.message]);
+
+    useEffect(() {
+      if (pendingAndroidWidgetTripId == null || currentMember == null) {
+        return null;
+      }
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!context.mounted) {
+          return;
+        }
+        unawaited(_handleAndroidWidgetLaunch(context, ref, currentMember));
+      });
+      return null;
+    }, [pendingAndroidWidgetTripId, currentMember?.id]);
 
     final selectedItem = ref.watch(navigationNotifierProvider).selectedItem;
     final timelineEntryState = ref.watch(
@@ -122,6 +144,86 @@ class TopPage extends HookConsumerWidget {
         body: _buildBody(context, ref, currentMember, selectedItem),
       ),
     );
+  }
+
+  Future<void> _handleAndroidWidgetLaunch(
+    BuildContext context,
+    WidgetRef ref,
+    MemberDto currentMember,
+  ) async {
+    final tripId = ref
+        .read(androidWidgetLaunchNotifierProvider.notifier)
+        .takePendingTripId();
+    if (tripId == null) {
+      return;
+    }
+
+    try {
+      final trip = await ref
+          .read(getTripEntryByIdUsecaseProvider)
+          .execute(tripId);
+      if (!context.mounted) {
+        return;
+      }
+      if (trip == null) {
+        await _showAndroidWidgetLaunchFailure(context, ref, currentMember);
+        return;
+      }
+
+      final groups = await ref
+          .read(getGroupsWithMembersUsecaseProvider)
+          .execute(currentMember);
+      if (!context.mounted) {
+        return;
+      }
+      final group = groups
+          .where((group) => group.id == trip.groupId)
+          .firstOrNull;
+      if (group == null) {
+        await _showAndroidWidgetLaunchFailure(context, ref, currentMember);
+        return;
+      }
+
+      ref
+          .read(navigationNotifierProvider.notifier)
+          .selectItem(NavigationItem.groupTimeline);
+      final timelineNotifier = ref.read(
+        groupTimelineNavigationNotifierProvider.notifier,
+      );
+      timelineNotifier.showGroupTimeline(group);
+      timelineNotifier.showTripManagement(
+        trip.groupId,
+        trip.year,
+        initialTripId: trip.id,
+      );
+    } catch (e, stack) {
+      logger.e(
+        'TopPage._handleAndroidWidgetLaunch: ${e.toString()}',
+        error: e,
+        stackTrace: stack,
+      );
+      if (context.mounted) {
+        await _showAndroidWidgetLaunchFailure(context, ref, currentMember);
+      }
+    }
+  }
+
+  Future<void> _showAndroidWidgetLaunchFailure(
+    BuildContext context,
+    WidgetRef ref,
+    MemberDto currentMember,
+  ) async {
+    ref
+        .read(navigationNotifierProvider.notifier)
+        .selectItem(NavigationItem.groupTimeline);
+    await ref
+        .read(groupTimelineNavigationNotifierProvider.notifier)
+        .prepareGroupTimelineEntry(currentMember);
+    if (context.mounted) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('指定された旅行が見つかりませんでした')));
+    }
   }
 
   bool _shouldHandleAndroidBack(WidgetRef ref) {

--- a/lib/presentation/app/top_page.dart
+++ b/lib/presentation/app/top_page.dart
@@ -211,7 +211,7 @@ class TopPage extends HookConsumerWidget {
       );
       timelineNotifier.showGroupTimeline(
         group,
-        clearGroupSelectionLoadFuture: true,
+        groupSelectionLoadFuture: Future<List<GroupDto>>.value(groups),
       );
       timelineNotifier.showTripManagement(
         trip.groupId,

--- a/lib/presentation/features/timeline/trip_row.dart
+++ b/lib/presentation/features/timeline/trip_row.dart
@@ -84,6 +84,7 @@ class _TripManagementDestinationPageDefinition
     return TripManagement(
       groupId: tripDestination.groupId,
       year: tripDestination.year,
+      initialTripId: tripDestination.initialTripId,
       onBackPressed: onBackPressed,
     );
   }

--- a/lib/presentation/features/trip/trip_management.dart
+++ b/lib/presentation/features/trip/trip_management.dart
@@ -48,6 +48,7 @@ class TripManagement extends HookConsumerWidget {
     final isLoading = useState(true);
     final isOpeningInitialTrip = useState(false);
     final initialTripHandled = useRef(false);
+    final initialTripDialogReady = useRef(initialTripId == null);
 
     Future<void> loadTripEntries() async {
       try {
@@ -250,6 +251,7 @@ class TripManagement extends HookConsumerWidget {
 
     useEffect(() {
       initialTripHandled.value = false;
+      initialTripDialogReady.value = initialTripId == null;
       return null;
     }, [groupId, year, initialTripId]);
 
@@ -264,11 +266,13 @@ class TripManagement extends HookConsumerWidget {
           await showEditTripDialog(
             tripId,
             onBeforeShowDialog: () {
+              initialTripDialogReady.value = true;
               isOpeningInitialTrip.value = false;
             },
           );
         } finally {
           if (context.mounted && isOpeningInitialTrip.value) {
+            initialTripDialogReady.value = true;
             isOpeningInitialTrip.value = false;
           }
         }
@@ -438,7 +442,7 @@ class TripManagement extends HookConsumerWidget {
     Widget buildContent() {
       final shouldHideForInitialTrip =
           initialTripId != null &&
-          (!initialTripHandled.value || isOpeningInitialTrip.value);
+          (!initialTripDialogReady.value || isOpeningInitialTrip.value);
       if (isLoading.value || shouldHideForInitialTrip) {
         return buildLoadingState();
       }

--- a/lib/presentation/features/trip/trip_management.dart
+++ b/lib/presentation/features/trip/trip_management.dart
@@ -47,6 +47,7 @@ class TripManagement extends HookConsumerWidget {
     final groupMembers = useState<List<GroupMemberDto>>([]);
     final isLoading = useState(true);
     final isOpeningInitialTrip = useState(false);
+    final isShowingInitialTripDialog = useState(false);
     final initialTripHandled = useRef(false);
     final initialTripDialogReady = useRef(initialTripId == null);
 
@@ -266,14 +267,19 @@ class TripManagement extends HookConsumerWidget {
           await showEditTripDialog(
             tripId,
             onBeforeShowDialog: () {
-              initialTripDialogReady.value = true;
+              isShowingInitialTripDialog.value = true;
               isOpeningInitialTrip.value = false;
             },
           );
         } finally {
-          if (context.mounted && isOpeningInitialTrip.value) {
+          if (context.mounted) {
             initialTripDialogReady.value = true;
-            isOpeningInitialTrip.value = false;
+            if (isShowingInitialTripDialog.value) {
+              isShowingInitialTripDialog.value = false;
+            }
+            if (isOpeningInitialTrip.value) {
+              isOpeningInitialTrip.value = false;
+            }
           }
         }
       }
@@ -439,10 +445,17 @@ class TripManagement extends HookConsumerWidget {
       return const Center(child: CircularProgressIndicator());
     }
 
+    Widget buildInitialTripBackdrop() {
+      return const SizedBox.expand();
+    }
+
     Widget buildContent() {
       final shouldHideForInitialTrip =
           initialTripId != null &&
           (!initialTripDialogReady.value || isOpeningInitialTrip.value);
+      if (shouldHideForInitialTrip && isShowingInitialTripDialog.value) {
+        return buildInitialTripBackdrop();
+      }
       if (isLoading.value || shouldHideForInitialTrip) {
         return buildLoadingState();
       }

--- a/lib/presentation/features/trip/trip_management.dart
+++ b/lib/presentation/features/trip/trip_management.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -44,6 +46,7 @@ class TripManagement extends HookConsumerWidget {
     final tripEntries = useState<List<TripEntryDto>>([]);
     final groupMembers = useState<List<GroupMemberDto>>([]);
     final isLoading = useState(true);
+    final isOpeningInitialTrip = useState(false);
     final initialTripHandled = useRef(false);
 
     Future<void> loadTripEntries() async {
@@ -196,7 +199,10 @@ class TripManagement extends HookConsumerWidget {
       }
     }
 
-    Future<void> showEditTripDialog(String tripId) async {
+    Future<void> showEditTripDialog(
+      String tripId, {
+      VoidCallback? onBeforeShowDialog,
+    }) async {
       final scaffoldMessenger = ScaffoldMessenger.of(context);
 
       try {
@@ -213,6 +219,7 @@ class TripManagement extends HookConsumerWidget {
           return;
         }
 
+        onBeforeShowDialog?.call();
         await showDialog(
           barrierDismissible: false,
           context: context,
@@ -251,10 +258,26 @@ class TripManagement extends HookConsumerWidget {
       if (tripId == null || isLoading.value || initialTripHandled.value) {
         return null;
       }
+      Future<void> showInitialTripDialog() async {
+        isOpeningInitialTrip.value = true;
+        try {
+          await showEditTripDialog(
+            tripId,
+            onBeforeShowDialog: () {
+              isOpeningInitialTrip.value = false;
+            },
+          );
+        } finally {
+          if (context.mounted && isOpeningInitialTrip.value) {
+            isOpeningInitialTrip.value = false;
+          }
+        }
+      }
+
       initialTripHandled.value = true;
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (context.mounted) {
-          showEditTripDialog(tripId);
+          unawaited(showInitialTripDialog());
         }
       });
       return null;
@@ -413,7 +436,10 @@ class TripManagement extends HookConsumerWidget {
     }
 
     Widget buildContent() {
-      if (isLoading.value) {
+      final shouldHideForInitialTrip =
+          initialTripId != null &&
+          (!initialTripHandled.value || isOpeningInitialTrip.value);
+      if (isLoading.value || shouldHideForInitialTrip) {
         return buildLoadingState();
       }
 

--- a/lib/presentation/features/trip/trip_management.dart
+++ b/lib/presentation/features/trip/trip_management.dart
@@ -17,6 +17,7 @@ import 'package:memora/presentation/shared/dialogs/delete_confirm_dialog.dart';
 class TripManagement extends HookConsumerWidget {
   final String groupId;
   final int year;
+  final String? initialTripId;
   final VoidCallback? onBackPressed;
   final bool isTestEnvironment;
 
@@ -24,6 +25,7 @@ class TripManagement extends HookConsumerWidget {
     super.key,
     required this.groupId,
     required this.year,
+    this.initialTripId,
     this.onBackPressed,
     this.isTestEnvironment = false,
   });
@@ -42,6 +44,7 @@ class TripManagement extends HookConsumerWidget {
     final tripEntries = useState<List<TripEntryDto>>([]);
     final groupMembers = useState<List<GroupMemberDto>>([]);
     final isLoading = useState(true);
+    final initialTripHandled = useRef(false);
 
     Future<void> loadTripEntries() async {
       try {
@@ -193,13 +196,11 @@ class TripManagement extends HookConsumerWidget {
       }
     }
 
-    Future<void> showEditTripDialog(TripEntryDto tripEntry) async {
+    Future<void> showEditTripDialog(String tripId) async {
       final scaffoldMessenger = ScaffoldMessenger.of(context);
 
       try {
-        final detailedTripEntry = await getTripEntryByIdUsecase.execute(
-          tripEntry.id,
-        );
+        final detailedTripEntry = await getTripEntryByIdUsecase.execute(tripId);
 
         if (!context.mounted) {
           return;
@@ -239,6 +240,25 @@ class TripManagement extends HookConsumerWidget {
         }
       }
     }
+
+    useEffect(() {
+      initialTripHandled.value = false;
+      return null;
+    }, [groupId, year, initialTripId]);
+
+    useEffect(() {
+      final tripId = initialTripId;
+      if (tripId == null || isLoading.value || initialTripHandled.value) {
+        return null;
+      }
+      initialTripHandled.value = true;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (context.mounted) {
+          showEditTripDialog(tripId);
+        }
+      });
+      return null;
+    }, [initialTripId, isLoading.value, groupId, year]);
 
     Future<void> deleteTripEntry(TripEntryDto tripEntry) async {
       final scaffoldMessenger = ScaffoldMessenger.of(context);
@@ -371,7 +391,7 @@ class TripManagement extends HookConsumerWidget {
                 icon: const Icon(Icons.delete, color: Colors.red),
                 onPressed: () => showDeleteConfirmDialog(tripEntry),
               ),
-              onTap: () => showEditTripDialog(tripEntry),
+              onTap: () => showEditTripDialog(tripEntry.id),
             ),
           );
         },

--- a/lib/presentation/notifiers/android_widget_launch_notifier.dart
+++ b/lib/presentation/notifiers/android_widget_launch_notifier.dart
@@ -20,6 +20,10 @@ final androidWidgetLaunchNotifierProvider =
     );
 
 class AndroidWidgetLaunchNotifier extends Notifier<AndroidWidgetLaunchState> {
+  static const _launchScheme = 'memorawidget';
+  static const _openTripHost = 'opentrip';
+  static const _tripIdQueryParameter = 'tripId';
+
   StreamSubscription<Uri?>? _subscription;
 
   @override
@@ -76,11 +80,11 @@ class AndroidWidgetLaunchNotifier extends Notifier<AndroidWidgetLaunchState> {
 
   String? _extractTripId(Uri? uri) {
     if (uri == null ||
-        uri.scheme.toLowerCase() != 'memorawidget' ||
-        uri.host.toLowerCase() != 'opentrip') {
+        uri.scheme.toLowerCase() != _launchScheme ||
+        uri.host.toLowerCase() != _openTripHost) {
       return null;
     }
-    final tripId = uri.queryParameters['tripId']?.trim();
+    final tripId = uri.queryParameters[_tripIdQueryParameter]?.trim();
     return tripId == null || tripId.isEmpty ? null : tripId;
   }
 }

--- a/lib/presentation/notifiers/android_widget_launch_notifier.dart
+++ b/lib/presentation/notifiers/android_widget_launch_notifier.dart
@@ -6,12 +6,29 @@ import 'package:memora/application/usecases/android_widget/watch_android_widget_
 import 'package:memora/core/app_logger.dart';
 
 class AndroidWidgetLaunchState extends Equatable {
-  const AndroidWidgetLaunchState({this.pendingTripId});
+  const AndroidWidgetLaunchState({
+    this.pendingTripId,
+    this.isInitialUriLoading = false,
+  });
 
   final String? pendingTripId;
+  final bool isInitialUriLoading;
 
   @override
-  List<Object?> get props => [pendingTripId];
+  List<Object?> get props => [pendingTripId, isInitialUriLoading];
+
+  AndroidWidgetLaunchState copyWith({
+    String? pendingTripId,
+    bool? isInitialUriLoading,
+    bool clearPendingTripId = false,
+  }) {
+    return AndroidWidgetLaunchState(
+      pendingTripId: clearPendingTripId
+          ? null
+          : (pendingTripId ?? this.pendingTripId),
+      isInitialUriLoading: isInitialUriLoading ?? this.isInitialUriLoading,
+    );
+  }
 }
 
 final androidWidgetLaunchNotifierProvider =
@@ -44,20 +61,22 @@ class AndroidWidgetLaunchNotifier extends Notifier<AndroidWidgetLaunchState> {
       _subscription = null;
     });
     unawaited(_loadInitialUri(usecase));
-    return const AndroidWidgetLaunchState();
+    return const AndroidWidgetLaunchState(isInitialUriLoading: true);
   }
 
   Future<void> _loadInitialUri(
     WatchAndroidWidgetLaunchUriUsecase usecase,
   ) async {
     try {
-      _receiveUri(await usecase.getInitialUri());
+      final tripId = _extractTripId(await usecase.getInitialUri());
+      state = state.copyWith(pendingTripId: tripId, isInitialUriLoading: false);
     } catch (e, stack) {
       logger.e(
         'AndroidWidgetLaunchNotifier.initialUri: ${e.toString()}',
         error: e,
         stackTrace: stack,
       );
+      state = state.copyWith(isInitialUriLoading: false);
     }
   }
 
@@ -66,7 +85,7 @@ class AndroidWidgetLaunchNotifier extends Notifier<AndroidWidgetLaunchState> {
     if (tripId == null) {
       return;
     }
-    state = AndroidWidgetLaunchState(pendingTripId: tripId);
+    state = state.copyWith(pendingTripId: tripId);
   }
 
   String? takePendingTripId() {
@@ -74,7 +93,7 @@ class AndroidWidgetLaunchNotifier extends Notifier<AndroidWidgetLaunchState> {
     if (tripId == null) {
       return null;
     }
-    state = const AndroidWidgetLaunchState();
+    state = state.copyWith(clearPendingTripId: true);
     return tripId;
   }
 

--- a/lib/presentation/notifiers/android_widget_launch_notifier.dart
+++ b/lib/presentation/notifiers/android_widget_launch_notifier.dart
@@ -1,0 +1,86 @@
+import 'dart:async';
+
+import 'package:equatable/equatable.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:memora/application/usecases/android_widget/watch_android_widget_launch_uri_usecase.dart';
+import 'package:memora/core/app_logger.dart';
+
+class AndroidWidgetLaunchState extends Equatable {
+  const AndroidWidgetLaunchState({this.pendingTripId});
+
+  final String? pendingTripId;
+
+  @override
+  List<Object?> get props => [pendingTripId];
+}
+
+final androidWidgetLaunchNotifierProvider =
+    NotifierProvider<AndroidWidgetLaunchNotifier, AndroidWidgetLaunchState>(
+      AndroidWidgetLaunchNotifier.new,
+    );
+
+class AndroidWidgetLaunchNotifier extends Notifier<AndroidWidgetLaunchState> {
+  StreamSubscription<Uri?>? _subscription;
+
+  @override
+  AndroidWidgetLaunchState build() {
+    final usecase = ref.watch(watchAndroidWidgetLaunchUriUsecaseProvider);
+    _subscription = usecase.clickedUris.listen(
+      _receiveUri,
+      onError: (Object error, StackTrace stackTrace) {
+        logger.e(
+          'AndroidWidgetLaunchNotifier.widgetClicked: ${error.toString()}',
+          error: error,
+          stackTrace: stackTrace,
+        );
+      },
+    );
+    ref.onDispose(() {
+      unawaited(_subscription?.cancel());
+      _subscription = null;
+    });
+    unawaited(_loadInitialUri(usecase));
+    return const AndroidWidgetLaunchState();
+  }
+
+  Future<void> _loadInitialUri(
+    WatchAndroidWidgetLaunchUriUsecase usecase,
+  ) async {
+    try {
+      _receiveUri(await usecase.getInitialUri());
+    } catch (e, stack) {
+      logger.e(
+        'AndroidWidgetLaunchNotifier.initialUri: ${e.toString()}',
+        error: e,
+        stackTrace: stack,
+      );
+    }
+  }
+
+  void _receiveUri(Uri? uri) {
+    final tripId = _extractTripId(uri);
+    if (tripId == null) {
+      return;
+    }
+    state = AndroidWidgetLaunchState(pendingTripId: tripId);
+  }
+
+  String? takePendingTripId() {
+    final tripId = state.pendingTripId;
+    if (tripId == null) {
+      return null;
+    }
+    state = const AndroidWidgetLaunchState();
+    return tripId;
+  }
+
+  String? _extractTripId(Uri? uri) {
+    if (uri == null ||
+        uri.scheme.toLowerCase() != 'memorawidget' ||
+        uri.host.toLowerCase() != 'opentrip') {
+      return null;
+    }
+    final tripId = uri.queryParameters['tripId']?.trim();
+    return tripId == null || tripId.isEmpty ? null : tripId;
+  }
+}

--- a/lib/presentation/notifiers/group_timeline_destination.dart
+++ b/lib/presentation/notifiers/group_timeline_destination.dart
@@ -48,6 +48,7 @@ class GroupTimelineTripManagementDestination extends GroupTimelineDestination {
   const GroupTimelineTripManagementDestination({
     required this.groupId,
     required this.year,
+    this.initialTripId,
   });
 
   @override
@@ -55,6 +56,7 @@ class GroupTimelineTripManagementDestination extends GroupTimelineDestination {
 
   @override
   final int year;
+  final String? initialTripId;
 
   @override
   GroupTimelineScreenState get screenState =>
@@ -65,11 +67,12 @@ class GroupTimelineTripManagementDestination extends GroupTimelineDestination {
     return identical(this, other) ||
         other is GroupTimelineTripManagementDestination &&
             other.groupId == groupId &&
-            other.year == year;
+            other.year == year &&
+            other.initialTripId == initialTripId;
   }
 
   @override
-  int get hashCode => Object.hash(screenState, groupId, year);
+  int get hashCode => Object.hash(screenState, groupId, year, initialTripId);
 }
 
 class GroupTimelineDvcPointCalculationDestination

--- a/lib/presentation/notifiers/group_timeline_navigation_notifier.dart
+++ b/lib/presentation/notifiers/group_timeline_navigation_notifier.dart
@@ -161,9 +161,13 @@ class GroupTimelineNavigationNotifier
     state = state.copyWith(destination: normalizeDestination(destination));
   }
 
-  void showTripManagement(String groupId, int year) {
+  void showTripManagement(String groupId, int year, {String? initialTripId}) {
     showDestination(
-      GroupTimelineTripManagementDestination(groupId: groupId, year: year),
+      GroupTimelineTripManagementDestination(
+        groupId: groupId,
+        year: year,
+        initialTripId: initialTripId,
+      ),
     );
   }
 

--- a/lib/presentation/notifiers/group_timeline_navigation_notifier.dart
+++ b/lib/presentation/notifiers/group_timeline_navigation_notifier.dart
@@ -127,6 +127,7 @@ class GroupTimelineNavigationNotifier
   void showGroupTimeline(
     GroupDto groupWithMembers, {
     List<TimelineRowType>? rowOrder,
+    Future<List<GroupDto>>? groupSelectionLoadFuture,
     bool clearGroupSelectionLoadFuture = false,
   }) {
     final rowDefinitions = buildTimelineRows(
@@ -154,8 +155,10 @@ class GroupTimelineNavigationNotifier
       destination: const GroupTimelineOverviewDestination(),
       groupTimelineInstance: groupTimeline,
       timelineRowDefinitions: rowDefinitions,
+      groupSelectionLoadFuture: groupSelectionLoadFuture,
       clearRefresh: true,
-      clearGroupSelectionLoadFuture: clearGroupSelectionLoadFuture,
+      clearGroupSelectionLoadFuture:
+          clearGroupSelectionLoadFuture && groupSelectionLoadFuture == null,
     );
   }
 

--- a/lib/presentation/notifiers/group_timeline_navigation_notifier.dart
+++ b/lib/presentation/notifiers/group_timeline_navigation_notifier.dart
@@ -127,6 +127,7 @@ class GroupTimelineNavigationNotifier
   void showGroupTimeline(
     GroupDto groupWithMembers, {
     List<TimelineRowType>? rowOrder,
+    bool clearGroupSelectionLoadFuture = false,
   }) {
     final rowDefinitions = buildTimelineRows(
       groupWithMembers: groupWithMembers,
@@ -154,7 +155,7 @@ class GroupTimelineNavigationNotifier
       groupTimelineInstance: groupTimeline,
       timelineRowDefinitions: rowDefinitions,
       clearRefresh: true,
-      clearGroupSelectionLoadFuture: true,
+      clearGroupSelectionLoadFuture: clearGroupSelectionLoadFuture,
     );
   }
 

--- a/lib/presentation/notifiers/group_timeline_navigation_notifier.dart
+++ b/lib/presentation/notifiers/group_timeline_navigation_notifier.dart
@@ -154,6 +154,7 @@ class GroupTimelineNavigationNotifier
       groupTimelineInstance: groupTimeline,
       timelineRowDefinitions: rowDefinitions,
       clearRefresh: true,
+      clearGroupSelectionLoadFuture: true,
     );
   }
 

--- a/test/unit/android/android_widget_launch_test.dart
+++ b/test/unit/android/android_widget_launch_test.dart
@@ -1,0 +1,29 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+const _itineraryWidgetPath =
+    'android/app/src/main/kotlin/com/example/memora/ItineraryWidget.kt';
+const _mainPath = 'lib/main.dart';
+
+void main() {
+  group('Androidウィジェットからのアプリ起動', () {
+    test('表示中の旅行IDを含むURIでMainActivityを起動する', () {
+      final source = File(_itineraryWidgetPath).readAsStringSync();
+
+      expect(source, contains('tripId = itineraryDate.optString("tripId")'));
+      expect(source, contains('actionStartActivity<MainActivity>'));
+      expect(source, contains('memoraWidget://openTrip?tripId='));
+    });
+
+    test('Flutter起動時にウィジェット起動Notifierを初期化する', () {
+      final source = File(_mainPath).readAsStringSync();
+
+      expect(source, contains('androidWidgetLaunchNotifierProvider'));
+      expect(
+        source,
+        contains('ref.watch(androidWidgetLaunchNotifierProvider)'),
+      );
+    });
+  });
+}

--- a/test/unit/android/android_widget_launch_test.dart
+++ b/test/unit/android/android_widget_launch_test.dart
@@ -22,7 +22,11 @@ void main() {
       expect(source, contains('ItineraryList(context, itineraryDate)'));
       expect(
         source,
-        contains('LazyColumn(modifier = openTripModifier(context, tripId))'),
+        contains('LazyColumn(modifier = GlanceModifier.fillMaxWidth())'),
+      );
+      expect(
+        source,
+        contains('Box(modifier = openTripModifier(context, tripId))'),
       );
     });
 

--- a/test/unit/android/android_widget_launch_test.dart
+++ b/test/unit/android/android_widget_launch_test.dart
@@ -16,6 +16,16 @@ void main() {
       expect(source, contains('memoraWidget://openTrip?tripId='));
     });
 
+    test('旅程一覧部分のタップでもMainActivityを起動する', () {
+      final source = File(_itineraryWidgetPath).readAsStringSync();
+
+      expect(source, contains('ItineraryList(context, itineraryDate)'));
+      expect(
+        source,
+        contains('LazyColumn(modifier = openTripModifier(context, tripId))'),
+      );
+    });
+
     test('Flutter起動時にウィジェット起動Notifierを初期化する', () {
       final source = File(_mainPath).readAsStringSync();
 

--- a/test/unit/main_test.dart
+++ b/test/unit/main_test.dart
@@ -9,6 +9,7 @@ import 'package:memora/application/queries/member/member_query_service.dart';
 import 'package:memora/core/time/app_clock.dart';
 import 'package:memora/domain/entities/account/user.dart';
 import 'package:memora/main.dart' as app;
+import 'package:memora/presentation/notifiers/android_widget_launch_notifier.dart';
 import 'package:memora/presentation/notifiers/auth_notifier.dart';
 import 'package:memora/presentation/app/top_page.dart';
 import 'package:memora/infrastructure/factories/auth_service_factory.dart';
@@ -18,6 +19,13 @@ import 'package:mockito/mockito.dart';
 
 import '../helpers/fake_auth_notifier.dart';
 import 'main_test.mocks.dart';
+
+class _IdleAndroidWidgetLaunchNotifier extends AndroidWidgetLaunchNotifier {
+  @override
+  AndroidWidgetLaunchState build() {
+    return const AndroidWidgetLaunchState();
+  }
+}
 
 @GenerateMocks([GroupQueryService, MemberQueryService, AuthService])
 void main() {
@@ -63,6 +71,9 @@ void main() {
         memberQueryServiceProvider.overrideWithValue(mockMemberQueryService),
         authServiceProvider.overrideWithValue(mockAuthService),
         groupQueryServiceProvider.overrideWithValue(mockGroupQueryService),
+        androidWidgetLaunchNotifierProvider.overrideWith(
+          () => _IdleAndroidWidgetLaunchNotifier(),
+        ),
       ],
       child: MaterialApp(
         title: 'memora',

--- a/test/unit/presentation/app/top_page_test.dart
+++ b/test/unit/presentation/app/top_page_test.dart
@@ -84,6 +84,13 @@ class _PendingAndroidWidgetLaunchNotifier extends AndroidWidgetLaunchNotifier {
   }
 }
 
+class _IdleAndroidWidgetLaunchNotifier extends AndroidWidgetLaunchNotifier {
+  @override
+  AndroidWidgetLaunchState build() {
+    return const AndroidWidgetLaunchState();
+  }
+}
+
 class _InitialUriLoadingAndroidWidgetLaunchNotifier
     extends AndroidWidgetLaunchNotifier {
   @override
@@ -460,10 +467,9 @@ void main() {
       currentMemberNotifierProvider.overrideWith(
         () => resolvedCurrentMemberNotifier,
       ),
-      if (androidWidgetLaunchNotifier != null)
-        androidWidgetLaunchNotifierProvider.overrideWith(
-          () => androidWidgetLaunchNotifier,
-        ),
+      androidWidgetLaunchNotifierProvider.overrideWith(
+        () => androidWidgetLaunchNotifier ?? _IdleAndroidWidgetLaunchNotifier(),
+      ),
       androidWidgetCacheStorageProvider.overrideWithValue(
         _FakeAndroidWidgetCacheStorage(),
       ),

--- a/test/unit/presentation/app/top_page_test.dart
+++ b/test/unit/presentation/app/top_page_test.dart
@@ -596,7 +596,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byKey(const Key('trip_management')), findsOneWidget);
-      expect(find.text('2025年の旅行管理'), findsOneWidget);
+      expect(find.text('2025年の旅行管理'), findsNothing);
       expect(find.text('旅行編集'), findsOneWidget);
       final container = ProviderScope.containerOf(
         tester.element(find.byType(TopPage)),

--- a/test/unit/presentation/app/top_page_test.dart
+++ b/test/unit/presentation/app/top_page_test.dart
@@ -607,6 +607,61 @@ void main() {
       );
     });
 
+    testWidgets('ウィジェット起動後に年表から戻っても年表を再表示しない', (WidgetTester tester) async {
+      final singleGroup = [groupsWithMembers.first];
+      final trip = TripEntryDto(
+        id: 'trip-1',
+        groupId: singleGroup.first.id,
+        year: 2025,
+        name: '北海道旅行',
+      );
+      when(
+        mockTripEntryQueryService.getTripEntryById(
+          trip.id,
+          tasksOrderBy: anyNamed('tasksOrderBy'),
+          itineraryItemsOrderBy: anyNamed('itineraryItemsOrderBy'),
+        ),
+      ).thenAnswer((_) async => trip);
+      when(
+        mockTripEntryQueryService.getTripEntriesByGroupIdAndYear(
+          trip.groupId,
+          trip.year,
+          orderBy: anyNamed('orderBy'),
+        ),
+      ).thenAnswer((_) async => [trip]);
+      when(
+        mockGroupQueryService.getGroupsWithMembersByMemberId(
+          any,
+          groupsOrderBy: anyNamed('groupsOrderBy'),
+          membersOrderBy: anyNamed('membersOrderBy'),
+        ),
+      ).thenAnswer((_) async => singleGroup);
+
+      await tester.pumpWidget(
+        createTestWidget(
+          currentMember: testMember,
+          availableGroupsWithMembers: singleGroup,
+          androidWidgetLaunchNotifier: _PendingAndroidWidgetLaunchNotifier(
+            trip.id,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('キャンセル'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('back_button')));
+      await tester.pumpAndSettle();
+      expect(find.byKey(const Key('group_timeline')), findsOneWidget);
+
+      await tester.tap(find.byKey(const Key('back_button')));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('group_timeline')), findsNothing);
+      expect(find.byKey(const Key('group_list')), findsOneWidget);
+      expect(find.text('グループ1'), findsOneWidget);
+    });
+
     testWidgets('ウィジェットで指定された旅行がない場合は通知して通常画面へ戻る', (WidgetTester tester) async {
       when(
         mockTripEntryQueryService.getTripEntryById(

--- a/test/unit/presentation/app/top_page_test.dart
+++ b/test/unit/presentation/app/top_page_test.dart
@@ -5,6 +5,7 @@ import 'package:memora/application/dtos/android_widget/android_widget_itinerary_
 import 'package:memora/application/dtos/group/group_member_dto.dart';
 import 'package:memora/application/dtos/account/user_dto.dart';
 import 'package:memora/application/dtos/member/member_dto.dart';
+import 'package:memora/application/dtos/trip/trip_entry_dto.dart';
 import 'package:memora/application/services/auth_service.dart';
 import 'package:memora/application/queries/dvc/dvc_limited_point_query_service.dart';
 import 'package:memora/application/queries/dvc/dvc_point_contract_query_service.dart';
@@ -28,6 +29,7 @@ import 'package:memora/domain/repositories/member/member_repository.dart';
 import 'package:memora/domain/repositories/trip/trip_entry_repository.dart';
 import 'package:memora/presentation/notifiers/auth_state.dart';
 import 'package:memora/presentation/notifiers/auth_notifier.dart';
+import 'package:memora/presentation/notifiers/android_widget_launch_notifier.dart';
 import 'package:memora/presentation/notifiers/group_timeline_navigation_notifier.dart';
 import 'package:memora/presentation/notifiers/navigation_notifier.dart';
 import 'package:memora/domain/entities/account/user.dart';
@@ -68,6 +70,17 @@ class _TestGroupTimelineNavigationNotifier
         year: 2024,
       ),
     );
+  }
+}
+
+class _PendingAndroidWidgetLaunchNotifier extends AndroidWidgetLaunchNotifier {
+  _PendingAndroidWidgetLaunchNotifier(this.tripId);
+
+  final String tripId;
+
+  @override
+  AndroidWidgetLaunchState build() {
+    return AndroidWidgetLaunchState(pendingTripId: tripId);
   }
 }
 
@@ -381,6 +394,7 @@ void main() {
     NavigationNotifier? navigationNotifier,
     GroupTimelineNavigationNotifier? groupTimelineNavigationNotifier,
     FakeCurrentMemberNotifier? currentMemberNotifier,
+    AndroidWidgetLaunchNotifier? androidWidgetLaunchNotifier,
   }) {
     final defaultMember = MemberDto(
       id: 'default_member',
@@ -438,6 +452,10 @@ void main() {
       currentMemberNotifierProvider.overrideWith(
         () => resolvedCurrentMemberNotifier,
       ),
+      if (androidWidgetLaunchNotifier != null)
+        androidWidgetLaunchNotifierProvider.overrideWith(
+          () => androidWidgetLaunchNotifier,
+        ),
       androidWidgetCacheStorageProvider.overrideWithValue(
         _FakeAndroidWidgetCacheStorage(),
       ),
@@ -497,6 +515,7 @@ void main() {
     NavigationNotifier? navigationNotifier,
     GroupTimelineNavigationNotifier? groupTimelineNavigationNotifier,
     FakeCurrentMemberNotifier? currentMemberNotifier,
+    AndroidWidgetLaunchNotifier? androidWidgetLaunchNotifier,
   }) {
     return ProviderScope(
       overrides: createTopPageTestOverrides(
@@ -508,12 +527,80 @@ void main() {
         navigationNotifier: navigationNotifier,
         groupTimelineNavigationNotifier: groupTimelineNavigationNotifier,
         currentMemberNotifier: currentMemberNotifier,
+        androidWidgetLaunchNotifier: androidWidgetLaunchNotifier,
       ),
       child: MaterialApp(home: TopPage(isTestEnvironment: true)),
     );
   }
 
   group('TopPage', () {
+    testWidgets('ウィジェットで指定された旅行の管理画面と編集モーダルを開く', (WidgetTester tester) async {
+      final trip = TripEntryDto(
+        id: 'trip-1',
+        groupId: groupsWithMembers.first.id,
+        year: 2025,
+        name: '北海道旅行',
+      );
+      when(
+        mockTripEntryQueryService.getTripEntryById(
+          trip.id,
+          tasksOrderBy: anyNamed('tasksOrderBy'),
+          itineraryItemsOrderBy: anyNamed('itineraryItemsOrderBy'),
+        ),
+      ).thenAnswer((_) async => trip);
+      when(
+        mockTripEntryQueryService.getTripEntriesByGroupIdAndYear(
+          trip.groupId,
+          trip.year,
+          orderBy: anyNamed('orderBy'),
+        ),
+      ).thenAnswer((_) async => [trip]);
+
+      await tester.pumpWidget(
+        createTestWidget(
+          currentMember: testMember,
+          androidWidgetLaunchNotifier: _PendingAndroidWidgetLaunchNotifier(
+            trip.id,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('trip_management')), findsOneWidget);
+      expect(find.text('2025年の旅行管理'), findsOneWidget);
+      expect(find.text('旅行編集'), findsOneWidget);
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(TopPage)),
+      );
+      expect(
+        container.read(androidWidgetLaunchNotifierProvider).pendingTripId,
+        isNull,
+      );
+    });
+
+    testWidgets('ウィジェットで指定された旅行がない場合は通知して通常画面へ戻る', (WidgetTester tester) async {
+      when(
+        mockTripEntryQueryService.getTripEntryById(
+          'missing-trip',
+          tasksOrderBy: anyNamed('tasksOrderBy'),
+          itineraryItemsOrderBy: anyNamed('itineraryItemsOrderBy'),
+        ),
+      ).thenAnswer((_) async => null);
+
+      await tester.pumpWidget(
+        createTestWidget(
+          currentMember: testMember,
+          androidWidgetLaunchNotifier: _PendingAndroidWidgetLaunchNotifier(
+            'missing-trip',
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('指定された旅行が見つかりませんでした'), findsOneWidget);
+      expect(find.byKey(const Key('group_list')), findsOneWidget);
+    });
+
     testWidgets('左上にハンバーガーメニューが表示される', (WidgetTester tester) async {
       // Arrange
       when(

--- a/test/unit/presentation/app/top_page_test.dart
+++ b/test/unit/presentation/app/top_page_test.dart
@@ -84,6 +84,14 @@ class _PendingAndroidWidgetLaunchNotifier extends AndroidWidgetLaunchNotifier {
   }
 }
 
+class _InitialUriLoadingAndroidWidgetLaunchNotifier
+    extends AndroidWidgetLaunchNotifier {
+  @override
+  AndroidWidgetLaunchState build() {
+    return const AndroidWidgetLaunchState(isInitialUriLoading: true);
+  }
+}
+
 class _FakeAndroidWidgetCacheStorage implements AndroidWidgetCacheStorage {
   String? targetGroupId;
 
@@ -534,6 +542,21 @@ void main() {
   }
 
   group('TopPage', () {
+    testWidgets('ウィジェット起動URIの確認中はグループ選択を表示しない', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        createTestWidget(
+          currentMember: testMember,
+          androidWidgetLaunchNotifier:
+              _InitialUriLoadingAndroidWidgetLaunchNotifier(),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.byKey(const Key('group_list')), findsNothing);
+      expect(find.text('グループを選択'), findsNothing);
+    });
+
     testWidgets('ウィジェットで指定された旅行の管理画面と編集モーダルを開く', (WidgetTester tester) async {
       final trip = TripEntryDto(
         id: 'trip-1',

--- a/test/unit/presentation/features/trip/trip_management_test.dart
+++ b/test/unit/presentation/features/trip/trip_management_test.dart
@@ -404,8 +404,15 @@ void main() {
         ),
       ).called(1);
 
+      clearInteractions(mockTripEntryQueryService);
       await tester.pump();
-      verifyNoMoreInteractions(mockTripEntryQueryService);
+      verifyNever(
+        mockTripEntryQueryService.getTripEntryById(
+          'trip-1',
+          tasksOrderBy: anyNamed('tasksOrderBy'),
+          itineraryItemsOrderBy: anyNamed('itineraryItemsOrderBy'),
+        ),
+      );
     });
 
     testWidgets('旅行詳細取得に失敗した場合にスナックバーが表示されること', (WidgetTester tester) async {

--- a/test/unit/presentation/features/trip/trip_management_test.dart
+++ b/test/unit/presentation/features/trip/trip_management_test.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:memora/application/exceptions/application_validation_exception.dart';
@@ -413,6 +415,56 @@ void main() {
           itineraryItemsOrderBy: anyNamed('itineraryItemsOrderBy'),
         ),
       );
+    });
+
+    testWidgets('初期編集対象の詳細取得中は旅行管理画面の内容を表示しない', (
+      WidgetTester tester,
+    ) async {
+      final detailCompleter = Completer<TripEntryDto?>();
+      when(
+        mockTripEntryQueryService.getTripEntriesByGroupIdAndYear(
+          testGroupId,
+          testYear,
+          orderBy: anyNamed('orderBy'),
+        ),
+      ).thenAnswer((_) async => testTripEntries);
+      when(
+        mockTripEntryQueryService.getTripEntryById(
+          'trip-1',
+          tasksOrderBy: anyNamed('tasksOrderBy'),
+          itineraryItemsOrderBy: anyNamed('itineraryItemsOrderBy'),
+        ),
+      ).thenAnswer((_) => detailCompleter.future);
+
+      await tester.pumpWidget(
+        createApp(
+          home: TripManagement(
+            groupId: testGroupId,
+            year: testYear,
+            initialTripId: 'trip-1',
+            isTestEnvironment: true,
+          ),
+        ),
+      );
+
+      await tester.pump();
+      await tester.pump();
+
+      verify(
+        mockTripEntryQueryService.getTripEntryById(
+          'trip-1',
+          tasksOrderBy: anyNamed('tasksOrderBy'),
+          itineraryItemsOrderBy: anyNamed('itineraryItemsOrderBy'),
+        ),
+      ).called(1);
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.text('$testYear年の旅行管理'), findsNothing);
+      expect(find.text('旅行追加'), findsNothing);
+
+      detailCompleter.complete(detailedTripEntry);
+      await tester.pumpAndSettle();
+
+      expect(find.text('旅行編集'), findsOneWidget);
     });
 
     testWidgets('旅行詳細取得に失敗した場合にスナックバーが表示されること', (WidgetTester tester) async {

--- a/test/unit/presentation/features/trip/trip_management_test.dart
+++ b/test/unit/presentation/features/trip/trip_management_test.dart
@@ -1,6 +1,6 @@
-import 'package:flutter/material.dart';
 import 'dart:async';
 
+import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:memora/application/exceptions/application_validation_exception.dart';
@@ -417,9 +417,7 @@ void main() {
       );
     });
 
-    testWidgets('初期編集対象の詳細取得中は旅行管理画面の内容を表示しない', (
-      WidgetTester tester,
-    ) async {
+    testWidgets('初期編集対象の詳細取得中は旅行管理画面の内容を表示しない', (WidgetTester tester) async {
       final detailCompleter = Completer<TripEntryDto?>();
       when(
         mockTripEntryQueryService.getTripEntriesByGroupIdAndYear(

--- a/test/unit/presentation/features/trip/trip_management_test.dart
+++ b/test/unit/presentation/features/trip/trip_management_test.dart
@@ -465,6 +465,57 @@ void main() {
       expect(find.text('旅行編集'), findsOneWidget);
     });
 
+    testWidgets('初期編集対象の表示予約中は旅行管理画面の内容を表示しない', (WidgetTester tester) async {
+      final tripEntriesCompleter = Completer<List<TripEntryDto>>();
+      final groupCompleter = Completer<GroupDto?>();
+      final detailCompleter = Completer<TripEntryDto?>();
+      when(
+        mockTripEntryQueryService.getTripEntriesByGroupIdAndYear(
+          testGroupId,
+          testYear,
+          orderBy: anyNamed('orderBy'),
+        ),
+      ).thenAnswer((_) => tripEntriesCompleter.future);
+      when(
+        mockGroupQueryService.getGroupWithMembersById(
+          testGroupId,
+          membersOrderBy: anyNamed('membersOrderBy'),
+        ),
+      ).thenAnswer((_) => groupCompleter.future);
+      when(
+        mockTripEntryQueryService.getTripEntryById(
+          'trip-1',
+          tasksOrderBy: anyNamed('tasksOrderBy'),
+          itineraryItemsOrderBy: anyNamed('itineraryItemsOrderBy'),
+        ),
+      ).thenAnswer((_) => detailCompleter.future);
+
+      await tester.pumpWidget(
+        createApp(
+          home: TripManagement(
+            groupId: testGroupId,
+            year: testYear,
+            initialTripId: 'trip-1',
+            isTestEnvironment: true,
+          ),
+        ),
+      );
+
+      tripEntriesCompleter.complete(testTripEntries);
+      groupCompleter.complete(testGroup);
+      await tester.pump();
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.text('$testYear年の旅行管理'), findsNothing);
+      expect(find.text('旅行追加'), findsNothing);
+      expect(find.text('北海道旅行'), findsNothing);
+
+      detailCompleter.complete(detailedTripEntry);
+      await tester.pumpAndSettle();
+
+      expect(find.text('旅行編集'), findsOneWidget);
+    });
+
     testWidgets('旅行詳細取得に失敗した場合にスナックバーが表示されること', (WidgetTester tester) async {
       // Arrange
       when(

--- a/test/unit/presentation/features/trip/trip_management_test.dart
+++ b/test/unit/presentation/features/trip/trip_management_test.dart
@@ -367,6 +367,47 @@ void main() {
       ).called(1);
     });
 
+    testWidgets('初期編集対象が指定された場合は初期化後に編集画面を一度だけ開く', (WidgetTester tester) async {
+      when(
+        mockTripEntryQueryService.getTripEntriesByGroupIdAndYear(
+          testGroupId,
+          testYear,
+          orderBy: anyNamed('orderBy'),
+        ),
+      ).thenAnswer((_) async => testTripEntries);
+      when(
+        mockTripEntryQueryService.getTripEntryById(
+          'trip-1',
+          tasksOrderBy: anyNamed('tasksOrderBy'),
+          itineraryItemsOrderBy: anyNamed('itineraryItemsOrderBy'),
+        ),
+      ).thenAnswer((_) async => detailedTripEntry);
+
+      await tester.pumpWidget(
+        createApp(
+          home: TripManagement(
+            groupId: testGroupId,
+            year: testYear,
+            initialTripId: 'trip-1',
+            isTestEnvironment: true,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('旅行編集'), findsOneWidget);
+      verify(
+        mockTripEntryQueryService.getTripEntryById(
+          'trip-1',
+          tasksOrderBy: anyNamed('tasksOrderBy'),
+          itineraryItemsOrderBy: anyNamed('itineraryItemsOrderBy'),
+        ),
+      ).called(1);
+
+      await tester.pump();
+      verifyNoMoreInteractions(mockTripEntryQueryService);
+    });
+
     testWidgets('旅行詳細取得に失敗した場合にスナックバーが表示されること', (WidgetTester tester) async {
       // Arrange
       when(

--- a/test/unit/presentation/features/trip/trip_management_test.dart
+++ b/test/unit/presentation/features/trip/trip_management_test.dart
@@ -516,6 +516,39 @@ void main() {
       expect(find.text('旅行編集'), findsOneWidget);
     });
 
+    testWidgets('初期編集ダイアログ表示中は下地に旅行管理画面の内容を表示しない', (WidgetTester tester) async {
+      when(
+        mockTripEntryQueryService.getTripEntriesByGroupIdAndYear(
+          testGroupId,
+          testYear,
+          orderBy: anyNamed('orderBy'),
+        ),
+      ).thenAnswer((_) async => testTripEntries);
+      when(
+        mockTripEntryQueryService.getTripEntryById(
+          'trip-1',
+          tasksOrderBy: anyNamed('tasksOrderBy'),
+          itineraryItemsOrderBy: anyNamed('itineraryItemsOrderBy'),
+        ),
+      ).thenAnswer((_) async => detailedTripEntry);
+
+      await tester.pumpWidget(
+        createApp(
+          home: TripManagement(
+            groupId: testGroupId,
+            year: testYear,
+            initialTripId: 'trip-1',
+            isTestEnvironment: true,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('旅行編集'), findsOneWidget);
+      expect(find.text('$testYear年の旅行管理'), findsNothing);
+      expect(find.text('旅行追加'), findsNothing);
+    });
+
     testWidgets('旅行詳細取得に失敗した場合にスナックバーが表示されること', (WidgetTester tester) async {
       // Arrange
       when(

--- a/test/unit/presentation/notifiers/android_widget_launch_notifier_test.dart
+++ b/test/unit/presentation/notifiers/android_widget_launch_notifier_test.dart
@@ -1,0 +1,86 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:memora/application/services/android_widget_launch_uri_source.dart';
+import 'package:memora/application/usecases/android_widget/watch_android_widget_launch_uri_usecase.dart';
+import 'package:memora/presentation/notifiers/android_widget_launch_notifier.dart';
+
+class _FakeAndroidWidgetLaunchUriSource
+    implements AndroidWidgetLaunchUriSource {
+  _FakeAndroidWidgetLaunchUriSource({this.initialUri});
+
+  final Uri? initialUri;
+  final controller = StreamController<Uri>.broadcast();
+
+  @override
+  Stream<Uri> get clickedUris => controller.stream;
+
+  @override
+  Future<Uri?> getInitialUri() async => initialUri;
+}
+
+void main() {
+  group('AndroidWidgetLaunchNotifier', () {
+    test('ウィジェットからの初回起動URIを保留し一度だけ取り出す', () async {
+      final source = _FakeAndroidWidgetLaunchUriSource(
+        initialUri: Uri.parse('memoraWidget://openTrip?tripId=trip-1'),
+      );
+      final container = ProviderContainer(
+        overrides: [
+          watchAndroidWidgetLaunchUriUsecaseProvider.overrideWithValue(
+            WatchAndroidWidgetLaunchUriUsecase(source),
+          ),
+        ],
+      );
+      addTearDown(() async {
+        container.dispose();
+        await source.controller.close();
+      });
+
+      container.read(androidWidgetLaunchNotifierProvider);
+      await Future<void>.delayed(Duration.zero);
+
+      final notifier = container.read(
+        androidWidgetLaunchNotifierProvider.notifier,
+      );
+      expect(
+        container.read(androidWidgetLaunchNotifierProvider).pendingTripId,
+        'trip-1',
+      );
+      expect(notifier.takePendingTripId(), 'trip-1');
+      expect(notifier.takePendingTripId(), isNull);
+    });
+
+    test('起動済みアプリへのクリックURIを保留し不正なURIは無視する', () async {
+      final source = _FakeAndroidWidgetLaunchUriSource();
+      final container = ProviderContainer(
+        overrides: [
+          watchAndroidWidgetLaunchUriUsecaseProvider.overrideWithValue(
+            WatchAndroidWidgetLaunchUriUsecase(source),
+          ),
+        ],
+      );
+      addTearDown(() async {
+        container.dispose();
+        await source.controller.close();
+      });
+
+      container.read(androidWidgetLaunchNotifierProvider);
+      source.controller.add(Uri.parse('memoraWidget://refresh'));
+      await Future<void>.delayed(Duration.zero);
+      expect(
+        container.read(androidWidgetLaunchNotifierProvider).pendingTripId,
+        isNull,
+      );
+
+      source.controller.add(Uri.parse('memoraWidget://openTrip?tripId=trip-2'));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        container.read(androidWidgetLaunchNotifierProvider).pendingTripId,
+        'trip-2',
+      );
+    });
+  });
+}

--- a/test/unit/presentation/notifiers/android_widget_launch_notifier_test.dart
+++ b/test/unit/presentation/notifiers/android_widget_launch_notifier_test.dart
@@ -8,16 +8,19 @@ import 'package:memora/presentation/notifiers/android_widget_launch_notifier.dar
 
 class _FakeAndroidWidgetLaunchUriSource
     implements AndroidWidgetLaunchUriSource {
-  _FakeAndroidWidgetLaunchUriSource({this.initialUri});
+  _FakeAndroidWidgetLaunchUriSource({this.initialUri, this.initialUriFuture});
 
   final Uri? initialUri;
+  final Future<Uri?>? initialUriFuture;
   final controller = StreamController<Uri>.broadcast();
 
   @override
   Stream<Uri> get clickedUris => controller.stream;
 
   @override
-  Future<Uri?> getInitialUri() async => initialUri;
+  Future<Uri?> getInitialUri() {
+    return initialUriFuture ?? Future.value(initialUri);
+  }
 }
 
 void main() {
@@ -48,8 +51,43 @@ void main() {
         container.read(androidWidgetLaunchNotifierProvider).pendingTripId,
         'trip-1',
       );
+      expect(
+        container.read(androidWidgetLaunchNotifierProvider).isInitialUriLoading,
+        isFalse,
+      );
       expect(notifier.takePendingTripId(), 'trip-1');
       expect(notifier.takePendingTripId(), isNull);
+    });
+
+    test('初回起動URIの確認中だけ読み込み中になる', () async {
+      final initialUriCompleter = Completer<Uri?>();
+      final source = _FakeAndroidWidgetLaunchUriSource(
+        initialUriFuture: initialUriCompleter.future,
+      );
+      final container = ProviderContainer(
+        overrides: [
+          watchAndroidWidgetLaunchUriUsecaseProvider.overrideWithValue(
+            WatchAndroidWidgetLaunchUriUsecase(source),
+          ),
+        ],
+      );
+      addTearDown(() async {
+        container.dispose();
+        await source.controller.close();
+      });
+
+      expect(
+        container.read(androidWidgetLaunchNotifierProvider).isInitialUriLoading,
+        isTrue,
+      );
+
+      initialUriCompleter.complete(null);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        container.read(androidWidgetLaunchNotifierProvider).isInitialUriLoading,
+        isFalse,
+      );
     });
 
     test('起動済みアプリへのクリックURIを保留し不正なURIは無視する', () async {

--- a/test/unit/presentation/notifiers/group_timeline_navigation_notifier_test.dart
+++ b/test/unit/presentation/notifiers/group_timeline_navigation_notifier_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:memora/application/dtos/group/group_member_dto.dart';
@@ -358,6 +360,41 @@ void main() {
         2024,
         initialTripId: 'trip-1',
       );
+
+      expect(
+        container.read(groupTimelineNavigationNotifierProvider).destination,
+        GroupTimelineTripManagementDestination(
+          groupId: testGroupWithMembers.id,
+          year: 2024,
+          initialTripId: 'trip-1',
+        ),
+      );
+    });
+
+    test('通常入口ロード中のウィジェット遷移はロード完了後も旅行管理画面を維持する', () async {
+      final completer = Completer<List<GroupDto>>();
+      when(
+        mockGroupQueryService.getGroupsWithMembersByMemberId(
+          testCurrentMember.id,
+          groupsOrderBy: anyNamed('groupsOrderBy'),
+          membersOrderBy: anyNamed('membersOrderBy'),
+        ),
+      ).thenAnswer((_) => completer.future);
+      final notifier = container.read(
+        groupTimelineNavigationNotifierProvider.notifier,
+      );
+
+      final prepareFuture = notifier.prepareGroupTimelineEntry(
+        testCurrentMember,
+      );
+      notifier.showGroupTimeline(testGroupWithMembers);
+      notifier.showTripManagement(
+        testGroupWithMembers.id,
+        2024,
+        initialTripId: 'trip-1',
+      );
+      completer.complete([testGroupWithMembers]);
+      await prepareFuture;
 
       expect(
         container.read(groupTimelineNavigationNotifierProvider).destination,

--- a/test/unit/presentation/notifiers/group_timeline_navigation_notifier_test.dart
+++ b/test/unit/presentation/notifiers/group_timeline_navigation_notifier_test.dart
@@ -331,6 +331,7 @@ void main() {
         const GroupTimelineTripManagementDestination(
           groupId: testGroupId,
           year: testYear,
+          initialTripId: 'trip-1',
         ),
       );
 
@@ -341,6 +342,29 @@ void main() {
         const GroupTimelineTripManagementDestination(
           groupId: testGroupId,
           year: testYear,
+          initialTripId: 'trip-1',
+        ),
+      );
+    });
+
+    test('ウィジェットから旅行管理画面へ初期編集対象を指定して遷移できる', () {
+      final notifier = container.read(
+        groupTimelineNavigationNotifierProvider.notifier,
+      );
+      notifier.showGroupTimeline(testGroupWithMembers);
+
+      notifier.showTripManagement(
+        testGroupWithMembers.id,
+        2024,
+        initialTripId: 'trip-1',
+      );
+
+      expect(
+        container.read(groupTimelineNavigationNotifierProvider).destination,
+        GroupTimelineTripManagementDestination(
+          groupId: testGroupWithMembers.id,
+          year: 2024,
+          initialTripId: 'trip-1',
         ),
       );
     });

--- a/test/unit/presentation/notifiers/group_timeline_navigation_notifier_test.dart
+++ b/test/unit/presentation/notifiers/group_timeline_navigation_notifier_test.dart
@@ -243,7 +243,7 @@ void main() {
       expect(state.timelineRowDefinitions[3].fixedColumnLabel, '花子');
     });
 
-    test('入口で所属グループが1件ならグループ年表を直接表示する', () async {
+    test('入口で所属グループが1件ならグループ年表を直接表示してロード状態をクリアする', () async {
       // Arrange
       when(
         mockGroupQueryService.getGroupsWithMembersByMemberId(
@@ -263,7 +263,7 @@ void main() {
       final state = container.read(groupTimelineNavigationNotifierProvider);
       expect(state.destination, const GroupTimelineOverviewDestination());
       expect(state.groupTimelineInstance, isNotNull);
-      expect(await state.groupSelectionLoadFuture, [testGroupWithMembers]);
+      expect(state.groupSelectionLoadFuture, isNull);
       verify(
         mockGroupQueryService.getGroupsWithMembersByMemberId(
           testCurrentMember.id,

--- a/test/unit/presentation/notifiers/group_timeline_navigation_notifier_test.dart
+++ b/test/unit/presentation/notifiers/group_timeline_navigation_notifier_test.dart
@@ -243,7 +243,7 @@ void main() {
       expect(state.timelineRowDefinitions[3].fixedColumnLabel, '花子');
     });
 
-    test('入口で所属グループが1件ならグループ年表を直接表示してロード状態をクリアする', () async {
+    test('入口で所属グループが1件ならグループ年表を直接表示する', () async {
       // Arrange
       when(
         mockGroupQueryService.getGroupsWithMembersByMemberId(
@@ -263,7 +263,7 @@ void main() {
       final state = container.read(groupTimelineNavigationNotifierProvider);
       expect(state.destination, const GroupTimelineOverviewDestination());
       expect(state.groupTimelineInstance, isNotNull);
-      expect(state.groupSelectionLoadFuture, isNull);
+      expect(await state.groupSelectionLoadFuture, [testGroupWithMembers]);
       verify(
         mockGroupQueryService.getGroupsWithMembersByMemberId(
           testCurrentMember.id,
@@ -387,7 +387,10 @@ void main() {
       final prepareFuture = notifier.prepareGroupTimelineEntry(
         testCurrentMember,
       );
-      notifier.showGroupTimeline(testGroupWithMembers);
+      notifier.showGroupTimeline(
+        testGroupWithMembers,
+        clearGroupSelectionLoadFuture: true,
+      );
       notifier.showTripManagement(
         testGroupWithMembers.id,
         2024,


### PR DESCRIPTION
## 概要
- Androidウィジェットの旅行ヘッダーをタップすると、旅行ID付きURIでアプリを起動
- 旅程一覧部分をタップした場合も、表示中の旅行ID付きURIでアプリを起動
- スクロール可能な旅程リスト親ではなく、リスト内の各エントリに起動アクションを付けてタップを拾う
- 初回起動・起動済みの両方でURIを受信し、認証とcurrentMember取得完了まで保留
- 対象グループ・年の旅行管理画面へ遷移し、旅行編集モーダルを一度だけ表示
- 対象旅行が取得できない場合はSnackBarを表示して通常のグループ年表導線へ復帰

## 検証
- `flutter test test/unit/android/android_widget_launch_test.dart`
- `./check.sh`
- `./gradlew :app:compileDebugKotlin`